### PR TITLE
Rough initial SimpleOres2 module (IC2-derived)

### DIFF
--- a/resources/CustomOreGen Standard Modules/SimpleOres2.xml
+++ b/resources/CustomOreGen Standard Modules/SimpleOres2.xml
@@ -1,0 +1,521 @@
+<!--*********************  CustomOreGen SimpleOres2 Ores Module ******************************
+*
+*   This file contains Presets, Options, and Distributions for 4 SimpleOres2 ores:
+*       Copper, Tin, Mythril, and Adamantium. (Onyx support has not been added.)
+*
+*   Based on the configuration files for IC2 Copper, Tin, and Urainum (for Adamantium),
+*       with tweaks to more closely fit the heights and frequency of default SO2.
+*
+*   This is an incomplete adaptation. Only "Veins" distributions have been adjusted from
+*       the values borrowed from the IC2 file, i.e., choosing "Standard" will work but
+*       will not behave as expected. Similarly, "Clouds" will not give expected results.
+*
+*   TODO:
+*
+*       - Add Onyx support
+*       - Tune SO2TinVeins down a bit (playtesting shows veins are slightly too frequent
+*         and much too long)
+*       - Reduce max height of Tin and Copper veins while also allowing to generate inside mountains
+*         (maybe by implementing child distributions for just the tall parts of tall biomes?)
+*       - Do Standard adaptations
+*       - Do Cloud adapatations
+*       - Develop biome-specific child distributions for Mythril and Adamantium
+*
+***********************************************************************************************-->
+<IfModInstalled name="simpleores">
+
+    <!--***************************   Options + Symbols   ***********************************
+    *
+    *   Below are options and symbols for each ore, similar to those for the standard ores.
+    *
+    *************************************************************************************-->
+    <ConfigSection>                
+    
+        <OptionDisplayGroup name='groupSO2' displayName='SimpleOres 2' displayState='shown'>
+            <Description> 
+                Distribution options for the SimpleOres 2 ores.
+            </Description>
+        </OptionDisplayGroup>
+        
+        <!--*******************   Copper   *********************-->
+        <ConfigSection>
+            
+            <OptionChoice name='so2CopperDist' displayState='shown' displayGroup='groupSO2'>
+                <Description> Controls how SimpleOres 2 Copper is generated </Description>
+                <DisplayName>SO2 Copper Type</DisplayName>
+                <Default>:= if(blockExists("copperOre"),"layeredVeins","disabled")</Default>
+                <Choice value='layeredVeins' displayValue='Veins'>
+                    <Description> 
+                        Groups of long narrow veins found about one third of the way down to bedrock.  Especially common in jungles.  
+                    </Description>
+                </Choice>
+                <Choice value='strategicClouds' displayValue='Clouds'>
+                    <Description> 
+                        Rare, sparsely populated clouds of ore extending over several chunks.  Found only in jungles.
+                    </Description>
+                </Choice>
+                <Choice value='vanillaStdGen' displayValue='Clusters'>
+                    <Description> 
+                        Small clusters of ore scattered about one third of the way down to bedrock.  This is the default IC2 copper generation.
+                    </Description>
+                </Choice>
+                <Choice value='none' displayValue='None' description='No copper is generated at all.'/>
+                <Choice value='disabled' displayValue='Disabled' description='No copper is generated, and no copper symbols are available in Mystcraft ages.'/>
+            </OptionChoice>
+            
+            <OptionNumeric name='so2CopperFreq' default='1'  min='0' max='5' displayState='hidden' displayGroup='groupSO2'>
+                <Description> Frequency multiplier for SimpleOres 2 Copper distributions </Description>
+                <DisplayName>SO2 Copper Freq.</DisplayName>
+            </OptionNumeric>
+            
+            <OptionNumeric name='so2CopperSize' default='1'  min='0' max='5' displayState='hidden' displayGroup='groupSO2'>
+                <Description> Size multiplier for SimpleOres 2 Copper distributions </Description>
+                <DisplayName>SO2 Copper Size</DisplayName>
+            </OptionNumeric>
+            
+            <IfCondition condition=':= so2CopperDist != "disabled"'>
+                <MystcraftSymbol name='so2CopperClusters' displayName='Copper Clusters'/>
+                <MystcraftSymbol name='so2CopperVeins' displayName='Copper Veins'/>
+                <MystcraftSymbol name='so2CopperClouds' displayName='Copper Clouds'>
+                    <Instability>:= 50 * (age.so2CopperClusters + age.so2CopperVeins + age.so2CopperClouds - 1)^3</Instability>
+                </MystcraftSymbol>
+            </IfCondition>
+       
+        </ConfigSection>           
+        
+        <!--********************   Tin   ***********************-->
+        <ConfigSection>
+            
+            <OptionChoice name='so2TinDist' displayState='shown' displayGroup='groupSO2'>
+                <Description> Controls how SimpleOres 2 Tin is generated </Description>
+                <DisplayName>SO2 Tin Type</DisplayName>
+                <Default>:= if(blockExists("tinOre"),"layeredVeins","disabled")</Default>
+                <Choice value='layeredVeins' displayValue='Veins'>
+                    <Description> 
+                        Groups of long narrow veins found about halfway down to bedrock.  More frequent in flat grassy plains.  
+                    </Description>
+                </Choice>
+                <Choice value='strategicClouds' displayValue='Clouds'>
+                    <Description> 
+                        Rare, sparsely populated clouds of ore extending over several chunks.  Found only in flat grassy plains.
+                    </Description>
+                </Choice>
+                <Choice value='vanillaStdGen' displayValue='Clusters'>
+                    <Description> 
+                        Small clusters of ore scattered from bedrock about two thirds of the way to the surface.  This is the default IC2 tin generation.
+                    </Description>
+                </Choice>
+                <Choice value='none' displayValue='None' description='No tin is generated at all.'/>
+                <Choice value='disabled' displayValue='Disabled' description='No tin is generated, and no tin symbols are available in Mystcraft ages.'/>
+            </OptionChoice>
+            
+            <OptionNumeric name='so2TinFreq' default='1'  min='0' max='5' displayState='hidden' displayGroup='groupSO2'>
+                <Description> Frequency multiplier for SimpleOres 2 Tin distributions </Description>
+                <DisplayName>SO2 Tin Freq.</DisplayName>
+            </OptionNumeric>
+            
+            <OptionNumeric name='so2TinSize' default='1'  min='0' max='5' displayState='hidden' displayGroup='groupSO2'>
+                <Description> Size multiplier for SimpleOres 2 Tin distributions </Description>
+                <DisplayName>SO2 Tin Size</DisplayName>
+            </OptionNumeric>  
+            
+            <IfCondition condition=':= so2TinDist != "disabled"'>
+                <MystcraftSymbol name='so2TinClusters' displayName='Tin Clusters'/>
+                <MystcraftSymbol name='so2TinVeins' displayName='Tin Veins'/>
+                <MystcraftSymbol name='so2TinClouds' displayName='Tin Clouds'>
+                    <Instability>:= 50 * (age.so2TinClusters + age.so2TinVeins + age.so2TinClouds - 1)^3</Instability>
+                </MystcraftSymbol>
+            </IfCondition>
+
+		</ConfigSection>           
+
+        <!--********************   Mythril   ***********************-->
+        <ConfigSection>
+            
+            <OptionChoice name='so2MythrilDist' displayState='shown' displayGroup='groupSO2'>
+                <Description> Controls how SimpleOres 2 Mythril is generated </Description>
+                <DisplayName>SO2 Mythril Type</DisplayName>
+                <Default>:= if(blockExists("mythrilOre"),"layeredVeins","disabled")</Default>
+                <Choice value='layeredVeins' displayValue='Veins'>
+                    <Description> 
+                        Groups of long narrow veins found about halfway down to bedrock.
+                    </Description>
+                </Choice>
+                <Choice value='strategicClouds' displayValue='Clouds'>
+                    <Description> 
+                        Rare, sparsely populated clouds of ore extending over several chunks.  Found only in flat grassy plains.
+                    </Description>
+                </Choice>
+                <Choice value='vanillaStdGen' displayValue='Clusters'>
+                    <Description> 
+                        Small clusters of ore scattered from bedrock about two thirds of the way to the surface.  This is the default IC2 tin generation.
+                    </Description>
+                </Choice>
+                <Choice value='none' displayValue='None' description='No mythril is generated at all.'/>
+                <Choice value='disabled' displayValue='Disabled' description='No mythril is generated, and no mythril symbols are available in Mystcraft ages.'/>
+            </OptionChoice>
+            
+            <OptionNumeric name='so2MythrilFreq' default='1'  min='0' max='5' displayState='hidden' displayGroup='groupSO2'>
+                <Description> Frequency multiplier for SimpleOres 2 Mythril distributions </Description>
+                <DisplayName>SO2 Mythril Freq.</DisplayName>
+            </OptionNumeric>
+            
+            <OptionNumeric name='so2MythrilSize' default='1'  min='0' max='5' displayState='hidden' displayGroup='groupSO2'>
+                <Description> Size multiplier for SimpleOres 2 Mythril distributions </Description>
+                <DisplayName>SO2 Mythril Size</DisplayName>
+            </OptionNumeric>  
+            
+            <IfCondition condition=':= so2MythrilDist != "disabled"'>
+                <MystcraftSymbol name='so2MythrilClusters' displayName='Mythril Clusters'/>
+                <MystcraftSymbol name='so2MythrilVeins' displayName='Mythril Veins'/>
+                <MystcraftSymbol name='so2MythrilClouds' displayName='Mythril Clouds'>
+                    <Instability>:= 50 * (age.so2MythrilClusters + age.so2MythrilVeins + age.so2MythrilClouds - 1)^3</Instability>
+                </MystcraftSymbol>
+            </IfCondition>
+
+		</ConfigSection>           
+
+        <!--********************   Adamantium   ***********************-->
+        <ConfigSection>
+            
+            <OptionChoice name='so2AdamantiumDist' displayState='shown' displayGroup='groupSO2'>
+                <Description> Controls how SimpleOres 2 Adamantium is generated </Description>
+                <DisplayName>SO2 Adamantium Type</DisplayName>
+                <Default>:= if(blockExists("adamantiumOre"),"layeredVeins","disabled")</Default>
+                <Choice value='layeredVeins' displayValue='Veins'>
+                    <Description> 
+                        Short narrow veins found about two-thirds of the way down to bedrock.
+                    </Description>
+                </Choice>
+                <Choice value='strategicClouds' displayValue='Clouds'>
+                    <Description> 
+                        Rare, sparsely populated clouds of ore extending over several chunks.  Found only in flat grassy plains.
+                    </Description>
+                </Choice>
+                <Choice value='vanillaStdGen' displayValue='Clusters'>
+                    <Description> 
+                        Small clusters of ore scattered from bedrock about two thirds of the way to bedrock.  This is the default SO2 Adamantium generation.
+                    </Description>
+                </Choice>
+                <Choice value='none' displayValue='None' description='No adamantium is generated at all.'/>
+                <Choice value='disabled' displayValue='Disabled' description='No adamantium is generated, and no adamantium symbols are available in Mystcraft ages.'/>
+            </OptionChoice>
+            
+            <OptionNumeric name='so2AdamantiumFreq' default='1'  min='0' max='5' displayState='hidden' displayGroup='groupSO2'>
+                <Description> Frequency multiplier for SimpleOres 2 Adamantium distributions </Description>
+                <DisplayName>SO2 Adamantium Freq.</DisplayName>
+            </OptionNumeric>
+            
+            <OptionNumeric name='so2AdamantiumSize' default='1'  min='0' max='5' displayState='hidden' displayGroup='groupSO2'>
+                <Description> Size multiplier for SimpleOres 2 Adamantium distributions </Description>
+                <DisplayName>SO2 Adamantium Size</DisplayName>
+            </OptionNumeric>  
+            
+            <IfCondition condition=':= so2AdamantiumDist != "disabled"'>
+                <MystcraftSymbol name='so2AdamantiumClusters' displayName='Adamantium Clusters'/>
+                <MystcraftSymbol name='so2AdamantiumVeins' displayName='Adamantium Veins'/>
+                <MystcraftSymbol name='so2AdamantiumClouds' displayName='Adamantium Clouds'>
+                    <Instability>:= 50 * (age.so2AdamantiumClusters + age.so2AdamantiumVeins + age.so2AdamantiumClouds - 1)^3</Instability>
+                </MystcraftSymbol>
+            </IfCondition>
+
+		</ConfigSection>           
+
+        
+        
+     </ConfigSection>    
+   
+    <!--*****************************   Distributions   *************************************
+    *   
+    *   Below are the actual distributions for the overworld and mystcraft ages.
+    *
+    *************************************************************************************-->
+    <IfCondition condition=':= dimension.generator = "RandomLevelSource"'>
+        
+        <Substitute name='SO2Substitute' block='stone'>
+            <Description> 
+                Replace SO2-generated ore clusters with stone.   
+            </Description>
+            <Comment>  
+                The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
+            </Comment>
+            <Replaces block='copperOre'/> 
+            <Replaces block='tinOre'/> 
+            <Replaces block='mythrilOre'/>
+            <Replaces block='adamantiumOre'/>
+        </Substitute>
+       
+        <!--*******************   Copper   *********************-->            
+        <ConfigSection>
+        
+            <IfCondition condition=':= if(age, age.so2CopperClusters > 0, so2CopperDist = "vanillaStdGen")'>
+                <StandardGen name='SO2CopperStandard' block='copperOre' inherits='PresetStandardGen'> 
+                    <Description> Equivalent to regular SO2 copper distribution </Description>
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x40773300</WireframeColor> 
+                    <Setting name='Size' avg=':= 1.25 * so2CopperSize * _default_'/> 
+                    <Setting name='Frequency' avg=':= 0.75 * so2CopperFreq * if(age,age.so2CopperClusters,1) * _default_' 
+                                                range=':= 4 * so2CopperFreq * if(age,age.so2CopperClusters,1)'/>
+                    <Setting name='Height' avg=':= 50/64 * dimension.groundLevel' range=':= 40/64 * dimension.groundLevel' type='uniform'/> 
+                </StandardGen>
+            </IfCondition>   
+            
+            <IfCondition condition=':= if(age, age.so2CopperVeins > 0, so2CopperDist = "layeredVeins")'>             
+                <Veins name='SO2CopperVeins' block='copperOre' inherits='PresetLayeredVeins'>
+                    <Description>  Average veins in the 10-90 range. </Description> 
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x40773300</WireframeColor> 
+                    <Setting name='MotherlodeFrequency' avg=':= 1.15 * so2CopperFreq * if(age,age.so2CopperVeins,1) * _default_'/>
+                    <Setting name='MotherlodeSize' avg=':= so2CopperSize * _default_' range=':= so2CopperSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 50/64 * dimension.groundLevel' range=':= 40/64 * dimension.groundLevel' type='normal'/>
+                    <Setting name='BranchFrequency' avg=':= 0.6 * _default_' range=':= 0.6 * _default_'/>
+                    <Setting name='BranchLength' avg=':= 1.2 * _default_'/>
+                    <Setting name='BranchHeightLimit' avg='24'/>
+                    <Setting name='SegmentRadius' avg=':= so2CopperSize * _default_' range=':= so2CopperSize * _default_'/>
+                </Veins>                
+                <Veins name='SO2CopperVeinsJungle' inherits='SO2CopperVeins'>
+                    <Description> This roughly triples the chance of finding Copper in jungle biomes. </Description> 
+                    <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':=_default_' range=':= 2 * _default_'/>
+                    <Setting name='BranchHeightLimit' avg=':= 2 * _default_'/>  
+                    <Biome name='Jungle'/>
+                    <Biome name='Jungle\s*Hills'/>
+                    <Biome name='Extreme\s*Jungle'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Mini\s*Jungle'/> <Comment> ExtraBiomesXL </Comment>  
+                </Veins>   
+            </IfCondition>     
+            
+            <IfCondition condition=':= if(age, age.so2CopperClouds > 0, so2CopperDist = "strategicClouds")'>
+                <Cloud name='SO2CopperCloud' block='copperOre' inherits='PresetStrategicCloud'>
+                    <Description>  
+                        Diffuse copper cloud surrounded by single-block "hint" veins, found in jungle biomes.
+                    </Description> 
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x40773300</WireframeColor> 
+                    <Setting name='DistributionFrequency' avg=':= 3.5 * so2CopperFreq * if(age,age.so2CopperClouds,1) * _default_'/>
+                    <Setting name='CloudRadius' avg=':= 1.1 * so2CopperSize * _default_' range=':= so2CopperSize * _default_'/>
+                    <Setting name='CloudThickness' avg=':= 1.1 * so2CopperSize * _default_' range=':= so2CopperSize * _default_'/> 
+                    <Biome name='Jungle'/>
+                    <Biome name='Jungle\s*Hills'/>
+                    <Biome name='Extreme\s*Jungle'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Mini\s*Jungle'/> <Comment> ExtraBiomesXL </Comment>  
+                    <Veins name='SO2CopperHintVeins' block='copperOre' inherits='PresetHintVeins'>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x40773300</WireframeColor> 
+                        <Setting name='MotherlodeFrequency' avg=':= _default_' range=':= _default_'/>   
+                        <Setting name='MotherlodeRangeLimit' avg=':= so2CopperSize * _default_' range=':= so2CopperSize * _default_'/>              
+                    </Veins>
+                </Cloud>
+            </IfCondition>  
+            
+        </ConfigSection>
+        
+        <!--********************   Tin   ***********************-->            
+        <ConfigSection>
+        
+            <IfCondition condition=':= if(age, age.so2TinClusters > 0, so2TinDist = "vanillaStdGen")'>            
+                <StandardGen name='SO2TinStandard' block='tinOre' inherits='PresetStandardGen'> 
+                    <Description> Equivalent to regular SO2 tin distribution </Description>
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x40FFFFFF</WireframeColor> 
+                    <Setting name='Size' avg=':= 0.75 * so2TinSize * _default_'/> 
+                    <Setting name='Frequency' avg=':= 1.25 * so2TinFreq * if(age,age.so2TinClusters,1) * _default_' 
+                                                range=':= 5 * so2TinFreq * if(age,age.so2TinClusters,1)'/>
+                    <Setting name='Height' avg=':= 50/64 * dimension.groundLevel' range=':= 40/64 * dimension.groundLevel' type='uniform'/> 
+                </StandardGen>
+            </IfCondition>   
+            
+            <IfCondition condition=':= if(age, age.so2TinVeins > 0, so2TinDist = "layeredVeins")'>    
+                <Veins name='SO2TinVeins' block='tinOre' inherits='PresetLayeredVeins'>
+                    <Description> 
+                        Average veins in the 10-90 range.
+                    </Description> 
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x40FFFFFF</WireframeColor> 
+                    <Setting name='MotherlodeFrequency' avg=':= 1.10 * so2TinFreq * if(age,age.so2TinVeins,1) * _default_'/>
+                    <Setting name='MotherlodeSize' avg=':= so2TinSize * _default_' range=':= so2TinSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 50/64 * dimension.groundLevel' range=':= 40/64 * dimension.groundLevel' type='normal'/>
+                    <Setting name='BranchHeightLimit' avg='20'/>
+                    <Setting name='BranchLength' avg=':= 0.8 * _default_'/>
+                    <Setting name='SegmentRadius' avg=':= so2TinSize * _default_' range=':= so2TinSize * _default_'/>
+                </Veins>
+                <Veins name='SO2TinVeinsPlains' inherits='SO2TinVeins'>
+                    <Description> This roughly triples the chance of finding tin in plains biomes. </Description> 
+                    <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':=_default_' range=':= 2 * _default_'/>
+                    <Setting name='BranchHeightLimit' avg=':= 2 * _default_'/>  
+                    <Biome name='Plains'/>
+                    <Biome name='Meadow'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Savanna'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Shrubland'/> <Comment> ExtraBiomesXL </Comment>
+                </Veins>
+            </IfCondition>     
+            
+            <IfCondition condition=':= if(age, age.so2TinClouds > 0, so2TinDist = "strategicClouds")'>
+                <Cloud name='SO2TinCloud' block='tinOre' inherits='PresetStrategicCloud'>
+                    <Description>  
+                        Diffuse tin cloud surrounded by single-block "hint" veins, found in plains biomes.
+                    </Description> 
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x40FFFFFF</WireframeColor> 
+                    <Setting name='DistributionFrequency' avg=':= 4 * so2TinFreq * if(age,age.so2TinClouds,1) * _default_'/>
+                    <Setting name='CloudRadius' avg=':= 0.9 * so2TinSize * _default_' range=':= so2TinSize * _default_'/>
+                    <Setting name='CloudThickness' avg=':= 0.9 * so2TinSize * _default_' range=':= so2TinSize * _default_'/> 
+                    <Biome name='Plains'/>
+                    <Biome name='Meadow'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Savanna'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Shrubland'/> <Comment> ExtraBiomesXL </Comment>
+                    <Veins name='SO2TinHintVeins' block='tinOre' inherits='PresetHintVeins'>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x40FFFFFF</WireframeColor> 
+                        <Setting name='MotherlodeFrequency' avg=':= _default_' range=':= _default_'/>   
+                        <Setting name='MotherlodeRangeLimit' avg=':= so2TinSize * _default_' range=':= so2TinSize * _default_'/>              
+                    </Veins>
+                </Cloud>
+            </IfCondition>  
+            
+        </ConfigSection>
+        
+					
+		<!--********************   Mythril   ***********************-->            
+        <ConfigSection>
+        
+            <IfCondition condition=':= if(age, age.so2MythrilClusters > 0, so2MythrilDist = "vanillaStdGen")'>            
+                <StandardGen name='SO2MythrilStandard' block='mythrilOre' inherits='PresetStandardGen'> 
+                    <Description> Equivalent to regular SO2 mythril distribution </Description>
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x4000A6F4</WireframeColor> 
+                    <Setting name='Size' avg=':= 0.75 * so2MythrilSize * _default_'/> 
+                    <Setting name='Frequency' avg=':= 1.25 * so2MythrilFreq * if(age,age.so2MythrilClusters,1) * _default_' 
+                                                range=':= 5 * so2MythrilFreq * if(age,age.so2MythrilClusters,1)'/>
+                    <Setting name='Height' avg=':= 19/64 * dimension.groundLevel' range=':= 15/64 * dimension.groundLevel' type='uniform'/> 
+                </StandardGen>
+            </IfCondition>   
+            
+            <IfCondition condition=':= if(age, age.so2MythrilVeins > 0, so2MythrilDist = "layeredVeins")'>    
+                <Veins name='SO2MythrilVeins' block='mythrilOre' inherits='PresetLayeredVeins'>
+                    <Description> 
+                        Small veins in the 4-35 range.
+                    </Description> 
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x4000A6F4</WireframeColor> 
+                    <Setting name='MotherlodeFrequency' avg=':= 6 * so2MythrilFreq * if(age,age.so2MythrilVeins,1) * _default_'/>
+                    <Setting name='MotherlodeSize' avg=':= 0.5 * so2MythrilSize * _default_' range=':= so2MythrilSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 19/64 * dimension.groundLevel' range=':= 15/64 * dimension.groundLevel' type='normal'/>
+                    <Setting name='BranchHeightLimit' avg='20'/>
+                    <Setting name='BranchLength' avg='12' range='6'/>
+                    <Setting name='SegmentRadius' avg=':= so2MythrilSize * _default_' range=':= so2MythrilSize * _default_'/>
+                </Veins>
+				<!--
+                <Veins name='SO2MythrilVeinsPlains' inherits='SO2MythrilVeins'>
+                    <Description> This roughly triples the chance of finding mythril in plains biomes. </Description> 
+                    <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':=_default_' range=':= 2 * _default_'/>
+                    <Setting name='BranchHeightLimit' avg=':= 2 * _default_'/>  
+                    <Biome name='Plains'/>
+                    <Biome name='Meadow'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Savanna'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Shrubland'/> <Comment> ExtraBiomesXL </Comment>
+                </Veins>
+				-->
+            </IfCondition>     
+            
+            <IfCondition condition=':= if(age, age.so2MythrilClouds > 0, so2MythrilDist = "strategicClouds")'>
+                <Cloud name='SO2MythrilCloud' block='mythrilOre' inherits='PresetStrategicCloud'>
+                    <Description>  
+                        Diffuse mythril cloud surrounded by single-block "hint" veins, found in plains biomes.
+                    </Description> 
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x4000A6F4</WireframeColor> 
+                    <Setting name='DistributionFrequency' avg=':= 4 * so2MythrilFreq * if(age,age.so2MythrilClouds,1) * _default_'/>
+                    <Setting name='CloudRadius' avg=':= 0.9 * so2MythrilSize * _default_' range=':= so2MythrilSize * _default_'/>
+                    <Setting name='CloudThickness' avg=':= 0.9 * so2MythrilSize * _default_' range=':= so2MythrilSize * _default_'/> 
+                    <Biome name='Plains'/>
+                    <Biome name='Meadow'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Savanna'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Shrubland'/> <Comment> ExtraBiomesXL </Comment>
+                    <Veins name='SO2MythrilHintVeins' block='mythrilOre' inherits='PresetHintVeins'>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x4000A6F4</WireframeColor> 
+                        <Setting name='MotherlodeFrequency' avg=':= _default_' range=':= _default_'/>   
+                        <Setting name='MotherlodeRangeLimit' avg=':= so2MythrilSize * _default_' range=':= so2MythrilSize * _default_'/>              
+                    </Veins>
+                </Cloud>
+            </IfCondition>  
+            
+        </ConfigSection>
+
+		
+		<!--********************   Adamantium   ***********************-->            
+        <ConfigSection>
+        
+            <IfCondition condition=':= if(age, age.so2AdamantiumClusters > 0, so2AdamantiumDist = "vanillaStdGen")'>            
+                <StandardGen name='SO2AdamantiumStandard' block='adamantiumOre' inherits='PresetStandardGen'> 
+                    <Description> Equivalent to regular SO2 adamantium distribution </Description>
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x4033BA31</WireframeColor> 
+                    <Setting name='Size' avg=':= 0.75 * so2AdamantiumSize * _default_'/> 
+                    <Setting name='Frequency' avg=':= 1.25 * so2AdamantiumFreq * if(age,age.so2AdamantiumClusters,1) * _default_' 
+                                                range=':= 5 * so2AdamantiumFreq * if(age,age.so2AdamantiumClusters,1)'/>
+                    <Setting name='Height' avg=':= 11/64 * dimension.groundLevel' range=':= 9/64 * dimension.groundLevel' type='uniform'/> 
+                </StandardGen>
+            </IfCondition>   
+            
+            <IfCondition condition=':= if(age, age.so2AdamantiumVeins > 0, so2AdamantiumDist = "layeredVeins")'>    
+                <Veins name='SO2AdamantiumVeins' block='adamantiumOre' inherits='PresetLayeredVeins'>
+                    <Description> 
+                        Small veins in the 2-20 range.
+                    </Description> 
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x4033BA31</WireframeColor> 
+                    <Setting name='MotherlodeFrequency' avg=':= 1.5 * so2AdamantiumFreq * if(age,age.so2AdamantiumVeins,1) * _default_'/>
+                    <Setting name='MotherlodeSize' avg='0' range='0'/>
+                    <Setting name='MotherlodeHeight' avg=':= 11/64 * dimension.groundLevel' range=':= 9/64 * dimension.groundLevel' type='normal'/>
+                    <Setting name='BranchHeightLimit' avg='10'/>
+                    <Setting name='BranchLength' avg='9' range='4'/>
+                    <Setting name='SegmentRadius' avg=':= so2AdamantiumSize * _default_' range=':= so2AdamantiumSize * _default_'/>
+                </Veins>
+				<!--
+                <Veins name='SO2AdamantiumVeinsPlains' inherits='SO2AdamantiumVeins'>
+                    <Description> This roughly triples the chance of finding adamantium in plains biomes. </Description> 
+                    <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':=_default_' range=':= 2 * _default_'/>
+                    <Setting name='BranchHeightLimit' avg=':= 2 * _default_'/>  
+                    <Biome name='Plains'/>
+                    <Biome name='Meadow'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Savanna'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Shrubland'/> <Comment> ExtraBiomesXL </Comment>
+                </Veins>
+				-->
+            </IfCondition>     
+            
+            <IfCondition condition=':= if(age, age.so2AdamantiumClouds > 0, so2AdamantiumDist = "strategicClouds")'>
+                <Cloud name='SO2AdamantiumCloud' block='adamantiumOre' inherits='PresetStrategicCloud'>
+                    <Description>  
+                        Diffuse adamantium cloud surrounded by single-block "hint" veins, found in plains biomes.
+                    </Description> 
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x4033BA31</WireframeColor> 
+                    <Setting name='DistributionFrequency' avg=':= 4 * so2AdamantiumFreq * if(age,age.so2AdamantiumClouds,1) * _default_'/>
+                    <Setting name='CloudRadius' avg=':= 0.9 * so2AdamantiumSize * _default_' range=':= so2AdamantiumSize * _default_'/>
+                    <Setting name='CloudThickness' avg=':= 0.9 * so2AdamantiumSize * _default_' range=':= so2AdamantiumSize * _default_'/> 
+                    <Biome name='Plains'/>
+                    <Biome name='Meadow'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Savanna'/> <Comment> ExtraBiomesXL </Comment>
+                    <Biome name='Shrubland'/> <Comment> ExtraBiomesXL </Comment>
+                    <Veins name='SO2AdamantiumHintVeins' block='adamantiumOre' inherits='PresetHintVeins'>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x4033BA31</WireframeColor> 
+                        <Setting name='MotherlodeFrequency' avg=':= _default_' range=':= _default_'/>   
+                        <Setting name='MotherlodeRangeLimit' avg=':= so2AdamantiumSize * _default_' range=':= so2AdamantiumSize * _default_'/>              
+                    </Veins>
+                </Cloud>
+            </IfCondition>  
+            
+        </ConfigSection>
+
+		
+		
+    </IfCondition>
+    
+</IfModInstalled>


### PR DESCRIPTION
From the file head:

Based on the configuration files for IC2 Copper, Tin, and Urainum (for
Adamantium), with tweaks to more closely fit the heights and frequency
of default SO2.

This is an incomplete adaptation. Only "Veins" distributions have been
adjusted from the values borrowed from the IC2 file, i.e., choosing
"Standard" will work but will not behave as expected. Similarly,
"Clouds" will not give expected results.

TODO:
- Add Onyx support
- Tune SO2TinVeins down a bit (playtesting shows veins are slightly too
  frequent
  and much too long)
- Reduce max height of Tin and Copper veins while also allowing to
  generate inside mountains
  (maybe by implementing child distributions for just the tall parts of
  tall biomes?)
- Do Standard adaptations
- Do Cloud adapatations
- Develop biome-specific child distributions for Mythril and Adamantium
