### PR TITLE
change block='10' to block='minecraft:lava'

### DIFF
--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -204,7 +204,7 @@
                     <BiomeType name='Mountain'/>
                     <Biome name='Green\s*Hills'/> <Comment> ExtraBiomesXL </Comment>
                 </Veins>
-                <Veins name='PRRubyVeinsLava' block='10' inherits='PRRubyVeins' seed='0xFF0300'>
+                <Veins name='PRRubyVeinsLava' block='minecraft:lava' inherits='PRRubyVeins' seed='0xFF0300'>
                     <Description> Fills center of each tube with lava </Description>
                     <Setting name='MotherlodeSize' avg=':= 0.4 * _default_'/>
                     <Setting name='SegmentRadius' avg=':= 0.4 * _default_'/>
@@ -263,7 +263,7 @@
                     <BiomeType name='Mountain'/>
                     <Biome name='Green\s*Hills'/> <Comment> ExtraBiomesXL </Comment>
                 </Veins>
-                <Veins name='PRSapphireVeinsLava' block='10' inherits='PRSapphireVeins' seed='0xFF0302'>
+                <Veins name='PRSapphireVeinsLava' block='minecraft:lava' inherits='PRSapphireVeins' seed='0xFF0302'>
                     <Description> Fills center of each tube with lava </Description>
                     <Setting name='MotherlodeSize' avg=':= 0.4 * _default_'/>
                     <Setting name='SegmentRadius' avg=':= 0.4 * _default_'/>
@@ -322,7 +322,7 @@
                     <BiomeType name='Mountain'/>
                     <Biome name='Green\s*Hills'/> <Comment> ExtraBiomesXL </Comment>
                 </Veins>
-                <Veins name='PRPeridotVeinsLava' block='10' inherits='PRPeridotVeins' seed='0xFF0301'>
+                <Veins name='PRPeridotVeinsLava' block='minecraft:lava' inherits='PRPeridotVeins' seed='0xFF0301'>
                     <Description> Fills center of each tube with lava </Description>
                     <Setting name='MotherlodeSize' avg=':= 0.4 * _default_'/>
                     <Setting name='SegmentRadius' avg=':= 0.4 * _default_'/>


### PR DESCRIPTION
Just changed to the ID-Name of Lava.

Something is still wrong with the Name of the ores. I checked them with NEI and they match, but COG still says

'ore block descriptor for PRRubyVeins is empty or does not match any registered blocks.'

at the first used occuring of block='projectred.exploration.ore:0' in row 194 for example (when using Ruby Veins-Option)

Hope this helps!

regards, Blast0r
