### PR TITLE
Update MapGenVeins.java

### DIFF
--- a/src/main/java/CustomOreGen/Server/MapGenVeins.java
+++ b/src/main/java/CustomOreGen/Server/MapGenVeins.java
@@ -83,6 +83,11 @@ public class MapGenVeins extends MapGenOreDistribution
     )
     public final PDist sgAngle;
     @DistributionSetting(
+            name = "SegmentPitch",
+            info = "Angle at which each segment rises or falls from the previous segment, in radians"
+    )
+    public final PDist sgPitch;
+    @DistributionSetting(
             name = "SegmentRadius",
             info = "Cross-section radius of branch segments, in meters"
     )
@@ -115,6 +120,7 @@ public class MapGenVeins extends MapGenOreDistribution
         this.sgForkLenMult = new PDist(0.75F, 0.25F);
         this.sgLength = new PDist(15.0F, 6.0F);
         this.sgAngle = new PDist(0.5F, 0.5F);
+        this.sgPitch = new PDist(0.0F, 0.1F);
         this.sgRadius = new PDist(0.5F, 0.3F);
         this.orDensity = new PDist(1.0F, 0.0F);
         this.orRadiusMult = new PDist(1.0F, 0.1F);
@@ -234,8 +240,10 @@ public class MapGenVeins extends MapGenOreDistribution
                 this.generateBranch(structureGroup, length * (fkLenMult > 1.0F ? 1.0F : fkLenMult), maxHeight, minHeight, fkMat, (Component)component, fkRandom);
             }
 
-            float var18 = random.nextFloat() * ((float)Math.PI * 2F);
-            mat.rotate(this.sgAngle.getValue(random), MathHelper.cos(var18), MathHelper.sin(var18), 0.0F);
+            Transform rot = new Transform();
+            rot.rotateY(this.sgAngle.getValue(random));
+            rot.rotateX(this.sgPitch.getValue(random));
+            mat.transform(rot);
         }
     }
     

--- a/src/main/resources/config/CustomOreGen_Config_Default.xml
+++ b/src/main/resources/config/CustomOreGen_Config_Default.xml
@@ -188,6 +188,7 @@
             <Setting name='SegmentForkLengthMult' avg='0.75' range='0.25' /> 
             <Setting name='SegmentLength' avg='15' range='6'/> 
             <Setting name='SegmentAngle' avg='0.50' range='0.50'/> 
+            <Setting name='SegmentPitch' avg='0.50' range='0.50'/> 
             <Setting name='SegmentRadius' avg=':= 0.5 * oreSize' range=':= 0.3 * oreSize'/>
             <Setting name='OreDensity' avg='1' range='0'/> 
             <Setting name='OreRadiusMult' avg='1.0' range='0.1'/> 
@@ -329,6 +330,7 @@
             <Setting name='SegmentForkLengthMult' avg='0' range='0'/> 
             <Setting name='SegmentLength' avg='20' range='8'/>
             <Setting name='SegmentAngle' avg='0.35' range='0.35'/> 
+            <Setting name='SegmentPitch' avg='0.35' range='0.35'/> 
             <Setting name='SegmentRadius' avg=':= 2.0 * oreSize' range=':= 1.0 * oreSize'/> 
             <Setting name='OreDensity' avg='0.04' range='0'/>
             <Setting name='OreRadiusMult' avg='1.0' range='0.1'/> 
@@ -352,6 +354,7 @@
             <Setting name='SegmentForkLengthMult' avg='0' range='0'/> 
             <Setting name='SegmentLength' avg='8' range='3'/>
             <Setting name='SegmentAngle' avg='0' range='0.25'/> 
+            <Setting name='SegmentPitch' avg='0' range='0.25'/> 
             <Setting name='SegmentRadius' avg=':= 2.0 * oreSize' range=':= 0.5 * oreSize'/> 
             <Setting name='OreDensity' avg='0.04' range='0'/>
             <Setting name='OreRadiusMult' avg='1.0' range='0.1'/> 
@@ -392,8 +395,9 @@
     -->
 
     <Import file='modules/default/ExtraCaves.xml'/>
-    <Import file='modules/default/MinecraftOres.xml'/>
-    <Import file='modules/default/IndustrialCraft2.xml'/>
+	<!--These two are overridden by Harder Ores's configs in 'modules/custom'-->
+    <!--<Import file='modules/default/MinecraftOres.xml'/>-->
+    <!--<Import file='modules/default/IndustrialCraft2.xml'/>-->
     <Import file='modules/default/Forestry.xml'/>
     <Import file='modules/default/ProjectRed.xml'/>
     <Import file='modules/default/Dartcraft.xml'/>

--- a/src/main/resources/config/modules/ExtraCaves.xml
+++ b/src/main/resources/config/modules/ExtraCaves.xml
@@ -34,6 +34,7 @@
             <Setting name='SegmentForkLengthMult' avg='0.75' range='0.25' /> 
             <Setting name='SegmentLength' avg='30' range='6'/> 
             <Setting name='SegmentAngle' avg='0.70' range='0.70'/> 
+            <Setting name='SegmentPitch' avg='0.70' range='0.70'/> 
             <Setting name='SegmentRadius' avg='6' range='3.8' type='normal'/>
             <Setting name='OreDensity' avg='1' range='0'/>
             <Setting name='OreRadiusMult' avg='1' range='0.1'/> 

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -135,6 +135,7 @@ Silver, Dark Iron
                     <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                     <Setting name='SegmentRadius' avg=':= 0.7 * factSilverSize * _default_' range=':= 0.5 * factSilverSize * _default_'/>
                     <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                 </Veins>
             </IfCondition>
                 

--- a/src/main/resources/config/modules/Metallurgy.xml
+++ b/src/main/resources/config/modules/Metallurgy.xml
@@ -1296,6 +1296,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * preciousSize * _default_' range=':= 0.5 * preciousSize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='zincVeinsForest' inherits='zincVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -1360,6 +1361,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * preciousSize * _default_' range=':= 0.5 * preciousSize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='m3silverVeinsForest' inherits='m3silverVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -1424,6 +1426,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * preciousSize * _default_' range=':= 0.5 * preciousSize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='platinumVeinsForest' inherits='platinumVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -1497,6 +1500,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * fantasySize * _default_' range=':= 0.5 * fantasySize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='promethiumVeinsForest' inherits='promethiumVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -1561,6 +1565,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * fantasySize * _default_' range=':= 0.5 * fantasySize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='deepironVeinsForest' inherits='deepironVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -1625,6 +1630,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * fantasySize * _default_' range=':= 0.5 * fantasySize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='infuscoliumVeinsForest' inherits='infuscoliumVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -1689,6 +1695,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * fantasySize * _default_' range=':= 0.5 * fantasySize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='oureclaseVeinsForest' inherits='oureclaseVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -1753,6 +1760,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * fantasySize * _default_' range=':= 0.5 * fantasySize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='astralm3silverVeinsForest' inherits='astralm3silverVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -1817,6 +1825,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * fantasySize * _default_' range=':= 0.5 * fantasySize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='carmotVeinsForest' inherits='carmotVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -1881,6 +1890,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * fantasySize * _default_' range=':= 0.5 * fantasySize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='mithrilVeinsForest' inherits='mithrilVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -1945,6 +1955,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * fantasySize * _default_' range=':= 0.5 * fantasySize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='rubraciumVeinsForest' inherits='rubraciumVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -2009,6 +2020,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * fantasySize * _default_' range=':= 0.5 * fantasySize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='orichalcumVeinsForest' inherits='orichalcumVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -2073,6 +2085,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * fantasySize * _default_' range=':= 0.5 * fantasySize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='adamantineVeinsForest' inherits='adamantineVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 
@@ -2137,6 +2150,7 @@
                      <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                      <Setting name='SegmentRadius' avg=':= 0.7 * fantasySize * _default_' range=':= 0.5 * fantasySize * _default_'/>
                      <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                  </Veins>
                  <Veins name='atlarusVeinsForest' inherits='atlarusVeins'>
                      <Description> This roughly triples the chance of finding ore in forested biomes. </Description> 

--- a/src/main/resources/config/modules/MinecraftOres.xml
+++ b/src/main/resources/config/modules/MinecraftOres.xml
@@ -476,6 +476,7 @@
                     <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                     <Setting name='SegmentRadius' avg=':= 0.7 * goldSize * _default_' range=':= 0.5 * goldSize * _default_'/>
                     <Setting name='SegmentAngle' avg='0.6' range='0.40' /> 
+            <Setting name='SegmentPitch' avg='0.6' range='0.40' /> 
                 </Veins>
                 <Veins name='GoldVeinsForest' inherits='GoldVeins'>
                     <Description> This roughly triples the chance of finding gold in forested biomes. </Description> 


### PR DESCRIPTION
Adds a pitch setting so that vein wandering height stays more consistent while allowing the vein to meander across the X-Z plane more freely.
Before, veins reach their clipped to a height of +/-30 very quickly: http://s29.postimg.org/lncfmhy1z/2015_02_17_12_36_48.png
After, same settings (default pitch): http://s29.postimg.org/4bc3124kn/2015_02_17_12_54_25.png
Very high segment angle (1.5 iirc) and short segment length, animating the segment pitch from 0 to 0.15: http://s23.postimg.org/5g99hjvjd/pitch.gif