### PR TITLE
Update ValidatorPDist.java

### DIFF
--- a/src/main/java/CustomOreGen/Config/ValidatorPDist.java
+++ b/src/main/java/CustomOreGen/Config/ValidatorPDist.java
@@ -40,12 +40,12 @@ public class ValidatorPDist extends ValidatorNode
         		heightScaledPDist = (HeightScaledPDist)setting;
         		this.pdist = heightScaledPDist.pdist;
         	} else {
-        		throw new ParserException("Setting \'" + this.name + "\' is not supported by this distribution.", this.getNode());
+        		throw new ParserException("Setting \'" + this.name + "\' in \'"+this._parentDist.toString()+"\' is not supported by this distribution.", this.getNode());
         	}
             
             if (this.pdist == null)
             {
-                throw new ParserException("Setting \'" + this.name + "\' is not supported by this distribution.", this.getNode());
+                throw new ParserException("Setting \'" + this.name + "\' in \'"+this._parentDist.toString()+"\' is not supported by this distribution.", this.getNode());
             }
         }
 
@@ -70,11 +70,11 @@ public class ValidatorPDist extends ValidatorNode
             }
             catch (IllegalAccessException var2)
             {
-                throw new ParserException("Setting \'" + this.name + "\' is not configurable.", this.getNode(), var2);
+                throw new ParserException("Setting \'" + this.name + "\' in \'"+this._parentDist.toString()+"\' is not configurable.", this.getNode(), var2);
             }
             catch (IllegalArgumentException var3)
             {
-                throw new ParserException("Setting \'" + this.name + "\' is not supported by this distribution.", this.getNode(), var3);
+                throw new ParserException("Setting \'" + this.name + "\' in \'"+this._parentDist.toString()+"\' is not supported by this distribution.", this.getNode(), var3);
             }
         }
 


### PR DESCRIPTION
Few minor tweaks to the error reporting.  I had been making changes to multiple files, each over 500 lines long, and was receiving the invalid error "CustomOreGen Config Error at Element <Setting> [line 343]: Setting 'Frequency' is not supported by this distribution." which didn't tell me which file I should be looking at (BOTH files had a "frequency" setting at that line), and changing one didn't effect the error--because BOTH were wrong, but it hadn't been informative that I'd made a positive alteration.

Change causes the parent node's name to also print, generating better feedback to the user on which distribution is causing a problem.  e.g. "CustomOreGen Config Error at Element <Setting> [line 343]: Setting 'Frequency' is not supported by the distribution 'MyOreVeins'."