### PR TITLE
The Huge Vein Project.

### DIFF
--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -10,8 +10,8 @@ Quartz, Charged Quartz
 
     <!-- Mod detection -->
     <IfModInstalled name="appliedenergistics2">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -204,7 +204,7 @@ Quartz, Charged Quartz
                 <!-- Begin  Huge Veins distribution of Quartz -->
                 <IfCondition condition=':= apenQuartzDist = "hugeVeins"'>
                 
-                    <Veins name='apenQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartz' inherits='PresetLayeredVeins'>
+                    <Veins name='apenQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartz' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -224,23 +224,6 @@ Quartz, Charged Quartz
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * apenQuartzFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Quartz Huge Vein Hint Veins -->
-                        <Veins name='apenQuartzBaseHintVeins' block='appliedenergistics2:tile.OreQuartz' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609BBEC2</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Quartz Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Quartz Huge Veins) Settings -->
@@ -252,21 +235,6 @@ Quartz, Charged Quartz
                         <WireframeColor>0x609BBEC2</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Desert'/>
-                        
-                        <!-- Begin Quartz Huge Vein Hint Veins -->
-                        <Veins name='apenQuartzPrefersHintVeins' block='appliedenergistics2:tile.OreQuartz' inherits='apenQuartzBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609BBEC2</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Desert'/>
-                        </Veins>
-                        <!-- End Quartz Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Quartz Huge Veins) Settings -->
                 
@@ -413,7 +381,7 @@ Quartz, Charged Quartz
                 <!-- Begin  Huge Veins distribution of Charged Quartz -->
                 <IfCondition condition=':= apenChargedQuartzDist = "hugeVeins"'>
                 
-                    <Veins name='apenChargedQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartzCharged' inherits='PresetLayeredVeins'>
+                    <Veins name='apenChargedQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartzCharged' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -433,23 +401,6 @@ Quartz, Charged Quartz
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.5 * apenChargedQuartzFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Charged Quartz Huge Vein Hint Veins -->
-                        <Veins name='apenChargedQuartzBaseHintVeins' block='appliedenergistics2:tile.OreQuartzCharged' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6093C6FF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Charged Quartz Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Charged Quartz Huge Veins) Settings -->
@@ -461,21 +412,6 @@ Quartz, Charged Quartz
                         <WireframeColor>0x6093C6FF</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Desert'/>
-                        
-                        <!-- Begin Charged Quartz Huge Vein Hint Veins -->
-                        <Veins name='apenChargedQuartzPrefersHintVeins' block='appliedenergistics2:tile.OreQuartzCharged' inherits='apenChargedQuartzBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6093C6FF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Desert'/>
-                        </Veins>
-                        <!-- End Charged Quartz Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Charged Quartz Huge Veins) Settings -->
                 
@@ -554,12 +490,9 @@ Quartz, Charged Quartz
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/ArsMagicka2.xml
+++ b/src/main/resources/config/modules/ArsMagicka2.xml
@@ -10,8 +10,8 @@ Vinteum, Chimerite, Blue Topaz
 
     <!-- Mod detection -->
     <IfModInstalled name="arsmagica2">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -203,7 +203,7 @@ Vinteum, Chimerite, Blue Topaz
                 <!-- Begin  Huge Veins distribution of Vinteum -->
                 <IfCondition condition=':= arsmVinteumDist = "hugeVeins"'>
                 
-                    <Veins name='arsmVinteumBaseVeins' block='arsmagica2:vinteumOre' inherits='PresetLayeredVeins'>
+                    <Veins name='arsmVinteumBaseVeins' block='arsmagica2:vinteumOre' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -225,23 +225,6 @@ Vinteum, Chimerite, Blue Topaz
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Vinteum Huge Vein Hint Veins -->
-                        <Veins name='arsmVinteumBaseHintVeins' block='arsmagica2:vinteumOre' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x605364EE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Vinteum Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Vinteum Huge Veins) Settings -->
@@ -253,21 +236,6 @@ Vinteum, Chimerite, Blue Topaz
                         <WireframeColor>0x605364EE</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Vinteum Huge Vein Hint Veins -->
-                        <Veins name='arsmVinteumPrefersHintVeins' block='arsmagica2:vinteumOre' inherits='arsmVinteumBaseHintVeins'>
-                            <Description>
-                                Spawns 4 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x605364EE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Vinteum Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Vinteum Huge Veins) Settings -->
                 
@@ -381,7 +349,7 @@ Vinteum, Chimerite, Blue Topaz
                 <!-- Begin  Huge Veins distribution of Chimerite -->
                 <IfCondition condition=':= arsmChimeriteDist = "hugeVeins"'>
                 
-                    <Veins name='arsmChimeriteBaseVeins' block='arsmagica2:vinteumOre:1' inherits='PresetLayeredVeins'>
+                    <Veins name='arsmChimeriteBaseVeins' block='arsmagica2:vinteumOre:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -401,23 +369,6 @@ Vinteum, Chimerite, Blue Topaz
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * arsmChimeriteFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Chimerite Huge Vein Hint Veins -->
-                        <Veins name='arsmChimeriteBaseHintVeins' block='arsmagica2:vinteumOre:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60B8E6C6</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Chimerite Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Chimerite Huge Veins) Settings -->
@@ -429,21 +380,6 @@ Vinteum, Chimerite, Blue Topaz
                         <WireframeColor>0x60B8E6C6</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Chimerite Huge Vein Hint Veins -->
-                        <Veins name='arsmChimeritePrefersHintVeins' block='arsmagica2:vinteumOre:1' inherits='arsmChimeriteBaseHintVeins'>
-                            <Description>
-                                Spawns 4 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60B8E6C6</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Chimerite Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Chimerite Huge Veins) Settings -->
                 
@@ -557,7 +493,7 @@ Vinteum, Chimerite, Blue Topaz
                 <!-- Begin  Huge Veins distribution of Blue Topaz -->
                 <IfCondition condition=':= arsmBlueTopazDist = "hugeVeins"'>
                 
-                    <Veins name='arsmBlueTopazBaseVeins' block='arsmagica2:vinteumOre:2' inherits='PresetLayeredVeins'>
+                    <Veins name='arsmBlueTopazBaseVeins' block='arsmagica2:vinteumOre:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -577,23 +513,6 @@ Vinteum, Chimerite, Blue Topaz
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * arsmBlueTopazFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Blue Topaz Huge Vein Hint Veins -->
-                        <Veins name='arsmBlueTopazBaseHintVeins' block='arsmagica2:vinteumOre:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x607EE5F4</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Blue Topaz Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Blue Topaz Huge Veins) Settings -->
@@ -605,21 +524,6 @@ Vinteum, Chimerite, Blue Topaz
                         <WireframeColor>0x607EE5F4</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Blue Topaz Huge Vein Hint Veins -->
-                        <Veins name='arsmBlueTopazPrefersHintVeins' block='arsmagica2:vinteumOre:2' inherits='arsmBlueTopazBaseHintVeins'>
-                            <Description>
-                                Spawns 4 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x607EE5F4</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Blue Topaz Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Blue Topaz Huge Veins) Settings -->
                 
@@ -698,12 +602,9 @@ Vinteum, Chimerite, Blue Topaz
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -10,8 +10,8 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
 
     <!-- Mod detection -->
     <IfModInstalled name="BiomesOPlenty">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -900,8 +900,6 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
             <!-- Setup End -->
             <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
                 
@@ -945,7 +943,7 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 <!-- Begin  Huge Veins distribution of EnderAmathyst -->
                 <IfCondition condition=':= boplEnderAmathystDist = "hugeVeins"'>
                 
-                    <Veins name='boplEnderAmathystBaseVeins' block='BiomesOPlenty:gemOre' inherits='PresetLayeredVeins'>
+                    <Veins name='boplEnderAmathystBaseVeins' block='BiomesOPlenty:gemOre' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -964,23 +962,6 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * boplEnderAmathystFreq * _default_'/>
                         <Replaces block='minecraft:end_stone'/>
-                        
-                        <!-- Begin EnderAmathyst Huge Vein Hint Veins -->
-                        <Veins name='boplEnderAmathystBaseHintVeins' block='BiomesOPlenty:gemOre' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DD4EEA</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:end_stone'/>
-                        </Veins>
-                        <!-- End EnderAmathyst Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1056,10 +1037,9 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
             </IfCondition>
             <!-- End Setup Complete -->
 
-
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/Chisel2.xml
+++ b/src/main/resources/config/modules/Chisel2.xml
@@ -10,8 +10,8 @@ Andesite, Diorite, Granite, Limestone, Marble
 
     <!-- Mod detection -->
     <IfModInstalled name="chisel">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -356,12 +356,9 @@ Andesite, Diorite, Granite, Limestone, Marble
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -10,8 +10,8 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
 
     <!-- Mod detection -->
     <IfModInstalled name="denseores">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -382,7 +382,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin  Huge Veins distribution of Iron -->
                 <IfCondition condition=':= dnsoIronDist = "hugeVeins"'>
                 
-                    <Veins name='dnsoIronBaseVeins' block='denseores:block0' inherits='PresetLayeredVeins'>
+                    <Veins name='dnsoIronBaseVeins' block='denseores:block0' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -402,23 +402,6 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.45 * dnsoIronFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Iron Huge Vein Hint Veins -->
-                        <Veins name='dnsoIronBaseHintVeins' block='denseores:block0' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDC2AF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Iron Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Iron Huge Veins) Settings -->
@@ -431,22 +414,6 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Cold'/>
                         <BiomeType name='Ocean' weight='-1'/>
-                        
-                        <!-- Begin Iron Huge Vein Hint Veins -->
-                        <Veins name='dnsoIronPrefersHintVeins' block='denseores:block0' inherits='dnsoIronBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDC2AF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Cold'/>
-                            <BiomeType name='Ocean' weight='-1'/>
-                        </Veins>
-                        <!-- End Iron Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Iron Huge Veins) Settings -->
                 
@@ -562,7 +529,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin  Huge Veins distribution of Gold -->
                 <IfCondition condition=':= dnsoGoldDist = "hugeVeins"'>
                 
-                    <Veins name='dnsoGoldBaseVeins' block='denseores:block0:1' inherits='PresetLayeredVeins'>
+                    <Veins name='dnsoGoldBaseVeins' block='denseores:block0:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -584,23 +551,6 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Gold Huge Vein Hint Veins -->
-                        <Veins name='dnsoGoldBaseHintVeins' block='denseores:block0:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EAEF57</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Gold Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Gold Huge Veins) Settings -->
@@ -612,21 +562,6 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <WireframeColor>0x60EAEF57</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Gold Huge Vein Hint Veins -->
-                        <Veins name='dnsoGoldPrefersHintVeins' block='denseores:block0:1' inherits='dnsoGoldBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EAEF57</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Gold Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Gold Huge Veins) Settings -->
                 
@@ -1328,7 +1263,6 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
             <!-- Setup Nether -->
             <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
                 
@@ -1379,7 +1313,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin  Huge Veins distribution of Nether Quartz -->
                 <IfCondition condition=':= dnsoNetherQuartzDist = "hugeVeins"'>
                 
-                    <Veins name='dnsoNetherQuartzBaseVeins' block='denseores:block0:7' inherits='PresetLayeredVeins'>
+                    <Veins name='dnsoNetherQuartzBaseVeins' block='denseores:block0:7' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1398,23 +1332,6 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * 1 * dnsoNetherQuartzFreq * _default_'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Nether Quartz Huge Vein Hint Veins -->
-                        <Veins name='dnsoNetherQuartzBaseHintVeins' block='denseores:block0:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60CDC1B3</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Nether Quartz Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1490,11 +1407,9 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
             </IfCondition>
             <!-- Nether Setup Complete -->
 
-
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -10,8 +10,8 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
 
     <!-- Mod detection -->
     <IfModInstalled name="ElectriCraft">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -323,7 +323,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= elcrCopperDist = "hugeVeins"'>
                 
-                    <Veins name='elcrCopperBaseVeins' block='ElectriCraft:electricraft_block_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='elcrCopperBaseVeins' block='ElectriCraft:electricraft_block_ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -345,23 +345,6 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <Setting name='BranchLength' avg=':= 0.95 * _default_' range=':= 0.95 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='elcrCopperBaseHintVeins' block='ElectriCraft:electricraft_block_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BB6E30</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
@@ -373,21 +356,6 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <WireframeColor>0x60BB6E30</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Jungle'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='elcrCopperPrefersHintVeins' block='ElectriCraft:electricraft_block_ore' inherits='elcrCopperBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BB6E30</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Jungle'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Copper Huge Veins) Settings -->
                 
@@ -503,7 +471,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= elcrTinDist = "hugeVeins"'>
                 
-                    <Veins name='elcrTinBaseVeins' block='ElectriCraft:electricraft_block_ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='elcrTinBaseVeins' block='ElectriCraft:electricraft_block_ore:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -525,23 +493,6 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <Setting name='BranchLength' avg=':= 0.9 * _default_' range=':= 1 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 11'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='elcrTinBaseHintVeins' block='ElectriCraft:electricraft_block_ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60A9C7CF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
@@ -553,21 +504,6 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <WireframeColor>0x60A9C7CF</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Plains'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='elcrTinPrefersHintVeins' block='ElectriCraft:electricraft_block_ore:1' inherits='elcrTinBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60A9C7CF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Plains'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Tin Huge Veins) Settings -->
                 
@@ -683,7 +619,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin  Huge Veins distribution of Silver -->
                 <IfCondition condition=':= elcrSilverDist = "hugeVeins"'>
                 
-                    <Veins name='elcrSilverBaseVeins' block='ElectriCraft:electricraft_block_ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='elcrSilverBaseVeins' block='ElectriCraft:electricraft_block_ore:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -705,23 +641,6 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Silver Huge Vein Hint Veins -->
-                        <Veins name='elcrSilverBaseHintVeins' block='ElectriCraft:electricraft_block_ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60B6D2EA</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Silver Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Huge Veins) Settings -->
@@ -733,21 +652,6 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <WireframeColor>0x60B6D2EA</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Mountain'/>
-                        
-                        <!-- Begin Silver Huge Vein Hint Veins -->
-                        <Veins name='elcrSilverPrefersHintVeins' block='ElectriCraft:electricraft_block_ore:2' inherits='elcrSilverBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60B6D2EA</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                        </Veins>
-                        <!-- End Silver Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Silver Huge Veins) Settings -->
                 
@@ -863,7 +767,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin  Huge Veins distribution of Nickel -->
                 <IfCondition condition=':= elcrNickelDist = "hugeVeins"'>
                 
-                    <Veins name='elcrNickelBaseVeins' block='ElectriCraft:electricraft_block_ore:3' inherits='PresetLayeredVeins'>
+                    <Veins name='elcrNickelBaseVeins' block='ElectriCraft:electricraft_block_ore:3' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -885,23 +789,6 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 1 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Nickel Huge Vein Hint Veins -->
-                        <Veins name='elcrNickelBaseHintVeins' block='ElectriCraft:electricraft_block_ore:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60D2D1B6</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Nickel Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Nickel Huge Veins) Settings -->
@@ -913,21 +800,6 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <WireframeColor>0x60D2D1B6</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Swamp'/>
-                        
-                        <!-- Begin Nickel Huge Vein Hint Veins -->
-                        <Veins name='elcrNickelPrefersHintVeins' block='ElectriCraft:electricraft_block_ore:3' inherits='elcrNickelBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60D2D1B6</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Swamp'/>
-                        </Veins>
-                        <!-- End Nickel Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Nickel Huge Veins) Settings -->
                 
@@ -1043,7 +915,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin  Huge Veins distribution of Aluminum -->
                 <IfCondition condition=':= elcrAluminumDist = "hugeVeins"'>
                 
-                    <Veins name='elcrAluminumBaseVeins' block='ElectriCraft:electricraft_block_ore:4' inherits='PresetLayeredVeins'>
+                    <Veins name='elcrAluminumBaseVeins' block='ElectriCraft:electricraft_block_ore:4' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1065,23 +937,6 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.7 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Aluminum Huge Vein Hint Veins -->
-                        <Veins name='elcrAluminumBaseHintVeins' block='ElectriCraft:electricraft_block_ore:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DAD9DB</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Aluminum Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Aluminum Huge Veins) Settings -->
@@ -1093,21 +948,6 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <WireframeColor>0x60DAD9DB</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Aluminum Huge Vein Hint Veins -->
-                        <Veins name='elcrAluminumPrefersHintVeins' block='ElectriCraft:electricraft_block_ore:4' inherits='elcrAluminumBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DAD9DB</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Aluminum Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Aluminum Huge Veins) Settings -->
                 
@@ -1223,7 +1063,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin  Huge Veins distribution of Platinum -->
                 <IfCondition condition=':= elcrPlatinumDist = "hugeVeins"'>
                 
-                    <Veins name='elcrPlatinumBaseVeins' block='ElectriCraft:electricraft_block_ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='elcrPlatinumBaseVeins' block='ElectriCraft:electricraft_block_ore:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1245,23 +1085,6 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <Setting name='BranchLength' avg=':= 0.7 * _default_' range=':= 1 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Platinum Huge Vein Hint Veins -->
-                        <Veins name='elcrPlatinumBaseHintVeins' block='ElectriCraft:electricraft_block_ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x602D84E7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Platinum Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Platinum Huge Veins) Settings -->
@@ -1273,21 +1096,6 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <WireframeColor>0x602D84E7</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Platinum Huge Vein Hint Veins -->
-                        <Veins name='elcrPlatinumPrefersHintVeins' block='ElectriCraft:electricraft_block_ore:5' inherits='elcrPlatinumBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x602D84E7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Platinum Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Platinum Huge Veins) Settings -->
                 
@@ -1366,12 +1174,9 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -10,8 +10,8 @@ Apatite, Copper, Tin
 
     <!-- Mod detection -->
     <IfModInstalled name="Forestry">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -184,7 +184,7 @@ Apatite, Copper, Tin
                 <!-- Begin  Huge Veins distribution of Apatite -->
                 <IfCondition condition=':= frstApatiteDist = "hugeVeins"'>
                 
-                    <Veins name='frstApatiteBaseVeins' block='Forestry:resources' inherits='PresetLayeredVeins'>
+                    <Veins name='frstApatiteBaseVeins' block='Forestry:resources' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -206,24 +206,6 @@ Apatite, Copper, Tin
                         <Setting name='BranchInclination' avg=':= -_default_' range=':= 0'/>
                         <Replaces block='minecraft:stone'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Apatite Huge Vein Hint Veins -->
-                        <Veins name='frstApatiteBaseHintVeins' block='Forestry:resources' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6052BBEF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Apatite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -512,12 +494,9 @@ Apatite, Copper, Tin
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -10,8 +10,8 @@ Fossils, Permafrost
 
     <!-- Mod detection -->
     <IfModInstalled name="fossil">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -389,12 +389,9 @@ Fossils, Permafrost
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -15,8 +15,8 @@ Sanguinite, Eximite, Meutoite
 
     <!-- Mod detection -->
     <IfModInstalled name="Metallurgy">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -2321,7 +2321,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= mtlgCopperDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgCopperBaseVeins' block='Metallurgy:base.ore' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgCopperBaseVeins' block='Metallurgy:base.ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2341,23 +2341,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * mtlgCopperFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='mtlgCopperBaseHintVeins' block='Metallurgy:base.ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EA6515</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
@@ -2370,22 +2353,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Cold'/>
                         <BiomeType name='Ocean' weight='-1'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='mtlgCopperPrefersHintVeins' block='Metallurgy:base.ore' inherits='mtlgCopperBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EA6515</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Cold'/>
-                            <BiomeType name='Ocean' weight='-1'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Copper Huge Veins) Settings -->
                 
@@ -2500,7 +2467,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= mtlgTinDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgTinBaseVeins' block='Metallurgy:base.ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgTinBaseVeins' block='Metallurgy:base.ore:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2520,23 +2487,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * mtlgTinFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='mtlgTinBaseHintVeins' block='Metallurgy:base.ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BDBDBD</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
@@ -2549,22 +2499,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Cold'/>
                         <BiomeType name='Ocean' weight='-1'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='mtlgTinPrefersHintVeins' block='Metallurgy:base.ore:1' inherits='mtlgTinBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BDBDBD</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Cold'/>
-                            <BiomeType name='Ocean' weight='-1'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Tin Huge Veins) Settings -->
                 
@@ -2679,7 +2613,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Manganese -->
                 <IfCondition condition=':= mtlgManganeseDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgManganeseBaseVeins' block='Metallurgy:base.ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgManganeseBaseVeins' block='Metallurgy:base.ore:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2699,23 +2633,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * mtlgManganeseFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Manganese Huge Vein Hint Veins -->
-                        <Veins name='mtlgManganeseBaseHintVeins' block='Metallurgy:base.ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FCC7C7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Manganese Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Manganese Huge Veins) Settings -->
@@ -2728,22 +2645,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Cold'/>
                         <BiomeType name='Ocean' weight='-1'/>
-                        
-                        <!-- Begin Manganese Huge Vein Hint Veins -->
-                        <Veins name='mtlgManganesePrefersHintVeins' block='Metallurgy:base.ore:2' inherits='mtlgManganeseBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FCC7C7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Cold'/>
-                            <BiomeType name='Ocean' weight='-1'/>
-                        </Veins>
-                        <!-- End Manganese Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Manganese Huge Veins) Settings -->
                 
@@ -2859,7 +2760,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Zinc -->
                 <IfCondition condition=':= mtlgZincDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgZincBaseVeins' block='Metallurgy:precious.ore' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgZincBaseVeins' block='Metallurgy:precious.ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2881,23 +2782,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Zinc Huge Vein Hint Veins -->
-                        <Veins name='mtlgZincBaseHintVeins' block='Metallurgy:precious.ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BFC55C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Zinc Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Zinc Huge Veins) Settings -->
@@ -2909,21 +2793,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x60BFC55C</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Zinc Huge Vein Hint Veins -->
-                        <Veins name='mtlgZincPrefersHintVeins' block='Metallurgy:precious.ore' inherits='mtlgZincBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BFC55C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Zinc Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Zinc Huge Veins) Settings -->
                 
@@ -3039,7 +2908,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Silver -->
                 <IfCondition condition=':= mtlgSilverDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgSilverBaseVeins' block='Metallurgy:precious.ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgSilverBaseVeins' block='Metallurgy:precious.ore:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3061,23 +2930,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Silver Huge Vein Hint Veins -->
-                        <Veins name='mtlgSilverBaseHintVeins' block='Metallurgy:precious.ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E1E1E1</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Silver Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Huge Veins) Settings -->
@@ -3089,21 +2941,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x60E1E1E1</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Mountain'/>
-                        
-                        <!-- Begin Silver Huge Vein Hint Veins -->
-                        <Veins name='mtlgSilverPrefersHintVeins' block='Metallurgy:precious.ore:1' inherits='mtlgSilverBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E1E1E1</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                        </Veins>
-                        <!-- End Silver Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Silver Huge Veins) Settings -->
                 
@@ -3219,7 +3056,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Platinum -->
                 <IfCondition condition=':= mtlgPlatinumDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgPlatinumBaseVeins' block='Metallurgy:precious.ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgPlatinumBaseVeins' block='Metallurgy:precious.ore:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3241,23 +3078,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Platinum Huge Vein Hint Veins -->
-                        <Veins name='mtlgPlatinumBaseHintVeins' block='Metallurgy:precious.ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60B8D6DB</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Platinum Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Platinum Huge Veins) Settings -->
@@ -3269,21 +3089,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x60B8D6DB</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Platinum Huge Vein Hint Veins -->
-                        <Veins name='mtlgPlatinumPrefersHintVeins' block='Metallurgy:precious.ore:2' inherits='mtlgPlatinumBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60B8D6DB</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Platinum Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Platinum Huge Veins) Settings -->
                 
@@ -3399,7 +3204,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Promethium -->
                 <IfCondition condition=':= mtlgPromethiumDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgPromethiumBaseVeins' block='Metallurgy:fantasy.ore' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgPromethiumBaseVeins' block='Metallurgy:fantasy.ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3421,23 +3226,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Promethium Huge Vein Hint Veins -->
-                        <Veins name='mtlgPromethiumBaseHintVeins' block='Metallurgy:fantasy.ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x605D8258</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Promethium Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Promethium Huge Veins) Settings -->
@@ -3449,21 +3237,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x605D8258</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Promethium Huge Vein Hint Veins -->
-                        <Veins name='mtlgPromethiumPrefersHintVeins' block='Metallurgy:fantasy.ore' inherits='mtlgPromethiumBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x605D8258</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Promethium Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Promethium Huge Veins) Settings -->
                 
@@ -3579,7 +3352,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Deep Iron -->
                 <IfCondition condition=':= mtlgDeepIronDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgDeepIronBaseVeins' block='Metallurgy:fantasy.ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgDeepIronBaseVeins' block='Metallurgy:fantasy.ore:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3601,23 +3374,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Deep Iron Huge Vein Hint Veins -->
-                        <Veins name='mtlgDeepIronBaseHintVeins' block='Metallurgy:fantasy.ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x604C5E6C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Deep Iron Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Deep Iron Huge Veins) Settings -->
@@ -3629,21 +3385,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x604C5E6C</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Deep Iron Huge Vein Hint Veins -->
-                        <Veins name='mtlgDeepIronPrefersHintVeins' block='Metallurgy:fantasy.ore:1' inherits='mtlgDeepIronBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x604C5E6C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Deep Iron Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Deep Iron Huge Veins) Settings -->
                 
@@ -3759,7 +3500,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Infuscolium -->
                 <IfCondition condition=':= mtlgInfuscoliumDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgInfuscoliumBaseVeins' block='Metallurgy:fantasy.ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgInfuscoliumBaseVeins' block='Metallurgy:fantasy.ore:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3781,23 +3522,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Infuscolium Huge Vein Hint Veins -->
-                        <Veins name='mtlgInfuscoliumBaseHintVeins' block='Metallurgy:fantasy.ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x608B2656</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Infuscolium Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Infuscolium Huge Veins) Settings -->
@@ -3809,21 +3533,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x608B2656</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Infuscolium Huge Vein Hint Veins -->
-                        <Veins name='mtlgInfuscoliumPrefersHintVeins' block='Metallurgy:fantasy.ore:2' inherits='mtlgInfuscoliumBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x608B2656</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Infuscolium Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Infuscolium Huge Veins) Settings -->
                 
@@ -3939,7 +3648,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Oureclase -->
                 <IfCondition condition=':= mtlgOureclaseDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgOureclaseBaseVeins' block='Metallurgy:fantasy.ore:4' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgOureclaseBaseVeins' block='Metallurgy:fantasy.ore:4' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3961,23 +3670,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Oureclase Huge Vein Hint Veins -->
-                        <Veins name='mtlgOureclaseBaseHintVeins' block='Metallurgy:fantasy.ore:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609A7607</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Oureclase Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Oureclase Huge Veins) Settings -->
@@ -3989,21 +3681,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x609A7607</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Oureclase Huge Vein Hint Veins -->
-                        <Veins name='mtlgOureclasePrefersHintVeins' block='Metallurgy:fantasy.ore:4' inherits='mtlgOureclaseBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609A7607</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Oureclase Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Oureclase Huge Veins) Settings -->
                 
@@ -4119,7 +3796,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Astral Silver -->
                 <IfCondition condition=':= mtlgAstralSilverDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgAstralSilverBaseVeins' block='Metallurgy:fantasy.ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgAstralSilverBaseVeins' block='Metallurgy:fantasy.ore:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4141,23 +3818,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Astral Silver Huge Vein Hint Veins -->
-                        <Veins name='mtlgAstralSilverBaseHintVeins' block='Metallurgy:fantasy.ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60ADC3C3</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Astral Silver Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Astral Silver Huge Veins) Settings -->
@@ -4169,21 +3829,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x60ADC3C3</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Astral Silver Huge Vein Hint Veins -->
-                        <Veins name='mtlgAstralSilverPrefersHintVeins' block='Metallurgy:fantasy.ore:5' inherits='mtlgAstralSilverBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60ADC3C3</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Astral Silver Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Astral Silver Huge Veins) Settings -->
                 
@@ -4299,7 +3944,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Carmot -->
                 <IfCondition condition=':= mtlgCarmotDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgCarmotBaseVeins' block='Metallurgy:fantasy.ore:6' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgCarmotBaseVeins' block='Metallurgy:fantasy.ore:6' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4321,23 +3966,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Carmot Huge Vein Hint Veins -->
-                        <Veins name='mtlgCarmotBaseHintVeins' block='Metallurgy:fantasy.ore:6' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60D7C986</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Carmot Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Carmot Huge Veins) Settings -->
@@ -4349,21 +3977,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x60D7C986</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Carmot Huge Vein Hint Veins -->
-                        <Veins name='mtlgCarmotPrefersHintVeins' block='Metallurgy:fantasy.ore:6' inherits='mtlgCarmotBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60D7C986</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Carmot Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Carmot Huge Veins) Settings -->
                 
@@ -4479,7 +4092,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Mithril -->
                 <IfCondition condition=':= mtlgMithrilDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgMithrilBaseVeins' block='Metallurgy:fantasy.ore:7' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgMithrilBaseVeins' block='Metallurgy:fantasy.ore:7' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4501,23 +4114,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Mithril Huge Vein Hint Veins -->
-                        <Veins name='mtlgMithrilBaseHintVeins' block='Metallurgy:fantasy.ore:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609AF3F7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Mithril Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Mithril Huge Veins) Settings -->
@@ -4529,21 +4125,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x609AF3F7</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Mithril Huge Vein Hint Veins -->
-                        <Veins name='mtlgMithrilPrefersHintVeins' block='Metallurgy:fantasy.ore:7' inherits='mtlgMithrilBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609AF3F7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Mithril Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Mithril Huge Veins) Settings -->
                 
@@ -4659,7 +4240,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Rubracium -->
                 <IfCondition condition=':= mtlgRubraciumDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgRubraciumBaseVeins' block='Metallurgy:fantasy.ore:8' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgRubraciumBaseVeins' block='Metallurgy:fantasy.ore:8' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4681,23 +4262,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Rubracium Huge Vein Hint Veins -->
-                        <Veins name='mtlgRubraciumBaseHintVeins' block='Metallurgy:fantasy.ore:8' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60A1363C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Rubracium Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Rubracium Huge Veins) Settings -->
@@ -4709,21 +4273,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x60A1363C</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Rubracium Huge Vein Hint Veins -->
-                        <Veins name='mtlgRubraciumPrefersHintVeins' block='Metallurgy:fantasy.ore:8' inherits='mtlgRubraciumBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60A1363C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Rubracium Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Rubracium Huge Veins) Settings -->
                 
@@ -4839,7 +4388,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Orichalcum -->
                 <IfCondition condition=':= mtlgOrichalcumDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgOrichalcumBaseVeins' block='Metallurgy:fantasy.ore:11' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgOrichalcumBaseVeins' block='Metallurgy:fantasy.ore:11' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4861,23 +4410,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Orichalcum Huge Vein Hint Veins -->
-                        <Veins name='mtlgOrichalcumBaseHintVeins' block='Metallurgy:fantasy.ore:11' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60466432</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Orichalcum Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Orichalcum Huge Veins) Settings -->
@@ -4889,21 +4421,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x60466432</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Orichalcum Huge Vein Hint Veins -->
-                        <Veins name='mtlgOrichalcumPrefersHintVeins' block='Metallurgy:fantasy.ore:11' inherits='mtlgOrichalcumBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60466432</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Orichalcum Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Orichalcum Huge Veins) Settings -->
                 
@@ -5019,7 +4536,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Adamantine -->
                 <IfCondition condition=':= mtlgAdamantineDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgAdamantineBaseVeins' block='Metallurgy:fantasy.ore:13' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgAdamantineBaseVeins' block='Metallurgy:fantasy.ore:13' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -5041,23 +4558,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Adamantine Huge Vein Hint Veins -->
-                        <Veins name='mtlgAdamantineBaseHintVeins' block='Metallurgy:fantasy.ore:13' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60AC0C0D</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Adamantine Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Adamantine Huge Veins) Settings -->
@@ -5069,21 +4569,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x60AC0C0D</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Adamantine Huge Vein Hint Veins -->
-                        <Veins name='mtlgAdamantinePrefersHintVeins' block='Metallurgy:fantasy.ore:13' inherits='mtlgAdamantineBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60AC0C0D</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Adamantine Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Adamantine Huge Veins) Settings -->
                 
@@ -5199,7 +4684,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Atlarus -->
                 <IfCondition condition=':= mtlgAtlarusDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgAtlarusBaseVeins' block='Metallurgy:fantasy.ore:14' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgAtlarusBaseVeins' block='Metallurgy:fantasy.ore:14' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -5221,23 +4706,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Atlarus Huge Vein Hint Veins -->
-                        <Veins name='mtlgAtlarusBaseHintVeins' block='Metallurgy:fantasy.ore:14' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60C4B117</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Atlarus Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Atlarus Huge Veins) Settings -->
@@ -5249,21 +4717,6 @@ Sanguinite, Eximite, Meutoite
                         <WireframeColor>0x60C4B117</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Atlarus Huge Vein Hint Veins -->
-                        <Veins name='mtlgAtlarusPrefersHintVeins' block='Metallurgy:fantasy.ore:14' inherits='mtlgAtlarusBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60C4B117</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Atlarus Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Atlarus Huge Veins) Settings -->
                 
@@ -5342,7 +4795,6 @@ Sanguinite, Eximite, Meutoite
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
             <!-- Setup Nether -->
             <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
                 
@@ -5395,7 +4847,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Ignatius -->
                 <IfCondition condition=':= mtlgIgnatiusDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgIgnatiusBaseVeins' block='Metallurgy:nether.ore' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgIgnatiusBaseVeins' block='Metallurgy:nether.ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -5414,23 +4866,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgIgnatiusFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ignatius Huge Vein Hint Veins -->
-                        <Veins name='mtlgIgnatiusBaseHintVeins' block='Metallurgy:nether.ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EE810A</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ignatius Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -5528,7 +4963,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Shadow Iron -->
                 <IfCondition condition=':= mtlgShadowIronDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgShadowIronBaseVeins' block='Metallurgy:nether.ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgShadowIronBaseVeins' block='Metallurgy:nether.ore:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -5547,23 +4982,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgShadowIronFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Shadow Iron Huge Vein Hint Veins -->
-                        <Veins name='mtlgShadowIronBaseHintVeins' block='Metallurgy:nether.ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60634C3F</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Shadow Iron Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -5661,7 +5079,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Lemurite -->
                 <IfCondition condition=':= mtlgLemuriteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgLemuriteBaseVeins' block='Metallurgy:nether.ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgLemuriteBaseVeins' block='Metallurgy:nether.ore:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -5680,23 +5098,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgLemuriteFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Lemurite Huge Vein Hint Veins -->
-                        <Veins name='mtlgLemuriteBaseHintVeins' block='Metallurgy:nether.ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60B1B1B4</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Lemurite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -5794,7 +5195,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Midasium -->
                 <IfCondition condition=':= mtlgMidasiumDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgMidasiumBaseVeins' block='Metallurgy:nether.ore:3' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgMidasiumBaseVeins' block='Metallurgy:nether.ore:3' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -5813,23 +5214,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgMidasiumFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Midasium Huge Vein Hint Veins -->
-                        <Veins name='mtlgMidasiumBaseHintVeins' block='Metallurgy:nether.ore:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60F6B237</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Midasium Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -5927,7 +5311,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Vyroxeres -->
                 <IfCondition condition=':= mtlgVyroxeresDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgVyroxeresBaseVeins' block='Metallurgy:nether.ore:4' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgVyroxeresBaseVeins' block='Metallurgy:nether.ore:4' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -5946,23 +5330,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgVyroxeresFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Vyroxeres Huge Vein Hint Veins -->
-                        <Veins name='mtlgVyroxeresBaseHintVeins' block='Metallurgy:nether.ore:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6057D411</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Vyroxeres Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -6060,7 +5427,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Ceruclase -->
                 <IfCondition condition=':= mtlgCeruclaseDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgCeruclaseBaseVeins' block='Metallurgy:nether.ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgCeruclaseBaseVeins' block='Metallurgy:nether.ore:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -6079,23 +5446,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgCeruclaseFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ceruclase Huge Vein Hint Veins -->
-                        <Veins name='mtlgCeruclaseBaseHintVeins' block='Metallurgy:nether.ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x603F869C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ceruclase Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -6193,7 +5543,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Alduorite -->
                 <IfCondition condition=':= mtlgAlduoriteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgAlduoriteBaseVeins' block='Metallurgy:nether.ore:6' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgAlduoriteBaseVeins' block='Metallurgy:nether.ore:6' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -6212,23 +5562,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgAlduoriteFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Alduorite Huge Vein Hint Veins -->
-                        <Veins name='mtlgAlduoriteBaseHintVeins' block='Metallurgy:nether.ore:6' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609FCED2</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Alduorite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -6326,7 +5659,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Kalendrite -->
                 <IfCondition condition=':= mtlgKalendriteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgKalendriteBaseVeins' block='Metallurgy:nether.ore:7' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgKalendriteBaseVeins' block='Metallurgy:nether.ore:7' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -6345,23 +5678,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgKalendriteFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Kalendrite Huge Vein Hint Veins -->
-                        <Veins name='mtlgKalendriteBaseHintVeins' block='Metallurgy:nether.ore:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60AB6AB9</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Kalendrite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -6459,7 +5775,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Vulcanite -->
                 <IfCondition condition=':= mtlgVulcaniteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgVulcaniteBaseVeins' block='Metallurgy:nether.ore:8' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgVulcaniteBaseVeins' block='Metallurgy:nether.ore:8' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -6478,23 +5794,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgVulcaniteFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Vulcanite Huge Vein Hint Veins -->
-                        <Veins name='mtlgVulcaniteBaseHintVeins' block='Metallurgy:nether.ore:8' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E66922</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Vulcanite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -6592,7 +5891,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Sanguinite -->
                 <IfCondition condition=':= mtlgSanguiniteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgSanguiniteBaseVeins' block='Metallurgy:nether.ore:9' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgSanguiniteBaseVeins' block='Metallurgy:nether.ore:9' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -6611,23 +5910,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgSanguiniteFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Sanguinite Huge Vein Hint Veins -->
-                        <Veins name='mtlgSanguiniteBaseHintVeins' block='Metallurgy:nether.ore:9' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60C30506</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Sanguinite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -6703,7 +5985,6 @@ Sanguinite, Eximite, Meutoite
             </IfCondition>
             <!-- Nether Setup Complete -->
 
-
             <!-- Setup End -->
             <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
                 
@@ -6748,7 +6029,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Eximite -->
                 <IfCondition condition=':= mtlgEximiteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgEximiteBaseVeins' block='Metallurgy:ender.ore' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgEximiteBaseVeins' block='Metallurgy:ender.ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -6767,23 +6048,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgEximiteFreq * _default_'/>
                         <Replaces block='minecraft:end_stone'/>
-                        
-                        <!-- Begin Eximite Huge Vein Hint Veins -->
-                        <Veins name='mtlgEximiteBaseHintVeins' block='Metallurgy:ender.ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x607B5994</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:end_stone'/>
-                        </Veins>
-                        <!-- End Eximite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -6881,7 +6145,7 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Meutoite -->
                 <IfCondition condition=':= mtlgMeutoiteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgMeutoiteBaseVeins' block='Metallurgy:ender.ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgMeutoiteBaseVeins' block='Metallurgy:ender.ore:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -6900,23 +6164,6 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgMeutoiteFreq * _default_'/>
                         <Replaces block='minecraft:end_stone'/>
-                        
-                        <!-- Begin Meutoite Huge Vein Hint Veins -->
-                        <Veins name='mtlgMeutoiteBaseHintVeins' block='Metallurgy:ender.ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x605E5168</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:end_stone'/>
-                        </Veins>
-                        <!-- End Meutoite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -6992,10 +6239,9 @@ Sanguinite, Eximite, Meutoite
             </IfCondition>
             <!-- End Setup Complete -->
 
-
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -10,8 +10,8 @@ Uranium
 
     <!-- Mod detection -->
     <IfModInstalled name="minechem">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -132,7 +132,7 @@ Uranium
                 <!-- Begin  Huge Veins distribution of Uranium -->
                 <IfCondition condition=':= mchmUraniumDist = "hugeVeins"'>
                 
-                    <Veins name='mchmUraniumBaseVeins' block='minechem:tile.oreUranium' inherits='PresetLayeredVeins'>
+                    <Veins name='mchmUraniumBaseVeins' block='minechem:tile.oreUranium' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -151,23 +151,6 @@ Uranium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * mchmUraniumFreq * _default_'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Uranium Huge Vein Hint Veins -->
-                        <Veins name='mchmUraniumBaseHintVeins' block='minechem:tile.oreUranium' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60ACFE91</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Uranium Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -243,12 +226,9 @@ Uranium
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -10,8 +10,8 @@ Rose Gold
 
     <!-- Mod detection -->
     <IfModInstalled name="MCA">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -224,12 +224,9 @@ Rose Gold
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/NetherOres.xml
+++ b/src/main/resources/config/modules/NetherOres.xml
@@ -14,8 +14,8 @@ Saltpeter, Magnesium
 
     <!-- Mod detection -->
     <IfModInstalled name="NetherOres">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -1278,19 +1278,6 @@ Saltpeter, Magnesium
             <!-- Setup Screen Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-
             <!-- Setup Nether -->
             <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
                 
@@ -1365,7 +1352,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Coal -->
                 <IfCondition condition=':= nthoCoalDist = "hugeVeins"'>
                 
-                    <Veins name='nthoCoalBaseVeins' block='NetherOres:tile.netherores.ore.0' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoCoalBaseVeins' block='NetherOres:tile.netherores.ore.0' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1384,23 +1371,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoCoalFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Coal Huge Vein Hint Veins -->
-                        <Veins name='nthoCoalBaseHintVeins' block='NetherOres:tile.netherores.ore.0' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x602D2D2D</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Coal Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1498,7 +1468,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Diamond -->
                 <IfCondition condition=':= nthoDiamondDist = "hugeVeins"'>
                 
-                    <Veins name='nthoDiamondBaseVeins' block='NetherOres:tile.netherores.ore.0:1' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoDiamondBaseVeins' block='NetherOres:tile.netherores.ore.0:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1517,23 +1487,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoDiamondFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Diamond Huge Vein Hint Veins -->
-                        <Veins name='nthoDiamondBaseHintVeins' block='NetherOres:tile.netherores.ore.0:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x608BF4E3</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Diamond Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1631,7 +1584,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Gold -->
                 <IfCondition condition=':= nthoGoldDist = "hugeVeins"'>
                 
-                    <Veins name='nthoGoldBaseVeins' block='NetherOres:tile.netherores.ore.0:2' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoGoldBaseVeins' block='NetherOres:tile.netherores.ore.0:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1650,23 +1603,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoGoldFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Gold Huge Vein Hint Veins -->
-                        <Veins name='nthoGoldBaseHintVeins' block='NetherOres:tile.netherores.ore.0:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EAEF57</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Gold Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1764,7 +1700,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Iron -->
                 <IfCondition condition=':= nthoIronDist = "hugeVeins"'>
                 
-                    <Veins name='nthoIronBaseVeins' block='NetherOres:tile.netherores.ore.0:3' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoIronBaseVeins' block='NetherOres:tile.netherores.ore.0:3' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1783,23 +1719,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoIronFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Iron Huge Vein Hint Veins -->
-                        <Veins name='nthoIronBaseHintVeins' block='NetherOres:tile.netherores.ore.0:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDC2AF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Iron Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1897,7 +1816,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Lapis Lazuli -->
                 <IfCondition condition=':= nthoLapisLazuliDist = "hugeVeins"'>
                 
-                    <Veins name='nthoLapisLazuliBaseVeins' block='NetherOres:tile.netherores.ore.0:4' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoLapisLazuliBaseVeins' block='NetherOres:tile.netherores.ore.0:4' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1916,23 +1835,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoLapisLazuliFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Lapis Lazuli Huge Vein Hint Veins -->
-                        <Veins name='nthoLapisLazuliBaseHintVeins' block='NetherOres:tile.netherores.ore.0:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x601442BA</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Lapis Lazuli Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2030,7 +1932,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Redstone -->
                 <IfCondition condition=':= nthoRedstoneDist = "hugeVeins"'>
                 
-                    <Veins name='nthoRedstoneBaseVeins' block='NetherOres:tile.netherores.ore.0:5' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoRedstoneBaseVeins' block='NetherOres:tile.netherores.ore.0:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2049,23 +1951,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoRedstoneFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Redstone Huge Vein Hint Veins -->
-                        <Veins name='nthoRedstoneBaseHintVeins' block='NetherOres:tile.netherores.ore.0:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60A80002</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Redstone Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2163,7 +2048,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= nthoCopperDist = "hugeVeins"'>
                 
-                    <Veins name='nthoCopperBaseVeins' block='NetherOres:tile.netherores.ore.0:6' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoCopperBaseVeins' block='NetherOres:tile.netherores.ore.0:6' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2182,23 +2067,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoCopperFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='nthoCopperBaseHintVeins' block='NetherOres:tile.netherores.ore.0:6' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2296,7 +2164,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= nthoTinDist = "hugeVeins"'>
                 
-                    <Veins name='nthoTinBaseVeins' block='NetherOres:tile.netherores.ore.0:7' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoTinBaseVeins' block='NetherOres:tile.netherores.ore.0:7' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2315,23 +2183,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTinFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='nthoTinBaseHintVeins' block='NetherOres:tile.netherores.ore.0:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2429,7 +2280,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Emerald -->
                 <IfCondition condition=':= nthoEmeraldDist = "hugeVeins"'>
                 
-                    <Veins name='nthoEmeraldBaseVeins' block='NetherOres:tile.netherores.ore.0:8' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoEmeraldBaseVeins' block='NetherOres:tile.netherores.ore.0:8' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2448,23 +2299,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoEmeraldFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Emerald Huge Vein Hint Veins -->
-                        <Veins name='nthoEmeraldBaseHintVeins' block='NetherOres:tile.netherores.ore.0:8' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x606CE391</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Emerald Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2562,7 +2396,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Silver -->
                 <IfCondition condition=':= nthoSilverDist = "hugeVeins"'>
                 
-                    <Veins name='nthoSilverBaseVeins' block='NetherOres:tile.netherores.ore.0:9' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoSilverBaseVeins' block='NetherOres:tile.netherores.ore.0:9' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2581,23 +2415,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSilverFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Silver Huge Vein Hint Veins -->
-                        <Veins name='nthoSilverBaseHintVeins' block='NetherOres:tile.netherores.ore.0:9' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E3F2F7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Silver Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2695,7 +2512,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Lead -->
                 <IfCondition condition=':= nthoLeadDist = "hugeVeins"'>
                 
-                    <Veins name='nthoLeadBaseVeins' block='NetherOres:tile.netherores.ore.0:10' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoLeadBaseVeins' block='NetherOres:tile.netherores.ore.0:10' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2714,23 +2531,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoLeadFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Lead Huge Vein Hint Veins -->
-                        <Veins name='nthoLeadBaseHintVeins' block='NetherOres:tile.netherores.ore.0:10' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60818EBE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Lead Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2828,7 +2628,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Uranium -->
                 <IfCondition condition=':= nthoUraniumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoUraniumBaseVeins' block='NetherOres:tile.netherores.ore.0:11' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoUraniumBaseVeins' block='NetherOres:tile.netherores.ore.0:11' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2847,23 +2647,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoUraniumFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Uranium Huge Vein Hint Veins -->
-                        <Veins name='nthoUraniumBaseHintVeins' block='NetherOres:tile.netherores.ore.0:11' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60ACFE91</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Uranium Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2961,7 +2744,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Nikolite -->
                 <IfCondition condition=':= nthoNikoliteDist = "hugeVeins"'>
                 
-                    <Veins name='nthoNikoliteBaseVeins' block='NetherOres:tile.netherores.ore.0:12' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoNikoliteBaseVeins' block='NetherOres:tile.netherores.ore.0:12' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2980,23 +2763,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoNikoliteFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Nikolite Huge Vein Hint Veins -->
-                        <Veins name='nthoNikoliteBaseHintVeins' block='NetherOres:tile.netherores.ore.0:12' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6001FFFC</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Nikolite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -3094,7 +2860,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Ruby -->
                 <IfCondition condition=':= nthoRubyDist = "hugeVeins"'>
                 
-                    <Veins name='nthoRubyBaseVeins' block='NetherOres:tile.netherores.ore.0:13' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoRubyBaseVeins' block='NetherOres:tile.netherores.ore.0:13' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3113,23 +2879,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoRubyFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ruby Huge Vein Hint Veins -->
-                        <Veins name='nthoRubyBaseHintVeins' block='NetherOres:tile.netherores.ore.0:13' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60D10415</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ruby Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -3227,7 +2976,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Peridot -->
                 <IfCondition condition=':= nthoPeridotDist = "hugeVeins"'>
                 
-                    <Veins name='nthoPeridotBaseVeins' block='NetherOres:tile.netherores.ore.0:14' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoPeridotBaseVeins' block='NetherOres:tile.netherores.ore.0:14' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3246,23 +2995,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoPeridotFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Peridot Huge Vein Hint Veins -->
-                        <Veins name='nthoPeridotBaseHintVeins' block='NetherOres:tile.netherores.ore.0:14' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6054A228</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Peridot Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -3360,7 +3092,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Sapphire -->
                 <IfCondition condition=':= nthoSapphireDist = "hugeVeins"'>
                 
-                    <Veins name='nthoSapphireBaseVeins' block='NetherOres:tile.netherores.ore.0:15' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoSapphireBaseVeins' block='NetherOres:tile.netherores.ore.0:15' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3379,23 +3111,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSapphireFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Sapphire Huge Vein Hint Veins -->
-                        <Veins name='nthoSapphireBaseHintVeins' block='NetherOres:tile.netherores.ore.0:15' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60554DB4</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Sapphire Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -3493,7 +3208,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Platinum -->
                 <IfCondition condition=':= nthoPlatinumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoPlatinumBaseVeins' block='NetherOres:tile.netherores.ore.1' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoPlatinumBaseVeins' block='NetherOres:tile.netherores.ore.1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3512,23 +3227,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoPlatinumFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Platinum Huge Vein Hint Veins -->
-                        <Veins name='nthoPlatinumBaseHintVeins' block='NetherOres:tile.netherores.ore.1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6072A0D2</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Platinum Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -3626,7 +3324,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Ferrous -->
                 <IfCondition condition=':= nthoFerrousDist = "hugeVeins"'>
                 
-                    <Veins name='nthoFerrousBaseVeins' block='NetherOres:tile.netherores.ore.1:1' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoFerrousBaseVeins' block='NetherOres:tile.netherores.ore.1:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3645,23 +3343,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoFerrousFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ferrous Huge Vein Hint Veins -->
-                        <Veins name='nthoFerrousBaseHintVeins' block='NetherOres:tile.netherores.ore.1:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDD396</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ferrous Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -3759,7 +3440,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Pig Iron -->
                 <IfCondition condition=':= nthoPigIronDist = "hugeVeins"'>
                 
-                    <Veins name='nthoPigIronBaseVeins' block='NetherOres:tile.netherores.ore.1:2' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoPigIronBaseVeins' block='NetherOres:tile.netherores.ore.1:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3778,23 +3459,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoPigIronFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Pig Iron Huge Vein Hint Veins -->
-                        <Veins name='nthoPigIronBaseHintVeins' block='NetherOres:tile.netherores.ore.1:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E89D97</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Pig Iron Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -3892,7 +3556,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Iridium -->
                 <IfCondition condition=':= nthoIridiumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoIridiumBaseVeins' block='NetherOres:tile.netherores.ore.1:3' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoIridiumBaseVeins' block='NetherOres:tile.netherores.ore.1:3' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -3911,23 +3575,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoIridiumFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Iridium Huge Vein Hint Veins -->
-                        <Veins name='nthoIridiumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60CECECE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Iridium Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -4025,7 +3672,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Osmium -->
                 <IfCondition condition=':= nthoOsmiumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoOsmiumBaseVeins' block='NetherOres:tile.netherores.ore.1:4' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoOsmiumBaseVeins' block='NetherOres:tile.netherores.ore.1:4' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4044,23 +3691,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoOsmiumFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Osmium Huge Vein Hint Veins -->
-                        <Veins name='nthoOsmiumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6043638A</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Osmium Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -4158,7 +3788,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Sulphur -->
                 <IfCondition condition=':= nthoSulphurDist = "hugeVeins"'>
                 
-                    <Veins name='nthoSulphurBaseVeins' block='NetherOres:tile.netherores.ore.1:5' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoSulphurBaseVeins' block='NetherOres:tile.netherores.ore.1:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4177,23 +3807,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSulphurFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Sulphur Huge Vein Hint Veins -->
-                        <Veins name='nthoSulphurBaseHintVeins' block='NetherOres:tile.netherores.ore.1:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FDFD11</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Sulphur Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -4291,7 +3904,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Titanium -->
                 <IfCondition condition=':= nthoTitaniumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoTitaniumBaseVeins' block='NetherOres:tile.netherores.ore.1:6' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoTitaniumBaseVeins' block='NetherOres:tile.netherores.ore.1:6' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4310,23 +3923,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTitaniumFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Titanium Huge Vein Hint Veins -->
-                        <Veins name='nthoTitaniumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:6' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60686868</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Titanium Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -4424,7 +4020,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Mithril -->
                 <IfCondition condition=':= nthoMithrilDist = "hugeVeins"'>
                 
-                    <Veins name='nthoMithrilBaseVeins' block='NetherOres:tile.netherores.ore.1:7' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoMithrilBaseVeins' block='NetherOres:tile.netherores.ore.1:7' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4443,23 +4039,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoMithrilFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Mithril Huge Vein Hint Veins -->
-                        <Veins name='nthoMithrilBaseHintVeins' block='NetherOres:tile.netherores.ore.1:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6075E0F6</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Mithril Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -4557,7 +4136,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Adamantium -->
                 <IfCondition condition=':= nthoAdamantiumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoAdamantiumBaseVeins' block='NetherOres:tile.netherores.ore.1:8' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoAdamantiumBaseVeins' block='NetherOres:tile.netherores.ore.1:8' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4576,23 +4155,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoAdamantiumFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Adamantium Huge Vein Hint Veins -->
-                        <Veins name='nthoAdamantiumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:8' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609CA6B0</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Adamantium Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -4690,7 +4252,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Rutile -->
                 <IfCondition condition=':= nthoRutileDist = "hugeVeins"'>
                 
-                    <Veins name='nthoRutileBaseVeins' block='NetherOres:tile.netherores.ore.1:9' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoRutileBaseVeins' block='NetherOres:tile.netherores.ore.1:9' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4709,23 +4271,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoRutileFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Rutile Huge Vein Hint Veins -->
-                        <Veins name='nthoRutileBaseHintVeins' block='NetherOres:tile.netherores.ore.1:9' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60D2C7A9</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Rutile Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -4823,7 +4368,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Tungsten -->
                 <IfCondition condition=':= nthoTungstenDist = "hugeVeins"'>
                 
-                    <Veins name='nthoTungstenBaseVeins' block='NetherOres:tile.netherores.ore.1:10' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoTungstenBaseVeins' block='NetherOres:tile.netherores.ore.1:10' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4842,23 +4387,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTungstenFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Tungsten Huge Vein Hint Veins -->
-                        <Veins name='nthoTungstenBaseHintVeins' block='NetherOres:tile.netherores.ore.1:10' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60212121</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Tungsten Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -4956,7 +4484,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Amber -->
                 <IfCondition condition=':= nthoAmberDist = "hugeVeins"'>
                 
-                    <Veins name='nthoAmberBaseVeins' block='NetherOres:tile.netherores.ore.1:11' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoAmberBaseVeins' block='NetherOres:tile.netherores.ore.1:11' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -4975,23 +4503,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoAmberFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Amber Huge Vein Hint Veins -->
-                        <Veins name='nthoAmberBaseHintVeins' block='NetherOres:tile.netherores.ore.1:11' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FEA219</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Amber Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -5089,7 +4600,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Tennantite -->
                 <IfCondition condition=':= nthoTennantiteDist = "hugeVeins"'>
                 
-                    <Veins name='nthoTennantiteBaseVeins' block='NetherOres:tile.netherores.ore.1:12' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoTennantiteBaseVeins' block='NetherOres:tile.netherores.ore.1:12' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -5108,23 +4619,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTennantiteFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Tennantite Huge Vein Hint Veins -->
-                        <Veins name='nthoTennantiteBaseHintVeins' block='NetherOres:tile.netherores.ore.1:12' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609EE2B1</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Tennantite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -5222,7 +4716,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Salt -->
                 <IfCondition condition=':= nthoSaltDist = "hugeVeins"'>
                 
-                    <Veins name='nthoSaltBaseVeins' block='NetherOres:tile.netherores.ore.1:13' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoSaltBaseVeins' block='NetherOres:tile.netherores.ore.1:13' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -5241,23 +4735,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSaltFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Salt Huge Vein Hint Veins -->
-                        <Veins name='nthoSaltBaseHintVeins' block='NetherOres:tile.netherores.ore.1:13' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FFFFFF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Salt Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -5355,7 +4832,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Saltpeter -->
                 <IfCondition condition=':= nthoSaltpeterDist = "hugeVeins"'>
                 
-                    <Veins name='nthoSaltpeterBaseVeins' block='NetherOres:tile.netherores.ore.1:14' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoSaltpeterBaseVeins' block='NetherOres:tile.netherores.ore.1:14' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -5374,23 +4851,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSaltpeterFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Saltpeter Huge Vein Hint Veins -->
-                        <Veins name='nthoSaltpeterBaseHintVeins' block='NetherOres:tile.netherores.ore.1:14' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60F4F6F9</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Saltpeter Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -5488,7 +4948,7 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Magnesium -->
                 <IfCondition condition=':= nthoMagnesiumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoMagnesiumBaseVeins' block='NetherOres:tile.netherores.ore.1:15' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoMagnesiumBaseVeins' block='NetherOres:tile.netherores.ore.1:15' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -5507,23 +4967,6 @@ Saltpeter, Magnesium
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoMagnesiumFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Magnesium Huge Vein Hint Veins -->
-                        <Veins name='nthoMagnesiumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:15' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60827066</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Magnesium Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -5599,11 +5042,9 @@ Saltpeter, Magnesium
             </IfCondition>
             <!-- Nether Setup Complete -->
 
-
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/Netherrocks.xml
+++ b/src/main/resources/config/modules/Netherrocks.xml
@@ -10,8 +10,8 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
 
     <!-- Mod detection -->
     <IfModInstalled name="netherrocks">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -260,19 +260,6 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
             <!-- Setup Screen Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-
             <!-- Setup Nether -->
             <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
                 
@@ -321,7 +308,7 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin  Huge Veins distribution of Malachite -->
                 <IfCondition condition=':= nthrMalachiteDist = "hugeVeins"'>
                 
-                    <Veins name='nthrMalachiteBaseVeins' block='netherrocks:malachite_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='nthrMalachiteBaseVeins' block='netherrocks:malachite_ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -340,23 +327,6 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrMalachiteFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Malachite Huge Vein Hint Veins -->
-                        <Veins name='nthrMalachiteBaseHintVeins' block='netherrocks:malachite_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60046652</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Malachite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -454,7 +424,7 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin  Huge Veins distribution of Dragonstone -->
                 <IfCondition condition=':= nthrDragonstoneDist = "hugeVeins"'>
                 
-                    <Veins name='nthrDragonstoneBaseVeins' block='netherrocks:dragonstone_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='nthrDragonstoneBaseVeins' block='netherrocks:dragonstone_ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -473,23 +443,6 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrDragonstoneFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Dragonstone Huge Vein Hint Veins -->
-                        <Veins name='nthrDragonstoneBaseHintVeins' block='netherrocks:dragonstone_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x602F0E0F</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Dragonstone Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -587,7 +540,7 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin  Huge Veins distribution of Illumenite -->
                 <IfCondition condition=':= nthrIllumeniteDist = "hugeVeins"'>
                 
-                    <Veins name='nthrIllumeniteBaseVeins' block='netherrocks:illumenite_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='nthrIllumeniteBaseVeins' block='netherrocks:illumenite_ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -606,23 +559,6 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrIllumeniteFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Illumenite Huge Vein Hint Veins -->
-                        <Veins name='nthrIllumeniteBaseHintVeins' block='netherrocks:illumenite_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FCFEB0</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Illumenite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -720,7 +656,7 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin  Huge Veins distribution of Fyrite -->
                 <IfCondition condition=':= nthrFyriteDist = "hugeVeins"'>
                 
-                    <Veins name='nthrFyriteBaseVeins' block='netherrocks:fyrite_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='nthrFyriteBaseVeins' block='netherrocks:fyrite_ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -739,23 +675,6 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrFyriteFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Fyrite Huge Vein Hint Veins -->
-                        <Veins name='nthrFyriteBaseHintVeins' block='netherrocks:fyrite_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BF0000</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Fyrite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -853,7 +772,7 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin  Huge Veins distribution of Ashtone -->
                 <IfCondition condition=':= nthrAshtoneDist = "hugeVeins"'>
                 
-                    <Veins name='nthrAshtoneBaseVeins' block='netherrocks:ashstone_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='nthrAshtoneBaseVeins' block='netherrocks:ashstone_ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -872,23 +791,6 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrAshtoneFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ashtone Huge Vein Hint Veins -->
-                        <Veins name='nthrAshtoneBaseHintVeins' block='netherrocks:ashstone_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x603F3F60</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ashtone Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -986,7 +888,7 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin  Huge Veins distribution of Argonite -->
                 <IfCondition condition=':= nthrArgoniteDist = "hugeVeins"'>
                 
-                    <Veins name='nthrArgoniteBaseVeins' block='netherrocks:argonite_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='nthrArgoniteBaseVeins' block='netherrocks:argonite_ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1005,23 +907,6 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrArgoniteFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Argonite Huge Vein Hint Veins -->
-                        <Veins name='nthrArgoniteBaseHintVeins' block='netherrocks:argonite_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x600F0035</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Argonite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1097,11 +982,9 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
             </IfCondition>
             <!-- Nether Setup Complete -->
 
-
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -10,8 +10,8 @@ Salt
 
     <!-- Mod detection -->
     <IfModInstalled name="harvestcraft">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -230,12 +230,9 @@ Salt
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -11,8 +11,8 @@ Basalt
 
     <!-- Mod detection -->
     <IfModInstalled name="ProjRed|Exploration">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -831,7 +831,7 @@ Basalt
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= predCopperDist = "hugeVeins"'>
                 
-                    <Veins name='predCopperBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='PresetLayeredVeins'>
+                    <Veins name='predCopperBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -853,23 +853,6 @@ Basalt
                         <Setting name='BranchLength' avg=':= 0.95 * _default_' range=':= 0.95 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='predCopperBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
@@ -881,21 +864,6 @@ Basalt
                         <WireframeColor>0x60FF8E2B</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Jungle'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='predCopperPrefersHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='predCopperBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Jungle'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Copper Huge Veins) Settings -->
                 
@@ -1011,7 +979,7 @@ Basalt
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= predTinDist = "hugeVeins"'>
                 
-                    <Veins name='predTinBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='PresetLayeredVeins'>
+                    <Veins name='predTinBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1033,23 +1001,6 @@ Basalt
                         <Setting name='BranchLength' avg=':= 0.9 * _default_' range=':= 1 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 11'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='predTinBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
@@ -1061,21 +1012,6 @@ Basalt
                         <WireframeColor>0x60E8E8E8</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Plains'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='predTinPrefersHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='predTinBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Plains'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Tin Huge Veins) Settings -->
                 
@@ -1191,7 +1127,7 @@ Basalt
                 <!-- Begin  Huge Veins distribution of Silver -->
                 <IfCondition condition=':= predSilverDist = "hugeVeins"'>
                 
-                    <Veins name='predSilverBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='predSilverBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1213,23 +1149,6 @@ Basalt
                         <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Silver Huge Vein Hint Veins -->
-                        <Veins name='predSilverBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E3F2F7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Silver Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Huge Veins) Settings -->
@@ -1241,21 +1160,6 @@ Basalt
                         <WireframeColor>0x60E3F2F7</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Mountain'/>
-                        
-                        <!-- Begin Silver Huge Vein Hint Veins -->
-                        <Veins name='predSilverPrefersHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='predSilverBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E3F2F7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                        </Veins>
-                        <!-- End Silver Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Silver Huge Veins) Settings -->
                 
@@ -1563,12 +1467,9 @@ Basalt
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -11,8 +11,8 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
 
     <!-- Mod detection -->
     <IfModInstalled name="Railcraft">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -537,7 +537,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Sulfur -->
                 <IfCondition condition=':= rlcrSulfurDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrSulfurBaseVeins' block='Railcraft:ore' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrSulfurBaseVeins' block='Railcraft:ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -557,24 +557,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * rlcrSulfurFreq * _default_'/>
                         <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
-                        
-                        <!-- Begin Sulfur Huge Vein Hint Veins -->
-                        <Veins name='rlcrSulfurBaseHintVeins' block='Railcraft:ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FFE25C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                        </Veins>
-                        <!-- End Sulfur Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -689,7 +671,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Poor Iron -->
                 <IfCondition condition=':= rlcrPoorIronDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrPoorIronBaseVeins' block='Railcraft:ore:7' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrPoorIronBaseVeins' block='Railcraft:ore:7' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -709,23 +691,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorIronFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Poor Iron Huge Vein Hint Veins -->
-                        <Veins name='rlcrPoorIronBaseHintVeins' block='Railcraft:ore:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDC2AF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Poor Iron Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Iron Huge Veins) Settings -->
@@ -738,22 +703,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Cold'/>
                         <BiomeType name='Ocean' weight='-1'/>
-                        
-                        <!-- Begin Poor Iron Huge Vein Hint Veins -->
-                        <Veins name='rlcrPoorIronPrefersHintVeins' block='Railcraft:ore:7' inherits='rlcrPoorIronBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDC2AF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Cold'/>
-                            <BiomeType name='Ocean' weight='-1'/>
-                        </Veins>
-                        <!-- End Poor Iron Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Poor Iron Huge Veins) Settings -->
                 
@@ -869,7 +818,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Poor Gold -->
                 <IfCondition condition=':= rlcrPoorGoldDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrPoorGoldBaseVeins' block='Railcraft:ore:8' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrPoorGoldBaseVeins' block='Railcraft:ore:8' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -891,23 +840,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Poor Gold Huge Vein Hint Veins -->
-                        <Veins name='rlcrPoorGoldBaseHintVeins' block='Railcraft:ore:8' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EAEF57</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Poor Gold Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Gold Huge Veins) Settings -->
@@ -919,21 +851,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <WireframeColor>0x60EAEF57</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Poor Gold Huge Vein Hint Veins -->
-                        <Veins name='rlcrPoorGoldPrefersHintVeins' block='Railcraft:ore:8' inherits='rlcrPoorGoldBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EAEF57</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Poor Gold Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Poor Gold Huge Veins) Settings -->
                 
@@ -1048,7 +965,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Poor Copper -->
                 <IfCondition condition=':= rlcrPoorCopperDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrPoorCopperBaseVeins' block='Railcraft:ore:9' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrPoorCopperBaseVeins' block='Railcraft:ore:9' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1068,23 +985,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorCopperFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Poor Copper Huge Vein Hint Veins -->
-                        <Veins name='rlcrPoorCopperBaseHintVeins' block='Railcraft:ore:9' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Poor Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Copper Huge Veins) Settings -->
@@ -1097,22 +997,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Cold'/>
                         <BiomeType name='Ocean' weight='-1'/>
-                        
-                        <!-- Begin Poor Copper Huge Vein Hint Veins -->
-                        <Veins name='rlcrPoorCopperPrefersHintVeins' block='Railcraft:ore:9' inherits='rlcrPoorCopperBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Cold'/>
-                            <BiomeType name='Ocean' weight='-1'/>
-                        </Veins>
-                        <!-- End Poor Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Poor Copper Huge Veins) Settings -->
                 
@@ -1227,7 +1111,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Poor Tin -->
                 <IfCondition condition=':= rlcrPoorTinDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrPoorTinBaseVeins' block='Railcraft:ore:10' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrPoorTinBaseVeins' block='Railcraft:ore:10' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1247,23 +1131,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorTinFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Poor Tin Huge Vein Hint Veins -->
-                        <Veins name='rlcrPoorTinBaseHintVeins' block='Railcraft:ore:10' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Poor Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Tin Huge Veins) Settings -->
@@ -1276,22 +1143,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Cold'/>
                         <BiomeType name='Ocean' weight='-1'/>
-                        
-                        <!-- Begin Poor Tin Huge Vein Hint Veins -->
-                        <Veins name='rlcrPoorTinPrefersHintVeins' block='Railcraft:ore:10' inherits='rlcrPoorTinBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Cold'/>
-                            <BiomeType name='Ocean' weight='-1'/>
-                        </Veins>
-                        <!-- End Poor Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Poor Tin Huge Veins) Settings -->
                 
@@ -1406,7 +1257,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Poor Lead -->
                 <IfCondition condition=':= rlcrPoorLeadDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrPoorLeadBaseVeins' block='Railcraft:ore:11' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrPoorLeadBaseVeins' block='Railcraft:ore:11' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1426,23 +1277,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorLeadFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Poor Lead Huge Vein Hint Veins -->
-                        <Veins name='rlcrPoorLeadBaseHintVeins' block='Railcraft:ore:11' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60818EBE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Poor Lead Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Lead Huge Veins) Settings -->
@@ -1455,22 +1289,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Cold'/>
                         <BiomeType name='Ocean' weight='-1'/>
-                        
-                        <!-- Begin Poor Lead Huge Vein Hint Veins -->
-                        <Veins name='rlcrPoorLeadPrefersHintVeins' block='Railcraft:ore:11' inherits='rlcrPoorLeadBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60818EBE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Cold'/>
-                            <BiomeType name='Ocean' weight='-1'/>
-                        </Veins>
-                        <!-- End Poor Lead Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Poor Lead Huge Veins) Settings -->
                 
@@ -1577,7 +1395,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Saltpeter -->
                 <IfCondition condition=':= rlcrSaltpeterDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrSaltpeterBaseVeins' block='Railcraft:ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrSaltpeterBaseVeins' block='Railcraft:ore:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1602,25 +1420,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Replaces block='minecraft:sandstone'/>
                         <Replaces block='minecraft:sand'/>
                         <BiomeType name='Desert'/>
-                        
-                        <!-- Begin Saltpeter Huge Vein Hint Veins -->
-                        <Veins name='rlcrSaltpeterBaseHintVeins' block='Railcraft:ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60CED0BA</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:sand'/>
-                            <BiomeType name='Desert'/>
-                        </Veins>
-                        <!-- End Saltpeter Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1770,7 +1569,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
             <!-- Setup Nether -->
             <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
                 
@@ -1814,7 +1612,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Firestone -->
                 <IfCondition condition=':= rlcrFirestoneDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrFirestoneBaseVeins' block='Railcraft:ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrFirestoneBaseVeins' block='Railcraft:ore:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1833,23 +1631,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 0.5 * 1 * rlcrFirestoneFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Firestone Huge Vein Hint Veins -->
-                        <Veins name='rlcrFirestoneBaseHintVeins' block='Railcraft:ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60C64E0D</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Firestone Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1925,11 +1706,9 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
             </IfCondition>
             <!-- Nether Setup Complete -->
 
-
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -13,8 +13,8 @@ Fluorite, Yellow Fluorite
 
     <!-- Mod detection -->
     <IfModInstalled name="ReactorCraft">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -643,7 +643,7 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Pitchblende -->
                 <IfCondition condition=':= recrPitchblendeDist = "hugeVeins"'>
                 
-                    <Veins name='recrPitchblendeBaseVeins' block='ReactorCraft:reactorcraft_block_ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='recrPitchblendeBaseVeins' block='ReactorCraft:reactorcraft_block_ore:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -665,23 +665,6 @@ Fluorite, Yellow Fluorite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Pitchblende Huge Vein Hint Veins -->
-                        <Veins name='recrPitchblendeBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60454454</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Pitchblende Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Pitchblende Huge Veins) Settings -->
@@ -693,21 +676,6 @@ Fluorite, Yellow Fluorite
                         <WireframeColor>0x60454454</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Mushroom'/>
-                        
-                        <!-- Begin Pitchblende Huge Vein Hint Veins -->
-                        <Veins name='recrPitchblendePrefersHintVeins' block='ReactorCraft:reactorcraft_block_ore:1' inherits='recrPitchblendeBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60454454</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mushroom'/>
-                        </Veins>
-                        <!-- End Pitchblende Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Pitchblende Huge Veins) Settings -->
                 
@@ -823,7 +791,7 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Cadmium -->
                 <IfCondition condition=':= recrCadmiumDist = "hugeVeins"'>
                 
-                    <Veins name='recrCadmiumBaseVeins' block='ReactorCraft:reactorcraft_block_ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='recrCadmiumBaseVeins' block='ReactorCraft:reactorcraft_block_ore:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -845,23 +813,6 @@ Fluorite, Yellow Fluorite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Cadmium Huge Vein Hint Veins -->
-                        <Veins name='recrCadmiumBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x607184A4</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Cadmium Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Cadmium Huge Veins) Settings -->
@@ -873,21 +824,6 @@ Fluorite, Yellow Fluorite
                         <WireframeColor>0x607184A4</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Cadmium Huge Vein Hint Veins -->
-                        <Veins name='recrCadmiumPrefersHintVeins' block='ReactorCraft:reactorcraft_block_ore:2' inherits='recrCadmiumBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x607184A4</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Cadmium Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Cadmium Huge Veins) Settings -->
                 
@@ -991,7 +927,7 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Indium -->
                 <IfCondition condition=':= recrIndiumDist = "hugeVeins"'>
                 
-                    <Veins name='recrIndiumBaseVeins' block='ReactorCraft:reactorcraft_block_ore:3' inherits='PresetLayeredVeins'>
+                    <Veins name='recrIndiumBaseVeins' block='ReactorCraft:reactorcraft_block_ore:3' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1013,23 +949,6 @@ Fluorite, Yellow Fluorite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Indium Huge Vein Hint Veins -->
-                        <Veins name='recrIndiumBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x607A7C89</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Indium Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1130,7 +1049,7 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Silver -->
                 <IfCondition condition=':= recrSilverDist = "hugeVeins"'>
                 
-                    <Veins name='recrSilverBaseVeins' block='ReactorCraft:reactorcraft_block_ore:4' inherits='PresetLayeredVeins'>
+                    <Veins name='recrSilverBaseVeins' block='ReactorCraft:reactorcraft_block_ore:4' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1152,23 +1071,6 @@ Fluorite, Yellow Fluorite
                         <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Silver Huge Vein Hint Veins -->
-                        <Veins name='recrSilverBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E3F2F7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Silver Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1285,7 +1187,7 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Calcite -->
                 <IfCondition condition=':= recrCalciteDist = "hugeVeins"'>
                 
-                    <Veins name='recrCalciteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:7' inherits='PresetLayeredVeins'>
+                    <Veins name='recrCalciteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:7' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1307,23 +1209,6 @@ Fluorite, Yellow Fluorite
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Calcite Huge Vein Hint Veins -->
-                        <Veins name='recrCalciteBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FEA219</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Calcite Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Calcite Huge Veins) Settings -->
@@ -1336,22 +1221,6 @@ Fluorite, Yellow Fluorite
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Swamp'/>
                         <BiomeType name='Water'/>
-                        
-                        <!-- Begin Calcite Huge Vein Hint Veins -->
-                        <Veins name='recrCalcitePrefersHintVeins' block='ReactorCraft:reactorcraft_block_ore:7' inherits='recrCalciteBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FEA219</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Swamp'/>
-                            <BiomeType name='Water'/>
-                        </Veins>
-                        <!-- End Calcite Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Calcite Huge Veins) Settings -->
                 
@@ -1453,7 +1322,7 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Magnetite -->
                 <IfCondition condition=':= recrMagnetiteDist = "hugeVeins"'>
                 
-                    <Veins name='recrMagnetiteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:8' inherits='PresetLayeredVeins'>
+                    <Veins name='recrMagnetiteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:8' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1473,23 +1342,6 @@ Fluorite, Yellow Fluorite
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 2 * recrMagnetiteFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Magnetite Huge Vein Hint Veins -->
-                        <Veins name='recrMagnetiteBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:8' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60212121</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Magnetite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1861,7 +1713,6 @@ Fluorite, Yellow Fluorite
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
             <!-- Setup Nether -->
             <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
                 
@@ -1909,7 +1760,7 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Ammonium Chloride -->
                 <IfCondition condition=':= recrAmmoniumChlorideDist = "hugeVeins"'>
                 
-                    <Veins name='recrAmmoniumChlorideBaseVeins' block='ReactorCraft:reactorcraft_block_ore:6' inherits='PresetLayeredVeins'>
+                    <Veins name='recrAmmoniumChlorideBaseVeins' block='ReactorCraft:reactorcraft_block_ore:6' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1931,23 +1782,6 @@ Fluorite, Yellow Fluorite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ammonium Chloride Huge Vein Hint Veins -->
-                        <Veins name='recrAmmoniumChlorideBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:6' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FFFFFF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ammonium Chloride Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2048,7 +1882,7 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Thorite -->
                 <IfCondition condition=':= recrThoriteDist = "hugeVeins"'>
                 
-                    <Veins name='recrThoriteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:9' inherits='PresetLayeredVeins'>
+                    <Veins name='recrThoriteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:9' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2070,23 +1904,6 @@ Fluorite, Yellow Fluorite
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Thorite Huge Vein Hint Veins -->
-                        <Veins name='recrThoriteBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:9' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6054A228</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Thorite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2162,7 +1979,6 @@ Fluorite, Yellow Fluorite
             </IfCondition>
             <!-- Nether Setup Complete -->
 
-
             <!-- Setup End -->
             <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
                 
@@ -2206,7 +2022,7 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of End Pitchblende -->
                 <IfCondition condition=':= recrEndPitchblendeDist = "hugeVeins"'>
                 
-                    <Veins name='recrEndPitchblendeBaseVeins' block='ReactorCraft:reactorcraft_block_ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='recrEndPitchblendeBaseVeins' block='ReactorCraft:reactorcraft_block_ore:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2225,23 +2041,6 @@ Fluorite, Yellow Fluorite
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * recrEndPitchblendeFreq * _default_'/>
                         <Replaces block='minecraft:end_stone'/>
-                        
-                        <!-- Begin End Pitchblende Huge Vein Hint Veins -->
-                        <Veins name='recrEndPitchblendeBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60454454</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:end_stone'/>
-                        </Veins>
-                        <!-- End End Pitchblende Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2317,10 +2116,9 @@ Fluorite, Yellow Fluorite
             </IfCondition>
             <!-- End Setup Complete -->
 
-
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -10,8 +10,8 @@ Copper, Tin, Mythril, Adamantium, Onyx
 
     <!-- Mod detection -->
     <IfModInstalled name="simpleores">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -283,7 +283,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= smpoCopperDist = "hugeVeins"'>
                 
-                    <Veins name='smpoCopperBaseVeins' block='simpleores:copper_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='smpoCopperBaseVeins' block='simpleores:copper_ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -305,23 +305,6 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <Setting name='BranchLength' avg=':= 1.2 * _default_' range=':= 1.2 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 24'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='smpoCopperBaseHintVeins' block='simpleores:copper_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
@@ -333,21 +316,6 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <WireframeColor>0x60FF8E2B</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Jungle'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='smpoCopperPrefersHintVeins' block='simpleores:copper_ore' inherits='smpoCopperBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Jungle'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Copper Huge Veins) Settings -->
                 
@@ -462,7 +430,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= smpoTinDist = "hugeVeins"'>
                 
-                    <Veins name='smpoTinBaseVeins' block='simpleores:tin_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='smpoTinBaseVeins' block='simpleores:tin_ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -483,23 +451,6 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <Setting name='BranchLength' avg=':= 0.5 * _default_' range=':= 0.5 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 20'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='smpoTinBaseHintVeins' block='simpleores:tin_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
@@ -511,21 +462,6 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <WireframeColor>0x60E8E8E8</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Plains'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='smpoTinPrefersHintVeins' block='simpleores:tin_ore' inherits='smpoTinBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Plains'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Tin Huge Veins) Settings -->
                 
@@ -640,7 +576,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin  Huge Veins distribution of Mythril -->
                 <IfCondition condition=':= smpoMythrilDist = "hugeVeins"'>
                 
-                    <Veins name='smpoMythrilBaseVeins' block='simpleores:mythril_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='smpoMythrilBaseVeins' block='simpleores:mythril_ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -661,23 +597,6 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <Setting name='BranchLength' avg=':= 12/_default_ * _default_' range=':= 6/_default_ * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 20'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Mythril Huge Vein Hint Veins -->
-                        <Veins name='smpoMythrilBaseHintVeins' block='simpleores:mythril_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6079AFD2</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Mythril Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Mythril Huge Veins) Settings -->
@@ -689,21 +608,6 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <WireframeColor>0x6079AFD2</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Plains'/>
-                        
-                        <!-- Begin Mythril Huge Vein Hint Veins -->
-                        <Veins name='smpoMythrilPrefersHintVeins' block='simpleores:mythril_ore' inherits='smpoMythrilBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6079AFD2</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Plains'/>
-                        </Veins>
-                        <!-- End Mythril Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Mythril Huge Veins) Settings -->
                 
@@ -818,7 +722,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin  Huge Veins distribution of Adamantium -->
                 <IfCondition condition=':= smpoAdamantiumDist = "hugeVeins"'>
                 
-                    <Veins name='smpoAdamantiumBaseVeins' block='simpleores:adamantium_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='smpoAdamantiumBaseVeins' block='simpleores:adamantium_ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -839,23 +743,6 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <Setting name='BranchLength' avg=':= 9/_default_ * _default_' range=':= 4/_default_ * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Adamantium Huge Vein Hint Veins -->
-                        <Veins name='smpoAdamantiumBaseHintVeins' block='simpleores:adamantium_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60159800</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Adamantium Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Adamantium Huge Veins) Settings -->
@@ -867,21 +754,6 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <WireframeColor>0x60159800</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Plains'/>
-                        
-                        <!-- Begin Adamantium Huge Vein Hint Veins -->
-                        <Veins name='smpoAdamantiumPrefersHintVeins' block='simpleores:adamantium_ore' inherits='smpoAdamantiumBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60159800</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Plains'/>
-                        </Veins>
-                        <!-- End Adamantium Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Adamantium Huge Veins) Settings -->
                 
@@ -960,7 +832,6 @@ Copper, Tin, Mythril, Adamantium, Onyx
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
             <!-- Setup Nether -->
             <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
                 
@@ -1008,7 +879,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin  Huge Veins distribution of Onyx -->
                 <IfCondition condition=':= smpoOnyxDist = "hugeVeins"'>
                 
-                    <Veins name='smpoOnyxBaseVeins' block='simpleores:onyx_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='smpoOnyxBaseVeins' block='simpleores:onyx_ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1027,23 +898,6 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * smpoOnyxFreq * _default_'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Onyx Huge Vein Hint Veins -->
-                        <Veins name='smpoOnyxBaseHintVeins' block='simpleores:onyx_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60232323</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Onyx Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -1119,11 +973,9 @@ Copper, Tin, Mythril, Adamantium, Onyx
             </IfCondition>
             <!-- Nether Setup Complete -->
 
-
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -11,8 +11,8 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
 
     <!-- Mod detection -->
     <IfModInstalled name="Thaumcraft">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -477,7 +477,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Huge Veins distribution of Amber -->
                 <IfCondition condition=':= thm4AmberDist = "hugeVeins"'>
                 
-                    <Veins name='thm4AmberBaseVeins' block='Thaumcraft:blockCustomOre:7' inherits='PresetLayeredVeins'>
+                    <Veins name='thm4AmberBaseVeins' block='Thaumcraft:blockCustomOre:7' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -496,23 +496,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 3 * thm4AmberFreq * _default_'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Amber Huge Vein Hint Veins -->
-                        <Veins name='thm4AmberBaseHintVeins' block='Thaumcraft:blockCustomOre:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FE9D1B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Amber Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Amber Huge Veins) Settings -->
@@ -524,21 +507,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <WireframeColor>0x60FE9D1B</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Mountain'/>
-                        
-                        <!-- Begin Amber Huge Vein Hint Veins -->
-                        <Veins name='thm4AmberPrefersHintVeins' block='Thaumcraft:blockCustomOre:7' inherits='thm4AmberBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FE9D1B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                        </Veins>
-                        <!-- End Amber Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Amber Huge Veins) Settings -->
                 
@@ -690,7 +658,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Huge Veins distribution of Cinnabar -->
                 <IfCondition condition=':= thm4CinnabarDist = "hugeVeins"'>
                 
-                    <Veins name='thm4CinnabarBaseVeins' block='Thaumcraft:blockCustomOre' inherits='PresetLayeredVeins'>
+                    <Veins name='thm4CinnabarBaseVeins' block='Thaumcraft:blockCustomOre' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -712,23 +680,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Cinnabar Huge Vein Hint Veins -->
-                        <Veins name='thm4CinnabarBaseHintVeins' block='Thaumcraft:blockCustomOre' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60831C20</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Cinnabar Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Cinnabar Huge Veins) Settings -->
@@ -740,21 +691,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <WireframeColor>0x60831C20</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Ocean'/>
-                        
-                        <!-- Begin Cinnabar Huge Vein Hint Veins -->
-                        <Veins name='thm4CinnabarPrefersHintVeins' block='Thaumcraft:blockCustomOre' inherits='thm4CinnabarBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60831C20</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Ocean'/>
-                        </Veins>
-                        <!-- End Cinnabar Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Cinnabar Huge Veins) Settings -->
                 
@@ -922,7 +858,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Huge Veins distribution of Air Infused Stone -->
                 <IfCondition condition=':= thm4AirInfusedStoneDist = "hugeVeins"'>
                 
-                    <Veins name='thm4AirInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:1' inherits='PresetLayeredVeins'>
+                    <Veins name='thm4AirInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -951,30 +887,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Air Infused Stone Huge Vein Hint Veins -->
-                        <Veins name='thm4AirInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FEFEAB</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                            <BiomeType name='Plains'/>
-                            <BiomeType name='Hills'/>
-                            <BiomeType name='Jungle'/>
-                            <BiomeType name='Beach'/>
-                            <BiomeType name='Mushroom'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Air Infused Stone Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Air Infused Stone Huge Veins) Settings -->
@@ -987,22 +899,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
                         <BiomeType name='Plains'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Air Infused Stone Huge Vein Hint Veins -->
-                        <Veins name='thm4AirInfusedStonePrefersHintVeins' block='Thaumcraft:blockCustomOre:1' inherits='thm4AirInfusedStoneBaseHintVeins'>
-                            <Description>
-                                Spawns 4 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FEFEAB</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Plains'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Air Infused Stone Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Air Infused Stone Huge Veins) Settings -->
                 
@@ -1187,7 +1083,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Huge Veins distribution of Fire Infused Stone -->
                 <IfCondition condition=':= thm4FireInfusedStoneDist = "hugeVeins"'>
                 
-                    <Veins name='thm4FireInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:2' inherits='PresetLayeredVeins'>
+                    <Veins name='thm4FireInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1214,28 +1110,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Wasteland'/>
                         <BiomeType name='Beach'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Fire Infused Stone Huge Vein Hint Veins -->
-                        <Veins name='thm4FireInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FC5100</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                            <BiomeType name='Desert'/>
-                            <BiomeType name='Wasteland'/>
-                            <BiomeType name='Beach'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Fire Infused Stone Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Fire Infused Stone Huge Veins) Settings -->
@@ -1248,22 +1122,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
                         <BiomeType name='Desert'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Fire Infused Stone Huge Vein Hint Veins -->
-                        <Veins name='thm4FireInfusedStonePrefersHintVeins' block='Thaumcraft:blockCustomOre:2' inherits='thm4FireInfusedStoneBaseHintVeins'>
-                            <Description>
-                                Spawns 4 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FC5100</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Desert'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Fire Infused Stone Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Fire Infused Stone Huge Veins) Settings -->
                 
@@ -1450,7 +1308,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Huge Veins distribution of Water Infused Stone -->
                 <IfCondition condition=':= thm4WaterInfusedStoneDist = "hugeVeins"'>
                 
-                    <Veins name='thm4WaterInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:3' inherits='PresetLayeredVeins'>
+                    <Veins name='thm4WaterInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:3' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1480,31 +1338,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Water Infused Stone Huge Vein Hint Veins -->
-                        <Veins name='thm4WaterInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6000C0FA</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                            <BiomeType name='Swamp'/>
-                            <BiomeType name='Water'/>
-                            <BiomeType name='Frozen'/>
-                            <BiomeType name='Jungle'/>
-                            <BiomeType name='Beach'/>
-                            <BiomeType name='Mushroom'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Water Infused Stone Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Water Infused Stone Huge Veins) Settings -->
@@ -1518,23 +1351,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Swamp'/>
                         <BiomeType name='Water'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Water Infused Stone Huge Vein Hint Veins -->
-                        <Veins name='thm4WaterInfusedStonePrefersHintVeins' block='Thaumcraft:blockCustomOre:3' inherits='thm4WaterInfusedStoneBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6000C0FA</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Swamp'/>
-                            <BiomeType name='Water'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Water Infused Stone Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Water Infused Stone Huge Veins) Settings -->
                 
@@ -1730,7 +1546,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Huge Veins distribution of Earth Infused Stone -->
                 <IfCondition condition=':= thm4EarthInfusedStoneDist = "hugeVeins"'>
                 
-                    <Veins name='thm4EarthInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:4' inherits='PresetLayeredVeins'>
+                    <Veins name='thm4EarthInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:4' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1760,31 +1576,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Earth Infused Stone Huge Vein Hint Veins -->
-                        <Veins name='thm4EarthInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6000D900</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                            <BiomeType name='Hills'/>
-                            <BiomeType name='Desert'/>
-                            <BiomeType name='Jungle'/>
-                            <BiomeType name='Wasteland'/>
-                            <BiomeType name='Beach'/>
-                            <BiomeType name='Mushroom'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Earth Infused Stone Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Earth Infused Stone Huge Veins) Settings -->
@@ -1798,23 +1589,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Mountain'/>
                         <BiomeType name='Hills'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Earth Infused Stone Huge Vein Hint Veins -->
-                        <Veins name='thm4EarthInfusedStonePrefersHintVeins' block='Thaumcraft:blockCustomOre:4' inherits='thm4EarthInfusedStoneBaseHintVeins'>
-                            <Description>
-                                Spawns 4 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6000D900</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                            <BiomeType name='Hills'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Earth Infused Stone Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Earth Infused Stone Huge Veins) Settings -->
                 
@@ -2006,7 +1780,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Huge Veins distribution of Order Infused Stone -->
                 <IfCondition condition=':= thm4OrderInfusedStoneDist = "hugeVeins"'>
                 
-                    <Veins name='thm4OrderInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:5' inherits='PresetLayeredVeins'>
+                    <Veins name='thm4OrderInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2034,29 +1808,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Hills'/>
                         <BiomeType name='Jungle'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Order Infused Stone Huge Vein Hint Veins -->
-                        <Veins name='thm4OrderInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EBEBF9</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                            <BiomeType name='Plains'/>
-                            <BiomeType name='Mountain'/>
-                            <BiomeType name='Hills'/>
-                            <BiomeType name='Jungle'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Order Infused Stone Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Order Infused Stone Huge Veins) Settings -->
@@ -2070,23 +1821,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Forest'/>
                         <BiomeType name='Jungle'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Order Infused Stone Huge Vein Hint Veins -->
-                        <Veins name='thm4OrderInfusedStonePrefersHintVeins' block='Thaumcraft:blockCustomOre:5' inherits='thm4OrderInfusedStoneBaseHintVeins'>
-                            <Description>
-                                Spawns 4 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EBEBF9</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                            <BiomeType name='Jungle'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Order Infused Stone Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Order Infused Stone Huge Veins) Settings -->
                 
@@ -2272,7 +2006,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Huge Veins distribution of Entropy Infused Stone -->
                 <IfCondition condition=':= thm4EntropyInfusedStoneDist = "hugeVeins"'>
                 
-                    <Veins name='thm4EntropyInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:6' inherits='PresetLayeredVeins'>
+                    <Veins name='thm4EntropyInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:6' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2300,29 +2034,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Entropy Infused Stone Huge Vein Hint Veins -->
-                        <Veins name='thm4EntropyInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:6' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60260920</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Swamp'/>
-                            <BiomeType name='Desert'/>
-                            <BiomeType name='Wasteland'/>
-                            <BiomeType name='Beach'/>
-                            <BiomeType name='Mushroom'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Entropy Infused Stone Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Entropy Infused Stone Huge Veins) Settings -->
@@ -2336,23 +2047,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Wasteland'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Entropy Infused Stone Huge Vein Hint Veins -->
-                        <Veins name='thm4EntropyInfusedStonePrefersHintVeins' block='Thaumcraft:blockCustomOre:6' inherits='thm4EntropyInfusedStoneBaseHintVeins'>
-                            <Description>
-                                Spawns 4 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60260920</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Wasteland'/>
-                            <BiomeType name='Mushroom'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Entropy Infused Stone Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Entropy Infused Stone Huge Veins) Settings -->
                 
@@ -2449,12 +2143,9 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -10,8 +10,8 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
 
     <!-- Mod detection -->
     <IfModInstalled name="ThermalFoundation">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -368,7 +368,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= thfoCopperDist = "hugeVeins"'>
                 
-                    <Veins name='thfoCopperBaseVeins' block='ThermalFoundation:Ore' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoCopperBaseVeins' block='ThermalFoundation:Ore' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -390,23 +390,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <Setting name='BranchLength' avg=':= 0.95 * _default_' range=':= 0.95 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='thfoCopperBaseHintVeins' block='ThermalFoundation:Ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
@@ -418,21 +401,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <WireframeColor>0x60FF8E2B</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Jungle'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='thfoCopperPrefersHintVeins' block='ThermalFoundation:Ore' inherits='thfoCopperBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Jungle'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Copper Huge Veins) Settings -->
                 
@@ -548,7 +516,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= thfoTinDist = "hugeVeins"'>
                 
-                    <Veins name='thfoTinBaseVeins' block='ThermalFoundation:Ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoTinBaseVeins' block='ThermalFoundation:Ore:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -570,23 +538,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <Setting name='BranchLength' avg=':= 0.9 * _default_' range=':= 1 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 11'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='thfoTinBaseHintVeins' block='ThermalFoundation:Ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
@@ -598,21 +549,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <WireframeColor>0x60E8E8E8</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Plains'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='thfoTinPrefersHintVeins' block='ThermalFoundation:Ore:1' inherits='thfoTinBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Plains'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Tin Huge Veins) Settings -->
                 
@@ -728,7 +664,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Silver -->
                 <IfCondition condition=':= thfoSilverDist = "hugeVeins"'>
                 
-                    <Veins name='thfoSilverBaseVeins' block='ThermalFoundation:Ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoSilverBaseVeins' block='ThermalFoundation:Ore:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -750,23 +686,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Silver Huge Vein Hint Veins -->
-                        <Veins name='thfoSilverBaseHintVeins' block='ThermalFoundation:Ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E3F2F7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Silver Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Huge Veins) Settings -->
@@ -778,21 +697,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <WireframeColor>0x60E3F2F7</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Mountain'/>
-                        
-                        <!-- Begin Silver Huge Vein Hint Veins -->
-                        <Veins name='thfoSilverPrefersHintVeins' block='ThermalFoundation:Ore:2' inherits='thfoSilverBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E3F2F7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                        </Veins>
-                        <!-- End Silver Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Silver Huge Veins) Settings -->
                 
@@ -907,7 +811,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Lead -->
                 <IfCondition condition=':= thfoLeadDist = "hugeVeins"'>
                 
-                    <Veins name='thfoLeadBaseVeins' block='ThermalFoundation:Ore:3' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoLeadBaseVeins' block='ThermalFoundation:Ore:3' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -928,23 +832,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Lead Huge Vein Hint Veins -->
-                        <Veins name='thfoLeadBaseHintVeins' block='ThermalFoundation:Ore:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60818EBE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Lead Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Lead Huge Veins) Settings -->
@@ -956,21 +843,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <WireframeColor>0x60818EBE</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Desert'/>
-                        
-                        <!-- Begin Lead Huge Vein Hint Veins -->
-                        <Veins name='thfoLeadPrefersHintVeins' block='ThermalFoundation:Ore:3' inherits='thfoLeadBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60818EBE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Desert'/>
-                        </Veins>
-                        <!-- End Lead Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Lead Huge Veins) Settings -->
                 
@@ -1086,7 +958,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Ferrous -->
                 <IfCondition condition=':= thfoFerrousDist = "hugeVeins"'>
                 
-                    <Veins name='thfoFerrousBaseVeins' block='ThermalFoundation:Ore:4' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoFerrousBaseVeins' block='ThermalFoundation:Ore:4' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1108,23 +980,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 1 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Ferrous Huge Vein Hint Veins -->
-                        <Veins name='thfoFerrousBaseHintVeins' block='ThermalFoundation:Ore:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BCBDAB</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Ferrous Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Ferrous Huge Veins) Settings -->
@@ -1136,21 +991,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <WireframeColor>0x60BCBDAB</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Swamp'/>
-                        
-                        <!-- Begin Ferrous Huge Vein Hint Veins -->
-                        <Veins name='thfoFerrousPrefersHintVeins' block='ThermalFoundation:Ore:4' inherits='thfoFerrousBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BCBDAB</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Swamp'/>
-                        </Veins>
-                        <!-- End Ferrous Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Ferrous Huge Veins) Settings -->
                 
@@ -1266,7 +1106,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Shiny -->
                 <IfCondition condition=':= thfoShinyDist = "hugeVeins"'>
                 
-                    <Veins name='thfoShinyBaseVeins' block='ThermalFoundation:Ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoShinyBaseVeins' block='ThermalFoundation:Ore:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1288,23 +1128,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <Setting name='BranchLength' avg=':= 0.7 * _default_' range=':= 1 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Shiny Huge Vein Hint Veins -->
-                        <Veins name='thfoShinyBaseHintVeins' block='ThermalFoundation:Ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x606FE5F3</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Shiny Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Shiny Huge Veins) Settings -->
@@ -1316,21 +1139,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <WireframeColor>0x606FE5F3</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Shiny Huge Vein Hint Veins -->
-                        <Veins name='thfoShinyPrefersHintVeins' block='ThermalFoundation:Ore:5' inherits='thfoShinyBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x606FE5F3</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Shiny Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Shiny Huge Veins) Settings -->
                 
@@ -1482,7 +1290,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Mana Infused -->
                 <IfCondition condition=':= thfoManaInfusedDist = "hugeVeins"'>
                 
-                    <Veins name='thfoManaInfusedBaseVeins' block='ThermalFoundation:Ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoManaInfusedBaseVeins' block='ThermalFoundation:Ore:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1504,23 +1312,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Mana Infused Huge Vein Hint Veins -->
-                        <Veins name='thfoManaInfusedBaseHintVeins' block='ThermalFoundation:Ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E2E273</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Mana Infused Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Mana Infused Huge Veins) Settings -->
@@ -1532,21 +1323,6 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <WireframeColor>0x60E2E273</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
                         <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Mana Infused Huge Vein Hint Veins -->
-                        <Veins name='thfoManaInfusedPrefersHintVeins' block='ThermalFoundation:Ore:5' inherits='thfoManaInfusedBaseHintVeins'>
-                            <Description>
-                                Spawns 4 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E2E273</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Mana Infused Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Mana Infused Huge Veins) Settings -->
                 
@@ -1625,12 +1401,9 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
- 
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -11,8 +11,8 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
 
     <!-- Mod detection -->
     <IfModInstalled name="TConstruct">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+    
+        <!-- Starting Configuration for Custom Ore Generation. -->
         <ConfigSection>
         
             
@@ -530,7 +530,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= ticoCopperDist = "hugeVeins"'>
                 
-                    <Veins name='ticoCopperBaseVeins' block='TConstruct:SearedBrick:3' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoCopperBaseVeins' block='TConstruct:SearedBrick:3' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -552,23 +552,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='ticoCopperBaseHintVeins' block='TConstruct:SearedBrick:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
@@ -580,21 +563,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <WireframeColor>0x60FF8E2B</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Jungle'/>
-                        
-                        <!-- Begin Copper Huge Vein Hint Veins -->
-                        <Veins name='ticoCopperPrefersHintVeins' block='TConstruct:SearedBrick:3' inherits='ticoCopperBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Jungle'/>
-                        </Veins>
-                        <!-- End Copper Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Copper Huge Veins) Settings -->
                 
@@ -710,7 +678,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= ticoTinDist = "hugeVeins"'>
                 
-                    <Veins name='ticoTinBaseVeins' block='TConstruct:SearedBrick:4' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoTinBaseVeins' block='TConstruct:SearedBrick:4' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -732,23 +700,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='ticoTinBaseHintVeins' block='TConstruct:SearedBrick:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
@@ -760,21 +711,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <WireframeColor>0x60E8E8E8</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Plains'/>
-                        
-                        <!-- Begin Tin Huge Vein Hint Veins -->
-                        <Veins name='ticoTinPrefersHintVeins' block='TConstruct:SearedBrick:4' inherits='ticoTinBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Plains'/>
-                        </Veins>
-                        <!-- End Tin Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Tin Huge Veins) Settings -->
                 
@@ -890,7 +826,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Aluminum -->
                 <IfCondition condition=':= ticoAluminumDist = "hugeVeins"'>
                 
-                    <Veins name='ticoAluminumBaseVeins' block='TConstruct:SearedBrick:5' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoAluminumBaseVeins' block='TConstruct:SearedBrick:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -912,23 +848,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.7 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Aluminum Huge Vein Hint Veins -->
-                        <Veins name='ticoAluminumBaseHintVeins' block='TConstruct:SearedBrick:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EDEDED</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Aluminum Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Aluminum Huge Veins) Settings -->
@@ -940,21 +859,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <WireframeColor>0x60EDEDED</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Aluminum Huge Vein Hint Veins -->
-                        <Veins name='ticoAluminumPrefersHintVeins' block='TConstruct:SearedBrick:5' inherits='ticoAluminumBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EDEDED</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Aluminum Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Aluminum Huge Veins) Settings -->
                 
@@ -1067,7 +971,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Iron Gravel -->
                 <IfCondition condition=':= ticoIronGravelDist = "hugeVeins"'>
                 
-                    <Veins name='ticoIronGravelBaseVeins' block='TConstruct:GravelOre' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoIronGravelBaseVeins' block='TConstruct:GravelOre' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1086,23 +990,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoIronGravelFreq * _default_'/>
                         <Replaces block='minecraft:gravel'/>
-                        
-                        <!-- Begin Iron Gravel Huge Vein Hint Veins -->
-                        <Veins name='ticoIronGravelBaseHintVeins' block='TConstruct:GravelOre' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDC2AF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                        </Veins>
-                        <!-- End Iron Gravel Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Iron Gravel Huge Veins) Settings -->
@@ -1114,21 +1001,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <WireframeColor>0x60DDC2AF</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Cold'/>
-                        
-                        <!-- Begin Iron Gravel Huge Vein Hint Veins -->
-                        <Veins name='ticoIronGravelPrefersHintVeins' block='TConstruct:GravelOre' inherits='ticoIronGravelBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDC2AF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                            <BiomeType name='Cold'/>
-                        </Veins>
-                        <!-- End Iron Gravel Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Iron Gravel Huge Veins) Settings -->
                 
@@ -1241,7 +1113,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Gold Gravel -->
                 <IfCondition condition=':= ticoGoldGravelDist = "hugeVeins"'>
                 
-                    <Veins name='ticoGoldGravelBaseVeins' block='TConstruct:GravelOre:1' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoGoldGravelBaseVeins' block='TConstruct:GravelOre:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1260,23 +1132,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 0.85 * ticoGoldGravelFreq * _default_'/>
                         <Replaces block='minecraft:gravel'/>
-                        
-                        <!-- Begin Gold Gravel Huge Vein Hint Veins -->
-                        <Veins name='ticoGoldGravelBaseHintVeins' block='TConstruct:GravelOre:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EAEF57</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                        </Veins>
-                        <!-- End Gold Gravel Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Gold Gravel Huge Veins) Settings -->
@@ -1288,21 +1143,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <WireframeColor>0x60EAEF57</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Gold Gravel Huge Vein Hint Veins -->
-                        <Veins name='ticoGoldGravelPrefersHintVeins' block='TConstruct:GravelOre:1' inherits='ticoGoldGravelBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EAEF57</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Gold Gravel Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Gold Gravel Huge Veins) Settings -->
                 
@@ -1415,7 +1255,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Copper Gravel -->
                 <IfCondition condition=':= ticoCopperGravelDist = "hugeVeins"'>
                 
-                    <Veins name='ticoCopperGravelBaseVeins' block='TConstruct:GravelOre:2' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoCopperGravelBaseVeins' block='TConstruct:GravelOre:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1434,23 +1274,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoCopperGravelFreq * _default_'/>
                         <Replaces block='minecraft:gravel'/>
-                        
-                        <!-- Begin Copper Gravel Huge Vein Hint Veins -->
-                        <Veins name='ticoCopperGravelBaseHintVeins' block='TConstruct:GravelOre:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                        </Veins>
-                        <!-- End Copper Gravel Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Gravel Huge Veins) Settings -->
@@ -1462,21 +1285,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <WireframeColor>0x60FF8E2B</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Jungle'/>
-                        
-                        <!-- Begin Copper Gravel Huge Vein Hint Veins -->
-                        <Veins name='ticoCopperGravelPrefersHintVeins' block='TConstruct:GravelOre:2' inherits='ticoCopperGravelBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                            <BiomeType name='Jungle'/>
-                        </Veins>
-                        <!-- End Copper Gravel Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Copper Gravel Huge Veins) Settings -->
                 
@@ -1589,7 +1397,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Tin Gravel -->
                 <IfCondition condition=':= ticoTinGravelDist = "hugeVeins"'>
                 
-                    <Veins name='ticoTinGravelBaseVeins' block='TConstruct:GravelOre:3' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoTinGravelBaseVeins' block='TConstruct:GravelOre:3' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1608,23 +1416,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoTinGravelFreq * _default_'/>
                         <Replaces block='minecraft:gravel'/>
-                        
-                        <!-- Begin Tin Gravel Huge Vein Hint Veins -->
-                        <Veins name='ticoTinGravelBaseHintVeins' block='TConstruct:GravelOre:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                        </Veins>
-                        <!-- End Tin Gravel Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Gravel Huge Veins) Settings -->
@@ -1636,21 +1427,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <WireframeColor>0x60E8E8E8</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Plains'/>
-                        
-                        <!-- Begin Tin Gravel Huge Vein Hint Veins -->
-                        <Veins name='ticoTinGravelPrefersHintVeins' block='TConstruct:GravelOre:3' inherits='ticoTinGravelBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                            <BiomeType name='Plains'/>
-                        </Veins>
-                        <!-- End Tin Gravel Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Tin Gravel Huge Veins) Settings -->
                 
@@ -1763,7 +1539,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Aluminum Gravel -->
                 <IfCondition condition=':= ticoAluminumGravelDist = "hugeVeins"'>
                 
-                    <Veins name='ticoAluminumGravelBaseVeins' block='TConstruct:GravelOre:4' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoAluminumGravelBaseVeins' block='TConstruct:GravelOre:4' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1782,23 +1558,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoAluminumGravelFreq * _default_'/>
                         <Replaces block='minecraft:gravel'/>
-                        
-                        <!-- Begin Aluminum Gravel Huge Vein Hint Veins -->
-                        <Veins name='ticoAluminumGravelBaseHintVeins' block='TConstruct:GravelOre:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EDEDED</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                        </Veins>
-                        <!-- End Aluminum Gravel Huge Vein Hint Veins -->
-
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Aluminum Gravel Huge Veins) Settings -->
@@ -1810,21 +1569,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <WireframeColor>0x60EDEDED</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Aluminum Gravel Huge Vein Hint Veins -->
-                        <Veins name='ticoAluminumGravelPrefersHintVeins' block='TConstruct:GravelOre:4' inherits='ticoAluminumGravelBaseHintVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EDEDED</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Aluminum Gravel Huge Vein Hint Veins -->
-
                     </Veins>
                     <!-- End Preferred Biome Distribution (Aluminum Gravel Huge Veins) Settings -->
                 
@@ -1903,7 +1647,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
-
             <!-- Setup Nether -->
             <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
                 
@@ -1962,7 +1705,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Cobalt -->
                 <IfCondition condition=':= ticoCobaltDist = "hugeVeins"'>
                 
-                    <Veins name='ticoCobaltBaseVeins' block='TConstruct:SearedBrick:1' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoCobaltBaseVeins' block='TConstruct:SearedBrick:1' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -1981,23 +1724,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 0.5 * 1 * ticoCobaltFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Cobalt Huge Vein Hint Veins -->
-                        <Veins name='ticoCobaltBaseHintVeins' block='TConstruct:SearedBrick:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x601D62B8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Cobalt Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2095,7 +1821,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Ardite -->
                 <IfCondition condition=':= ticoArditeDist = "hugeVeins"'>
                 
-                    <Veins name='ticoArditeBaseVeins' block='TConstruct:SearedBrick:2' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoArditeBaseVeins' block='TConstruct:SearedBrick:2' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2114,23 +1840,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 0.5 * 1 * ticoArditeFreq * _default_'/>
                         <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ardite Huge Vein Hint Veins -->
-                        <Veins name='ticoArditeBaseHintVeins' block='TConstruct:SearedBrick:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60F48A00</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ardite Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2228,7 +1937,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Nether Cobalt Gravel -->
                 <IfCondition condition=':= ticoNetherCobaltGravelDist = "hugeVeins"'>
                 
-                    <Veins name='ticoNetherCobaltGravelBaseVeins' block='TConstruct:GravelOre:5' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoNetherCobaltGravelBaseVeins' block='TConstruct:GravelOre:5' inherits='PresetHugeVeins'>
                         <Description>
                             Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
                             parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
@@ -2247,23 +1956,6 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * ticoNetherCobaltGravelFreq * _default_'/>
                         <Replaces block='minecraft:gravel'/>
-                        
-                        <!-- Begin Nether Cobalt Gravel Huge Vein Hint Veins -->
-                        <Veins name='ticoNetherCobaltGravelBaseHintVeins' block='TConstruct:GravelOre:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x601D62B8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                        </Veins>
-                        <!-- End Nether Cobalt Gravel Huge Vein Hint Veins -->
-
                     </Veins>
                 
                 </IfCondition>
@@ -2339,11 +2031,9 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
             </IfCondition>
             <!-- Nether Setup Complete -->
 
-
- 
         
         </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
+        <!-- Configuration for Custom Ore Generation Complete! -->
     
     </IfModInstalled> 
  

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -9,10 +9,10 @@ Nether Quartz
 
 ================================================================ -->
 
-    
-    <!-- Starting Custom Ore Gen Configuration. -->
+    <!-- Starting Configuration for Custom Ore Generation. -->
     <ConfigSection>
-         
+    
+        
         <!-- Setup Screen Configuration -->
         <ConfigSection>
             <OptionDisplayGroup name='groupVanillaMinecraft' displayName='Vanilla Minecraft' displayState='shown'> 
@@ -104,6 +104,11 @@ Nether Quartz
                             Small Deposits.
                         </Description>
                     </Choice>
+                    <Choice value='hugeVeins' displayValue='Huge Veins'>
+                        <Description>
+                            Huge Veins.
+                        </Description>
+                    </Choice>
                     <Choice value='strategicCloud' displayValue='Clouds'>
                         <Description>
                             Strategic Clouds.
@@ -141,6 +146,11 @@ Nether Quartz
                     <Choice value='smallDeposits' displayValue='Small Deposits'>
                         <Description>
                             Small Deposits.
+                        </Description>
+                    </Choice>
+                    <Choice value='hugeVeins' displayValue='Huge Veins'>
+                        <Description>
+                            Huge Veins.
                         </Description>
                     </Choice>
                     <Choice value='strategicCloud' displayValue='Clouds'>
@@ -336,6 +346,11 @@ Nether Quartz
                     <Choice value='smallDeposits' displayValue='Small Deposits'>
                         <Description>
                             Small Deposits.
+                        </Description>
+                    </Choice>
+                    <Choice value='hugeVeins' displayValue='Huge Veins'>
+                        <Description>
+                            Huge Veins.
                         </Description>
                     </Choice>
                     <Choice value='strategicCloud' displayValue='Clouds'>
@@ -695,6 +710,48 @@ Nether Quartz
             <!-- End  Small Deposits distribution of Iron -->
             
             
+            <!-- Begin  Huge Veins distribution of Iron -->
+            <IfCondition condition=':= vnlaIronDist = "hugeVeins"'>
+            
+                <Veins name='vnlaIronBaseVeins' block='minecraft:iron_ore' inherits='PresetHugeVeins'>
+                    <Description>
+                        Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
+                        parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
+                        branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
+                        enough ore to keep a player supplied for a very long time.
+                        The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
+                        could make finding them much easier and the motherlodes are big enough to supply several people without
+                        shortage.  This might be a good way to add challenge to multiplayer worlds.
+                        Credit: based on feedback by dyrewulf from the MC forums.
+                    </Description>
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x60DDC2AF</WireframeColor>
+                    <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaIronSize * _default_' range=':= 1 * 1 * vnlaIronSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
+                    <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaIronSize * _default_' range=':= 1 * 1 * vnlaIronSize * _default_'/>
+                    <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
+                    <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * vnlaIronFreq * _default_'/>
+                    <Setting name='BranchHeightLimit' avg=':= 10.5'/>
+                    <Replaces block='minecraft:stone'/>
+                </Veins>
+                
+                <!-- Begin Preferred Biome Distribution (Iron Huge Veins) Settings -->
+                <Veins name='vnlaIronPrefersVeins' block='minecraft:iron_ore' inherits='vnlaIronBaseVeins'>
+                    <Description>
+                        Spawns 2 more times in preferred biomes.
+                    </Description>
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x60DDC2AF</WireframeColor>
+                    <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
+                    <BiomeType name='Cold'/>
+                    <BiomeType name='Ocean' weight='-1'/>
+                </Veins>
+                <!-- End Preferred Biome Distribution (Iron Huge Veins) Settings -->
+            
+            </IfCondition>
+            <!-- End  Huge Veins distribution of Iron -->
+            
+            
             <!-- Begin  StrategicCloud distribution of Iron -->
             <IfCondition condition=':= vnlaIronDist = "strategicCloud"'>
             
@@ -831,6 +888,49 @@ Nether Quartz
             
             </IfCondition>
             <!-- End  Small Deposits distribution of Gold -->
+            
+            
+            <!-- Begin  Huge Veins distribution of Gold -->
+            <IfCondition condition=':= vnlaGoldDist = "hugeVeins"'>
+            
+                <Veins name='vnlaGoldBaseVeins' block='minecraft:gold_ore' inherits='PresetHugeVeins'>
+                    <Description>
+                        Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
+                        parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
+                        branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
+                        enough ore to keep a player supplied for a very long time.
+                        The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
+                        could make finding them much easier and the motherlodes are big enough to supply several people without
+                        shortage.  This might be a good way to add challenge to multiplayer worlds.
+                        Credit: based on feedback by dyrewulf from the MC forums.
+                    </Description>
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x60EAEF57</WireframeColor>
+                    <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * vnlaGoldSize * _default_' range=':= 1 * 0.8 * vnlaGoldSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                    <Setting name='SegmentRadius' avg=':= 1 * 0.8 * vnlaGoldSize * _default_' range=':= 1 * 0.8 * vnlaGoldSize * _default_'/>
+                    <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
+                    <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * vnlaGoldFreq * _default_'/>
+                    <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
+                    <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
+                    <Setting name='BranchHeightLimit' avg=':= 10'/>
+                    <Replaces block='minecraft:stone'/>
+                </Veins>
+                
+                <!-- Begin Preferred Biome Distribution (Gold Huge Veins) Settings -->
+                <Veins name='vnlaGoldPrefersVeins' block='minecraft:gold_ore' inherits='vnlaGoldBaseVeins'>
+                    <Description>
+                        Spawns 2 more times in preferred biomes.
+                    </Description>
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x60EAEF57</WireframeColor>
+                    <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
+                    <BiomeType name='Forest'/>
+                </Veins>
+                <!-- End Preferred Biome Distribution (Gold Huge Veins) Settings -->
+            
+            </IfCondition>
+            <!-- End  Huge Veins distribution of Gold -->
             
             
             <!-- Begin  StrategicCloud distribution of Gold -->
@@ -1498,7 +1598,6 @@ Nether Quartz
         </IfCondition>
         <!-- Overworld Setup Complete -->
 
-
         <!-- Setup Nether -->
         <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
             
@@ -1558,6 +1657,34 @@ Nether Quartz
             
             </IfCondition>
             <!-- End  Small Deposits distribution of Nether Quartz -->
+            
+            
+            <!-- Begin  Huge Veins distribution of Nether Quartz -->
+            <IfCondition condition=':= vnlaNetherQuartzDist = "hugeVeins"'>
+            
+                <Veins name='vnlaNetherQuartzBaseVeins' block='minecraft:quartz_ore' inherits='PresetHugeVeins'>
+                    <Description>
+                        Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
+                        parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
+                        branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
+                        enough ore to keep a player supplied for a very long time.
+                        The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
+                        could make finding them much easier and the motherlodes are big enough to supply several people without
+                        shortage.  This might be a good way to add challenge to multiplayer worlds.
+                        Credit: based on feedback by dyrewulf from the MC forums.
+                    </Description>
+                    <DrawWireframe>:=drawWireframes</DrawWireframe>
+                    <WireframeColor>0x60DBCCBF</WireframeColor>
+                    <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaNetherQuartzSize * _default_' range=':= 1 * 1 * vnlaNetherQuartzSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
+                    <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaNetherQuartzSize * _default_' range=':= 1 * 1 * vnlaNetherQuartzSize * _default_'/>
+                    <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
+                    <Setting name='MotherlodeFrequency' avg=':= 4 * 1 * vnlaNetherQuartzFreq * _default_'/>
+                    <Replaces block='minecraft:netherrack'/>
+                </Veins>
+            
+            </IfCondition>
+            <!-- End  Huge Veins distribution of Nether Quartz -->
             
             
             <!-- Begin  StrategicCloud distribution of Nether Quartz -->
@@ -1629,11 +1756,9 @@ Nether Quartz
         </IfCondition>
         <!-- Nether Setup Complete -->
 
-
- 
-
+    
     </ConfigSection>
-    <!-- Custom Ore Gen Configuration Complete! -->
+    <!-- Configuration for Custom Ore Generation Complete! -->
 
 
 


### PR DESCRIPTION
Up until now, I had neglected to set huge veins to the huge veins preset, so I had been under the assumption that they were like the layered veins, only slightly larger and harder to find.  To make them easier to spot, I added hint veins.

Now that I've found the mistake, I fixed the preset, and discovered that the extremely long tendrils prevents the need for hint veins.  Besides, hint or not, Draco's "Ore Flowers" mod does a nice job of hinting at an ore's presence. ;)

I also added huge veins for vanilla iron, gold, and nether quartz.

Finally, I've also fixed some comments to give the name of the mod as "Custom Ore Generation," rather than "Custom Ore Gen," which is something of a itch that needed scratching. ;)