### PR TITLE
Nether quartz was replacing stone instead of netherrack.  Fixed.

### DIFF
--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -336,7 +336,6 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                     <Replaces block='denseores:block0:4' />
                     <Replaces block='denseores:block0:5' />
                     <Replaces block='denseores:block0:6' />
-                    <Replaces block='denseores:block0:7' />
                 </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
                 
@@ -1267,20 +1266,13 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
             <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
                 
                 <!-- Starting Original Nether Ore Removal -->
-                <Substitute name='dnsoNetherOreSubstitute0' block='minecraft:stone'>
+                <Substitute name='dnsoNetherOreSubstitute0' block='minecraft:netherrack'>
                     <Description>
                         Replace vanilla-generated ore clusters.
                     </Description>
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='denseores:block0:0' />
-                    <Replaces block='denseores:block0:1' />
-                    <Replaces block='denseores:block0:2' />
-                    <Replaces block='denseores:block0:3' />
-                    <Replaces block='denseores:block0:4' />
-                    <Replaces block='denseores:block0:5' />
-                    <Replaces block='denseores:block0:6' />
                     <Replaces block='denseores:block0:7' />
                 </Substitute>
                 <!-- Original Nether Ore Removal Complete -->
@@ -1303,7 +1295,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoNetherQuartzSize * _default_' range=':= 1 * 1 * dnsoNetherQuartzSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * 1 * dnsoNetherQuartzFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
+                        <Replaces block='minecraft:netherrack'/>
                     </Veins>
                 
                 </IfCondition>
@@ -1331,7 +1323,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoNetherQuartzSize * _default_' range=':= 1 * 1 * dnsoNetherQuartzSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * 1 * dnsoNetherQuartzFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
+                        <Replaces block='minecraft:netherrack'/>
                     </Veins>
                 
                 </IfCondition>
@@ -1358,7 +1350,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * dnsoNetherQuartzSize * _default_' range=':= 1 * 1 * 1 * dnsoNetherQuartzSize  * _default_'/>
                         <Setting name='DistributionFrequency' avg=':= 2 * 1 * dnsoNetherQuartzFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
+                        <Replaces block='minecraft:netherrack'/>
                         
                         <!-- Begin Nether Quartz Strategic Cloud Hint Veins -->
                         <Veins name='dnsoNetherQuartzBaseHintVeins' block='denseores:block0:7' inherits='PresetHintVeins'>
@@ -1372,7 +1364,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                             <WireframeColor>0x60CDC1B3</WireframeColor>
                             <Replaces block='minecraft:dirt'/>
                             <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
+                            <Replaces block='minecraft:netherrack'/>
                         </Veins>
                         <!-- End Nether Quartz Strategic Cloud Hint Veins -->
 
@@ -1394,7 +1386,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <Setting name='Size' avg=':= 1 * 1 * dnsoNetherQuartzSize * _default_'/>
                         <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
                         <Setting name='Frequency' avg=':= 2 * 1 * dnsoNetherQuartzFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
+                        <Replaces block='minecraft:netherrack'/>
                     </StandardGen>
                 
                 </IfCondition>


### PR DESCRIPTION
Made a typo in the INI file; Sprocket gave Nether Quartz the default material replacement of minecraft:stone.  The replace field is now correct.