### PR TITLE
Some fixes, some changes

### DIFF
--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -1,12 +1,8 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Applied Energistics Module
-
-Generates: 
-Quartz, Charged Quartz
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Applied Energistics" Module: This
+      configuration covers quartz and charged quartz.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="appliedenergistics2">
@@ -125,8 +121,8 @@ Quartz, Charged Quartz
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='appliedenergistics2:tile.OreQuartz:0' />
-                    <Replaces block='appliedenergistics2:tile.OreQuartzCharged:0' />
+                    <Replaces block='appliedenergistics2:tile.OreQuartz' />
+                    <Replaces block='appliedenergistics2:tile.OreQuartzCharged' />
                 </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
                 
@@ -137,14 +133,15 @@ Quartz, Charged Quartz
                 <!-- Begin LayeredVeins distribution of Quartz -->
                 <IfCondition condition=':= apenQuartzDist = "layeredVeins"'>
                 
-                    <Veins name='apenQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartz' inherits='PresetLayeredVeins'>
+                    <Veins name='apenQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartz'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609BBEC2</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * apenQuartzSize * _default_' range=':= 1 * 1 * apenQuartzSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * apenQuartzSize * _default_' range=':= 1 * 1 * apenQuartzSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * apenQuartzFreq * _default_'/>
@@ -153,7 +150,7 @@ Quartz, Charged Quartz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Quartz Layered Veins) Settings -->
-                    <Veins name='apenQuartzPrefersVeins' block='appliedenergistics2:tile.OreQuartz' inherits='apenQuartzBaseVeins'>
+                    <Veins name='apenQuartzPrefersVeins' block='appliedenergistics2:tile.OreQuartz'  inherits='apenQuartzBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -171,22 +168,24 @@ Quartz, Charged Quartz
                 <!-- Begin  Small Deposits distribution of Quartz -->
                 <IfCondition condition=':= apenQuartzDist = "smallDeposits"'>
                 
-                    <Veins name='apenQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartz' inherits='PresetSmallDeposits'>
+                    <Veins name='apenQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartz'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609BBEC2</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * apenQuartzSize * _default_' range=':= 1 * 1 * apenQuartzSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * apenQuartzSize * _default_' range=':= 1 * 1 * apenQuartzSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * apenQuartzFreq * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Quartz Small Deposits) Settings -->
-                    <Veins name='apenQuartzPrefersVeins' block='appliedenergistics2:tile.OreQuartz' inherits='apenQuartzBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Quartz Deposit Veins) Settings -->
+                    <Veins name='apenQuartzPrefersVeins' block='appliedenergistics2:tile.OreQuartz'  inherits='apenQuartzBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -195,7 +194,7 @@ Quartz, Charged Quartz
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Desert'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Quartz Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Quartz Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Quartz -->
@@ -204,16 +203,26 @@ Quartz, Charged Quartz
                 <!-- Begin  Huge Veins distribution of Quartz -->
                 <IfCondition condition=':= apenQuartzDist = "hugeVeins"'>
                 
-                    <Veins name='apenQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartz' inherits='PresetHugeVeins'>
+                    <Veins name='apenQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartz'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609BBEC2</WireframeColor>
@@ -227,7 +236,7 @@ Quartz, Charged Quartz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Quartz Huge Veins) Settings -->
-                    <Veins name='apenQuartzPrefersVeins' block='appliedenergistics2:tile.OreQuartz' inherits='apenQuartzBaseVeins'>
+                    <Veins name='apenQuartzPrefersVeins' block='appliedenergistics2:tile.OreQuartz'  inherits='apenQuartzBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -247,12 +256,16 @@ Quartz, Charged Quartz
                 
                     <Cloud name='apenQuartzBaseCloud' block='appliedenergistics2:tile.OreQuartz' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609BBEC2</WireframeColor>
@@ -267,10 +280,16 @@ Quartz, Charged Quartz
                         <!-- Begin Quartz Strategic Cloud Hint Veins -->
                         <Veins name='apenQuartzBaseHintVeins' block='appliedenergistics2:tile.OreQuartz' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x609BBEC2</WireframeColor>
@@ -314,14 +333,15 @@ Quartz, Charged Quartz
                 <!-- Begin LayeredVeins distribution of Charged Quartz -->
                 <IfCondition condition=':= apenChargedQuartzDist = "layeredVeins"'>
                 
-                    <Veins name='apenChargedQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartzCharged' inherits='PresetLayeredVeins'>
+                    <Veins name='apenChargedQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartzCharged'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6093C6FF</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * apenChargedQuartzSize * _default_' range=':= 1 * 1 * apenChargedQuartzSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * apenChargedQuartzSize * _default_' range=':= 1 * 1 * apenChargedQuartzSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.5 * apenChargedQuartzFreq * _default_'/>
@@ -330,7 +350,7 @@ Quartz, Charged Quartz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Charged Quartz Layered Veins) Settings -->
-                    <Veins name='apenChargedQuartzPrefersVeins' block='appliedenergistics2:tile.OreQuartzCharged' inherits='apenChargedQuartzBaseVeins'>
+                    <Veins name='apenChargedQuartzPrefersVeins' block='appliedenergistics2:tile.OreQuartzCharged'  inherits='apenChargedQuartzBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -348,22 +368,24 @@ Quartz, Charged Quartz
                 <!-- Begin  Small Deposits distribution of Charged Quartz -->
                 <IfCondition condition=':= apenChargedQuartzDist = "smallDeposits"'>
                 
-                    <Veins name='apenChargedQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartzCharged' inherits='PresetSmallDeposits'>
+                    <Veins name='apenChargedQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartzCharged'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6093C6FF</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * apenChargedQuartzSize * _default_' range=':= 1 * 1 * apenChargedQuartzSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * apenChargedQuartzSize * _default_' range=':= 1 * 1 * apenChargedQuartzSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.5 * apenChargedQuartzFreq * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Charged Quartz Small Deposits) Settings -->
-                    <Veins name='apenChargedQuartzPrefersVeins' block='appliedenergistics2:tile.OreQuartzCharged' inherits='apenChargedQuartzBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Charged Quartz Deposit Veins) Settings -->
+                    <Veins name='apenChargedQuartzPrefersVeins' block='appliedenergistics2:tile.OreQuartzCharged'  inherits='apenChargedQuartzBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -372,7 +394,7 @@ Quartz, Charged Quartz
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Desert'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Charged Quartz Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Charged Quartz Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Charged Quartz -->
@@ -381,16 +403,26 @@ Quartz, Charged Quartz
                 <!-- Begin  Huge Veins distribution of Charged Quartz -->
                 <IfCondition condition=':= apenChargedQuartzDist = "hugeVeins"'>
                 
-                    <Veins name='apenChargedQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartzCharged' inherits='PresetHugeVeins'>
+                    <Veins name='apenChargedQuartzBaseVeins' block='appliedenergistics2:tile.OreQuartzCharged'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6093C6FF</WireframeColor>
@@ -404,7 +436,7 @@ Quartz, Charged Quartz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Charged Quartz Huge Veins) Settings -->
-                    <Veins name='apenChargedQuartzPrefersVeins' block='appliedenergistics2:tile.OreQuartzCharged' inherits='apenChargedQuartzBaseVeins'>
+                    <Veins name='apenChargedQuartzPrefersVeins' block='appliedenergistics2:tile.OreQuartzCharged'  inherits='apenChargedQuartzBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -424,12 +456,16 @@ Quartz, Charged Quartz
                 
                     <Cloud name='apenChargedQuartzBaseCloud' block='appliedenergistics2:tile.OreQuartzCharged' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6093C6FF</WireframeColor>
@@ -444,10 +480,16 @@ Quartz, Charged Quartz
                         <!-- Begin Charged Quartz Strategic Cloud Hint Veins -->
                         <Veins name='apenChargedQuartzBaseHintVeins' block='appliedenergistics2:tile.OreQuartzCharged' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6093C6FF</WireframeColor>

--- a/src/main/resources/config/modules/ArsMagica2.xml
+++ b/src/main/resources/config/modules/ArsMagica2.xml
@@ -1,12 +1,8 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Ars Magica 2 Module
-
-Generates: 
-Vinteum, Chimerite, Blue Topaz
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Ars Magica 2" Module: This configuration
+      covers vinteum, chimerite, and blue topaz.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="arsmagica2">
@@ -154,7 +150,7 @@ Vinteum, Chimerite, Blue Topaz
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='arsmagica2:vinteumOre:0' />
+                    <Replaces block='arsmagica2:vinteumOre' />
                     <Replaces block='arsmagica2:vinteumOre:1' />
                     <Replaces block='arsmagica2:vinteumOre:2' />
                 </Substitute>
@@ -167,14 +163,15 @@ Vinteum, Chimerite, Blue Topaz
                 <!-- Begin Layered Veins distribution of Vinteum -->
                 <IfCondition condition=':= arsmVinteumDist = "layeredVeins"'>
                 
-                    <Veins name='arsmVinteumBaseVeins' block='arsmagica2:vinteumOre' inherits='PresetLayeredVeins'>
+                    <Veins name='arsmVinteumBaseVeins' block='arsmagica2:vinteumOre'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x605364EE</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * arsmVinteumSize * _default_' range=':= 1 * 0.8 * arsmVinteumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 8' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 8' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * arsmVinteumSize * _default_' range=':= 1 * 0.8 * arsmVinteumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * arsmVinteumFreq * _default_'/>
@@ -185,7 +182,7 @@ Vinteum, Chimerite, Blue Topaz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Vinteum Layered Veins) Settings -->
-                    <Veins name='arsmVinteumPrefersVeins' block='arsmagica2:vinteumOre' inherits='arsmVinteumBaseVeins'>
+                    <Veins name='arsmVinteumPrefersVeins' block='arsmagica2:vinteumOre'  inherits='arsmVinteumBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -203,16 +200,26 @@ Vinteum, Chimerite, Blue Topaz
                 <!-- Begin  Huge Veins distribution of Vinteum -->
                 <IfCondition condition=':= arsmVinteumDist = "hugeVeins"'>
                 
-                    <Veins name='arsmVinteumBaseVeins' block='arsmagica2:vinteumOre' inherits='PresetHugeVeins'>
+                    <Veins name='arsmVinteumBaseVeins' block='arsmagica2:vinteumOre'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x605364EE</WireframeColor>
@@ -228,7 +235,7 @@ Vinteum, Chimerite, Blue Topaz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Vinteum Huge Veins) Settings -->
-                    <Veins name='arsmVinteumPrefersVeins' block='arsmagica2:vinteumOre' inherits='arsmVinteumBaseVeins'>
+                    <Veins name='arsmVinteumPrefersVeins' block='arsmagica2:vinteumOre'  inherits='arsmVinteumBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -248,12 +255,16 @@ Vinteum, Chimerite, Blue Topaz
                 
                     <Cloud name='arsmVinteumBaseCloud' block='arsmagica2:vinteumOre' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x605364EE</WireframeColor>
@@ -268,10 +279,16 @@ Vinteum, Chimerite, Blue Topaz
                         <!-- Begin Vinteum Strategic Cloud Hint Veins -->
                         <Veins name='arsmVinteumBaseHintVeins' block='arsmagica2:vinteumOre' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x605364EE</WireframeColor>
@@ -315,14 +332,15 @@ Vinteum, Chimerite, Blue Topaz
                 <!-- Begin Layered Veins distribution of Chimerite -->
                 <IfCondition condition=':= arsmChimeriteDist = "layeredVeins"'>
                 
-                    <Veins name='arsmChimeriteBaseVeins' block='arsmagica2:vinteumOre:1' inherits='PresetLayeredVeins'>
+                    <Veins name='arsmChimeriteBaseVeins' block='arsmagica2:vinteumOre:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B8E6C6</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * arsmChimeriteSize * _default_' range=':= 1 * 0.8 * arsmChimeriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * arsmChimeriteSize * _default_' range=':= 1 * 0.8 * arsmChimeriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * arsmChimeriteFreq * _default_'/>
@@ -331,7 +349,7 @@ Vinteum, Chimerite, Blue Topaz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Chimerite Layered Veins) Settings -->
-                    <Veins name='arsmChimeritePrefersVeins' block='arsmagica2:vinteumOre:1' inherits='arsmChimeriteBaseVeins'>
+                    <Veins name='arsmChimeritePrefersVeins' block='arsmagica2:vinteumOre:1'  inherits='arsmChimeriteBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -349,16 +367,26 @@ Vinteum, Chimerite, Blue Topaz
                 <!-- Begin  Huge Veins distribution of Chimerite -->
                 <IfCondition condition=':= arsmChimeriteDist = "hugeVeins"'>
                 
-                    <Veins name='arsmChimeriteBaseVeins' block='arsmagica2:vinteumOre:1' inherits='PresetHugeVeins'>
+                    <Veins name='arsmChimeriteBaseVeins' block='arsmagica2:vinteumOre:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B8E6C6</WireframeColor>
@@ -372,7 +400,7 @@ Vinteum, Chimerite, Blue Topaz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Chimerite Huge Veins) Settings -->
-                    <Veins name='arsmChimeritePrefersVeins' block='arsmagica2:vinteumOre:1' inherits='arsmChimeriteBaseVeins'>
+                    <Veins name='arsmChimeritePrefersVeins' block='arsmagica2:vinteumOre:1'  inherits='arsmChimeriteBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -392,12 +420,16 @@ Vinteum, Chimerite, Blue Topaz
                 
                     <Cloud name='arsmChimeriteBaseCloud' block='arsmagica2:vinteumOre:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B8E6C6</WireframeColor>
@@ -412,10 +444,16 @@ Vinteum, Chimerite, Blue Topaz
                         <!-- Begin Chimerite Strategic Cloud Hint Veins -->
                         <Veins name='arsmChimeriteBaseHintVeins' block='arsmagica2:vinteumOre:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60B8E6C6</WireframeColor>
@@ -459,14 +497,15 @@ Vinteum, Chimerite, Blue Topaz
                 <!-- Begin Layered Veins distribution of Blue Topaz -->
                 <IfCondition condition=':= arsmBlueTopazDist = "layeredVeins"'>
                 
-                    <Veins name='arsmBlueTopazBaseVeins' block='arsmagica2:vinteumOre:2' inherits='PresetLayeredVeins'>
+                    <Veins name='arsmBlueTopazBaseVeins' block='arsmagica2:vinteumOre:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607EE5F4</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * arsmBlueTopazSize * _default_' range=':= 1 * 0.8 * arsmBlueTopazSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * arsmBlueTopazSize * _default_' range=':= 1 * 0.8 * arsmBlueTopazSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * arsmBlueTopazFreq * _default_'/>
@@ -475,7 +514,7 @@ Vinteum, Chimerite, Blue Topaz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Blue Topaz Layered Veins) Settings -->
-                    <Veins name='arsmBlueTopazPrefersVeins' block='arsmagica2:vinteumOre:2' inherits='arsmBlueTopazBaseVeins'>
+                    <Veins name='arsmBlueTopazPrefersVeins' block='arsmagica2:vinteumOre:2'  inherits='arsmBlueTopazBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -493,16 +532,26 @@ Vinteum, Chimerite, Blue Topaz
                 <!-- Begin  Huge Veins distribution of Blue Topaz -->
                 <IfCondition condition=':= arsmBlueTopazDist = "hugeVeins"'>
                 
-                    <Veins name='arsmBlueTopazBaseVeins' block='arsmagica2:vinteumOre:2' inherits='PresetHugeVeins'>
+                    <Veins name='arsmBlueTopazBaseVeins' block='arsmagica2:vinteumOre:2'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607EE5F4</WireframeColor>
@@ -516,7 +565,7 @@ Vinteum, Chimerite, Blue Topaz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Blue Topaz Huge Veins) Settings -->
-                    <Veins name='arsmBlueTopazPrefersVeins' block='arsmagica2:vinteumOre:2' inherits='arsmBlueTopazBaseVeins'>
+                    <Veins name='arsmBlueTopazPrefersVeins' block='arsmagica2:vinteumOre:2'  inherits='arsmBlueTopazBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -536,12 +585,16 @@ Vinteum, Chimerite, Blue Topaz
                 
                     <Cloud name='arsmBlueTopazBaseCloud' block='arsmagica2:vinteumOre:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607EE5F4</WireframeColor>
@@ -556,10 +609,16 @@ Vinteum, Chimerite, Blue Topaz
                         <!-- Begin Blue Topaz Strategic Cloud Hint Veins -->
                         <Veins name='arsmBlueTopazBaseHintVeins' block='arsmagica2:vinteumOre:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x607EE5F4</WireframeColor>

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -1,12 +1,9 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Biomes O Plenty Module
-
-Generates: 
-EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Biomes O Plenty" Module: This
+      configuration covers enderamathyst, ruby, peridot, topaz,
+      tanzanite, apatite, and sapphire.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="BiomesOPlenty">
@@ -296,17 +293,21 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 <!-- Begin Sparse Veins distribution of Ruby -->
                 <IfCondition condition=':= boplRubyDist = "sparseVeins"'>
                 
-                    <Veins name='boplRubyBaseVeins' block='BiomesOPlenty:gemOre:2' inherits='PresetSparseVeins'>
+                    <Veins name='boplRubyBaseVeins' block='BiomesOPlenty:gemOre:2'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C60031</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * boplRubySize * _default_' range=':= 1 * 0.5 * boplRubySize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplRubySize * _default_' range=':= 1 * 0.5 * boplRubySize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 0.4 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * boplRubyFreq * _default_'/>
@@ -315,8 +316,8 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplRubySize * 0.7 * _default_' range=':= 1 * 0.5 * boplRubySize * 0.5 * _default_'/>
                         <Setting name='SegmentAngle' avg=':= 0.6' range=':= 0.40'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Sandy'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -328,12 +329,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 
                     <Cloud name='boplRubyBaseCloud' block='BiomesOPlenty:gemOre:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C60031</WireframeColor>
@@ -349,10 +354,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <!-- Begin Ruby Strategic Cloud Hint Veins -->
                         <Veins name='boplRubyBaseHintVeins' block='BiomesOPlenty:gemOre:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60C60031</WireframeColor>
@@ -396,17 +407,21 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 <!-- Begin Sparse Veins distribution of Peridot -->
                 <IfCondition condition=':= boplPeridotDist = "sparseVeins"'>
                 
-                    <Veins name='boplPeridotBaseVeins' block='BiomesOPlenty:gemOre:4' inherits='PresetSparseVeins'>
+                    <Veins name='boplPeridotBaseVeins' block='BiomesOPlenty:gemOre:4'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60076855</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * boplPeridotSize * _default_' range=':= 1 * 0.5 * boplPeridotSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplPeridotSize * _default_' range=':= 1 * 0.5 * boplPeridotSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 0.4 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * boplPeridotFreq * _default_'/>
@@ -415,10 +430,10 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplPeridotSize * 0.7 * _default_' range=':= 1 * 0.5 * boplPeridotSize * 0.5 * _default_'/>
                         <Setting name='SegmentAngle' avg=':= 0.6' range=':= 0.40'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Plains'/>
                         <BiomeType name='Cold' weight='-1'/>
                         <BiomeType name='Dry' weight='-1'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -430,12 +445,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 
                     <Cloud name='boplPeridotBaseCloud' block='BiomesOPlenty:gemOre:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60076855</WireframeColor>
@@ -453,10 +472,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <!-- Begin Peridot Strategic Cloud Hint Veins -->
                         <Veins name='boplPeridotBaseHintVeins' block='BiomesOPlenty:gemOre:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60076855</WireframeColor>
@@ -504,17 +529,21 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 <!-- Begin Sparse Veins distribution of Topaz -->
                 <IfCondition condition=':= boplTopazDist = "sparseVeins"'>
                 
-                    <Veins name='boplTopazBaseVeins' block='BiomesOPlenty:gemOre:6' inherits='PresetSparseVeins'>
+                    <Veins name='boplTopazBaseVeins' block='BiomesOPlenty:gemOre:6'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D95A03</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * boplTopazSize * _default_' range=':= 1 * 0.5 * boplTopazSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplTopazSize * _default_' range=':= 1 * 0.5 * boplTopazSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 0.4 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * boplTopazFreq * _default_'/>
@@ -523,8 +552,8 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplTopazSize * 0.7 * _default_' range=':= 1 * 0.5 * boplTopazSize * 0.5 * _default_'/>
                         <Setting name='SegmentAngle' avg=':= 0.6' range=':= 0.40'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Jungle'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -536,12 +565,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 
                     <Cloud name='boplTopazBaseCloud' block='BiomesOPlenty:gemOre:6' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D95A03</WireframeColor>
@@ -557,10 +590,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <!-- Begin Topaz Strategic Cloud Hint Veins -->
                         <Veins name='boplTopazBaseHintVeins' block='BiomesOPlenty:gemOre:6' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60D95A03</WireframeColor>
@@ -604,17 +643,21 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 <!-- Begin Sparse Veins distribution of Tanzanite -->
                 <IfCondition condition=':= boplTanzaniteDist = "sparseVeins"'>
                 
-                    <Veins name='boplTanzaniteBaseVeins' block='BiomesOPlenty:gemOre:8' inherits='PresetSparseVeins'>
+                    <Veins name='boplTanzaniteBaseVeins' block='BiomesOPlenty:gemOre:8'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607701B9</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * boplTanzaniteSize * _default_' range=':= 1 * 0.5 * boplTanzaniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplTanzaniteSize * _default_' range=':= 1 * 0.5 * boplTanzaniteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 0.4 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * boplTanzaniteFreq * _default_'/>
@@ -623,8 +666,8 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplTanzaniteSize * 0.7 * _default_' range=':= 1 * 0.5 * boplTanzaniteSize * 0.5 * _default_'/>
                         <Setting name='SegmentAngle' avg=':= 0.6' range=':= 0.40'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Cold'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -636,12 +679,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 
                     <Cloud name='boplTanzaniteBaseCloud' block='BiomesOPlenty:gemOre:8' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607701B9</WireframeColor>
@@ -657,10 +704,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <!-- Begin Tanzanite Strategic Cloud Hint Veins -->
                         <Veins name='boplTanzaniteBaseHintVeins' block='BiomesOPlenty:gemOre:8' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x607701B9</WireframeColor>
@@ -704,24 +757,28 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 <!-- Begin Sparse Veins distribution of Apatite -->
                 <IfCondition condition=':= boplApatiteDist = "sparseVeins"'>
                 
-                    <Veins name='boplApatiteBaseVeins' block='BiomesOPlenty:gemOre:10' inherits='PresetSparseVeins'>
+                    <Veins name='boplApatiteBaseVeins' block='BiomesOPlenty:gemOre:10'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60109D81</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * boplApatiteSize * _default_' range=':= 1 * 1 * boplApatiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 55' range=':= 8' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 55' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * boplApatiteSize * _default_' range=':= 1 * 1 * boplApatiteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 5 * boplApatiteFreq * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Swamp'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -733,12 +790,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 
                     <Cloud name='boplApatiteBaseCloud' block='BiomesOPlenty:gemOre:10' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60109D81</WireframeColor>
@@ -754,10 +815,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <!-- Begin Apatite Strategic Cloud Hint Veins -->
                         <Veins name='boplApatiteBaseHintVeins' block='BiomesOPlenty:gemOre:10' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60109D81</WireframeColor>
@@ -801,17 +868,21 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 <!-- Begin Sparse Veins distribution of Sapphire -->
                 <IfCondition condition=':= boplSapphireDist = "sparseVeins"'>
                 
-                    <Veins name='boplSapphireBaseVeins' block='BiomesOPlenty:gemOre:12' inherits='PresetSparseVeins'>
+                    <Veins name='boplSapphireBaseVeins' block='BiomesOPlenty:gemOre:12'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x603494C3</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * boplSapphireSize * _default_' range=':= 1 * 0.5 * boplSapphireSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplSapphireSize * _default_' range=':= 1 * 0.5 * boplSapphireSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 0.4 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * boplSapphireFreq * _default_'/>
@@ -820,8 +891,8 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplSapphireSize * 0.7 * _default_' range=':= 1 * 0.5 * boplSapphireSize * 0.5 * _default_'/>
                         <Setting name='SegmentAngle' avg=':= 0.6' range=':= 0.40'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Ocean'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -833,12 +904,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 
                     <Cloud name='boplSapphireBaseCloud' block='BiomesOPlenty:gemOre:12' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x603494C3</WireframeColor>
@@ -854,10 +929,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <!-- Begin Sapphire Strategic Cloud Hint Veins -->
                         <Veins name='boplSapphireBaseHintVeins' block='BiomesOPlenty:gemOre:12' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x603494C3</WireframeColor>
@@ -911,7 +992,7 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='BiomesOPlenty:gemOre:0' />
+                    <Replaces block='BiomesOPlenty:gemOre' />
                 </Substitute>
                 <!-- Original End Ore Removal Complete -->
                 
@@ -922,14 +1003,15 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 <!-- Begin Layered Veins distribution of EnderAmathyst -->
                 <IfCondition condition=':= boplEnderAmathystDist = "layeredVeins"'>
                 
-                    <Veins name='boplEnderAmathystBaseVeins' block='BiomesOPlenty:gemOre' inherits='PresetLayeredVeins'>
+                    <Veins name='boplEnderAmathystBaseVeins' block='BiomesOPlenty:gemOre'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DD4EEA</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * boplEnderAmathystSize * _default_' range=':= 1 * 1 * boplEnderAmathystSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * boplEnderAmathystSize * _default_' range=':= 1 * 1 * boplEnderAmathystSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * boplEnderAmathystFreq * _default_'/>
@@ -943,16 +1025,26 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 <!-- Begin  Huge Veins distribution of EnderAmathyst -->
                 <IfCondition condition=':= boplEnderAmathystDist = "hugeVeins"'>
                 
-                    <Veins name='boplEnderAmathystBaseVeins' block='BiomesOPlenty:gemOre' inherits='PresetHugeVeins'>
+                    <Veins name='boplEnderAmathystBaseVeins' block='BiomesOPlenty:gemOre'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DD4EEA</WireframeColor>
@@ -973,12 +1065,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                 
                     <Cloud name='boplEnderAmathystBaseCloud' block='BiomesOPlenty:gemOre' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DD4EEA</WireframeColor>
@@ -993,10 +1089,16 @@ EnderAmathyst, Ruby, Peridot, Topaz, Tanzanite, Apatite, Sapphire
                         <!-- Begin EnderAmathyst Strategic Cloud Hint Veins -->
                         <Veins name='boplEnderAmathystBaseHintVeins' block='BiomesOPlenty:gemOre' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60DD4EEA</WireframeColor>

--- a/src/main/resources/config/modules/Chisel2.xml
+++ b/src/main/resources/config/modules/Chisel2.xml
@@ -1,12 +1,8 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Chisel 2 Module
-
-Generates: 
-Andesite, Diorite, Granite, Limestone, Marble
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Chisel 2" Module: This configuration
+      covers andesite, diorite, granite, limestone, and marble.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="chisel">
@@ -157,11 +153,11 @@ Andesite, Diorite, Granite, Limestone, Marble
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='chisel:andesite:0' />
-                    <Replaces block='chisel:diorite:0' />
-                    <Replaces block='chisel:granite:0' />
-                    <Replaces block='chisel:limestone:0' />
-                    <Replaces block='chisel:marble:0' />
+                    <Replaces block='chisel:andesite' />
+                    <Replaces block='chisel:diorite' />
+                    <Replaces block='chisel:granite' />
+                    <Replaces block='chisel:limestone' />
+                    <Replaces block='chisel:marble' />
                 </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
                 
@@ -172,14 +168,15 @@ Andesite, Diorite, Granite, Limestone, Marble
                 <!-- Begin Layered Veins distribution of Andesite -->
                 <IfCondition condition=':= chslAndesiteDist = "layeredVeins"'>
                 
-                    <Veins name='chslAndesiteBaseVeins' block='chisel:andesite' inherits='PresetLayeredVeins'>
+                    <Veins name='chslAndesiteBaseVeins' block='chisel:andesite'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60CECABE</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * chslAndesiteSize * _default_' range=':= 1 * 1 * chslAndesiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * chslAndesiteSize * _default_' range=':= 1 * 1 * chslAndesiteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * chslAndesiteFreq * _default_'/>
@@ -187,7 +184,7 @@ Andesite, Diorite, Granite, Limestone, Marble
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Andesite Layered Veins) Settings -->
-                    <Veins name='chslAndesitePrefersVeins' block='chisel:andesite' inherits='chslAndesiteBaseVeins'>
+                    <Veins name='chslAndesitePrefersVeins' block='chisel:andesite'  inherits='chslAndesiteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -209,14 +206,15 @@ Andesite, Diorite, Granite, Limestone, Marble
                 <!-- Begin Layered Veins distribution of Diorite -->
                 <IfCondition condition=':= chslDioriteDist = "layeredVeins"'>
                 
-                    <Veins name='chslDioriteBaseVeins' block='chisel:diorite' inherits='PresetLayeredVeins'>
+                    <Veins name='chslDioriteBaseVeins' block='chisel:diorite'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E6E5D3</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * chslDioriteSize * _default_' range=':= 1 * 1 * chslDioriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * chslDioriteSize * _default_' range=':= 1 * 1 * chslDioriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * chslDioriteFreq * _default_'/>
@@ -224,7 +222,7 @@ Andesite, Diorite, Granite, Limestone, Marble
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Diorite Layered Veins) Settings -->
-                    <Veins name='chslDioritePrefersVeins' block='chisel:diorite' inherits='chslDioriteBaseVeins'>
+                    <Veins name='chslDioritePrefersVeins' block='chisel:diorite'  inherits='chslDioriteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -246,14 +244,15 @@ Andesite, Diorite, Granite, Limestone, Marble
                 <!-- Begin Layered Veins distribution of Granite -->
                 <IfCondition condition=':= chslGraniteDist = "layeredVeins"'>
                 
-                    <Veins name='chslGraniteBaseVeins' block='chisel:granite' inherits='PresetLayeredVeins'>
+                    <Veins name='chslGraniteBaseVeins' block='chisel:granite'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60F2D9C3</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * chslGraniteSize * _default_' range=':= 1 * 1 * chslGraniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * chslGraniteSize * _default_' range=':= 1 * 1 * chslGraniteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * chslGraniteFreq * _default_'/>
@@ -261,7 +260,7 @@ Andesite, Diorite, Granite, Limestone, Marble
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Granite Layered Veins) Settings -->
-                    <Veins name='chslGranitePrefersVeins' block='chisel:granite' inherits='chslGraniteBaseVeins'>
+                    <Veins name='chslGranitePrefersVeins' block='chisel:granite'  inherits='chslGraniteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -283,14 +282,15 @@ Andesite, Diorite, Granite, Limestone, Marble
                 <!-- Begin Layered Veins distribution of Limestone -->
                 <IfCondition condition=':= chslLimestoneDist = "layeredVeins"'>
                 
-                    <Veins name='chslLimestoneBaseVeins' block='chisel:limestone' inherits='PresetLayeredVeins'>
+                    <Veins name='chslLimestoneBaseVeins' block='chisel:limestone'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A5A28F</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * chslLimestoneSize * _default_' range=':= 1 * 1 * chslLimestoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * chslLimestoneSize * _default_' range=':= 1 * 1 * chslLimestoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * chslLimestoneFreq * _default_'/>
@@ -298,7 +298,7 @@ Andesite, Diorite, Granite, Limestone, Marble
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Limestone Layered Veins) Settings -->
-                    <Veins name='chslLimestonePrefersVeins' block='chisel:limestone' inherits='chslLimestoneBaseVeins'>
+                    <Veins name='chslLimestonePrefersVeins' block='chisel:limestone'  inherits='chslLimestoneBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -320,14 +320,15 @@ Andesite, Diorite, Granite, Limestone, Marble
                 <!-- Begin Layered Veins distribution of Marble -->
                 <IfCondition condition=':= chslMarbleDist = "layeredVeins"'>
                 
-                    <Veins name='chslMarbleBaseVeins' block='chisel:marble' inherits='PresetLayeredVeins'>
+                    <Veins name='chslMarbleBaseVeins' block='chisel:marble'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60CECECE</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * chslMarbleSize * _default_' range=':= 1 * 1 * chslMarbleSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * chslMarbleSize * _default_' range=':= 1 * 1 * chslMarbleSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * chslMarbleFreq * _default_'/>
@@ -335,7 +336,7 @@ Andesite, Diorite, Granite, Limestone, Marble
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Marble Layered Veins) Settings -->
-                    <Veins name='chslMarblePrefersVeins' block='chisel:marble' inherits='chslMarbleBaseVeins'>
+                    <Veins name='chslMarblePrefersVeins' block='chisel:marble'  inherits='chslMarbleBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -1,12 +1,9 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Dense Ores Module
-
-Generates: 
-Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Dense Ores" Module: This configuration
+      covers iron, gold, lapis, diamond, emerald, redstone, coal, and
+      nether quartz.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="denseores">
@@ -329,7 +326,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='denseores:block0:0' />
+                    <Replaces block='denseores:block0' />
                     <Replaces block='denseores:block0:1' />
                     <Replaces block='denseores:block0:2' />
                     <Replaces block='denseores:block0:3' />
@@ -346,14 +343,15 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin Layered Veins distribution of Iron -->
                 <IfCondition condition=':= dnsoIronDist = "layeredVeins"'>
                 
-                    <Veins name='dnsoIronBaseVeins' block='denseores:block0' inherits='PresetLayeredVeins'>
+                    <Veins name='dnsoIronBaseVeins' block='denseores:block0'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoIronSize * _default_' range=':= 1 * 1 * dnsoIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoIronSize * _default_' range=':= 1 * 1 * dnsoIronSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.45 * dnsoIronFreq * _default_'/>
@@ -362,7 +360,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Iron Layered Veins) Settings -->
-                    <Veins name='dnsoIronPrefersVeins' block='denseores:block0' inherits='dnsoIronBaseVeins'>
+                    <Veins name='dnsoIronPrefersVeins' block='denseores:block0'  inherits='dnsoIronBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -381,16 +379,26 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin  Huge Veins distribution of Iron -->
                 <IfCondition condition=':= dnsoIronDist = "hugeVeins"'>
                 
-                    <Veins name='dnsoIronBaseVeins' block='denseores:block0' inherits='PresetHugeVeins'>
+                    <Veins name='dnsoIronBaseVeins' block='denseores:block0'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -404,7 +412,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Iron Huge Veins) Settings -->
-                    <Veins name='dnsoIronPrefersVeins' block='denseores:block0' inherits='dnsoIronBaseVeins'>
+                    <Veins name='dnsoIronPrefersVeins' block='denseores:block0'  inherits='dnsoIronBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -425,12 +433,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 
                     <Cloud name='dnsoIronBaseCloud' block='denseores:block0' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -445,10 +457,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <!-- Begin Iron Strategic Cloud Hint Veins -->
                         <Veins name='dnsoIronBaseHintVeins' block='denseores:block0' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -492,14 +510,15 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin Layered Veins distribution of Gold -->
                 <IfCondition condition=':= dnsoGoldDist = "layeredVeins"'>
                 
-                    <Veins name='dnsoGoldBaseVeins' block='denseores:block0:1' inherits='PresetLayeredVeins'>
+                    <Veins name='dnsoGoldBaseVeins' block='denseores:block0:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * dnsoGoldSize * _default_' range=':= 1 * 0.8 * dnsoGoldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * dnsoGoldSize * _default_' range=':= 1 * 0.8 * dnsoGoldSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.43 * dnsoGoldFreq * _default_'/>
@@ -510,7 +529,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Gold Layered Veins) Settings -->
-                    <Veins name='dnsoGoldPrefersVeins' block='denseores:block0:1' inherits='dnsoGoldBaseVeins'>
+                    <Veins name='dnsoGoldPrefersVeins' block='denseores:block0:1'  inherits='dnsoGoldBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -528,16 +547,26 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin  Huge Veins distribution of Gold -->
                 <IfCondition condition=':= dnsoGoldDist = "hugeVeins"'>
                 
-                    <Veins name='dnsoGoldBaseVeins' block='denseores:block0:1' inherits='PresetHugeVeins'>
+                    <Veins name='dnsoGoldBaseVeins' block='denseores:block0:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
@@ -553,7 +582,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Gold Huge Veins) Settings -->
-                    <Veins name='dnsoGoldPrefersVeins' block='denseores:block0:1' inherits='dnsoGoldBaseVeins'>
+                    <Veins name='dnsoGoldPrefersVeins' block='denseores:block0:1'  inherits='dnsoGoldBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -573,12 +602,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 
                     <Cloud name='dnsoGoldBaseCloud' block='denseores:block0:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
@@ -593,10 +626,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <!-- Begin Gold Strategic Cloud Hint Veins -->
                         <Veins name='dnsoGoldBaseHintVeins' block='denseores:block0:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60EAEF57</WireframeColor>
@@ -640,35 +679,24 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin VerticalVeins distribution of Lapis -->
                 <IfCondition condition=':= dnsoLapisDist = "verticalVeins"'>
                 
-                    <Veins name='dnsoLapisBaseParentVeins' block='denseores:block0:2' inherits='PresetVerticalVeins'>
+                    <Veins name='dnsoLapisBaseVeins' block='denseores:block0:2'  inherits='PresetVerticalVeins' >
                         <Description>
-                            Single vertical veins that occur with no motherlodes.
+                            Single vertical veins that occur with no
+                            motherlodes.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x600646B1</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoLapisSize * _default_' range=':= 1 * 1 * dnsoLapisSize * _default_'/>
                         <Setting name='MotherlodeHeight' avg=':= 8' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoLapisSize * _default_' range=':= 1 * 1 * dnsoLapisSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':=  1 * 0.2 * dnsoLapisFreq * _default_'/>
+                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.2 * dnsoLapisFreq * _default_'/>
                         <Setting name='BranchLength' avg=':= 36/64 * _default_' range=':= 12 * _default_'/>
                         <Replaces block='minecraft:stone'/>
-                        <Veins name='dnsoLapisBaseChildVeins' block='denseores:block0:2' inherits='PresetVerticalVeins'>
-                            <Description>
-                                Single vertical veins that occur with no motherlodes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x600646B1</WireframeColor>
-                            <Setting name='MotherlodeHeight' avg=':= 8' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
-                            <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoLapisSize * _default_' range=':= 1 * 1 * dnsoLapisSize * _default_'/>
-                            <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                            <Setting name='MotherlodeFrequency' avg=':= 1 * 0.2 * dnsoLapisFreq * 3 * _default_'/>
-                            <Setting name='BranchLength' avg=':= 36/64 * _default_' range=':= 12 * _default_'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Lapis Vertical Veins) Settings -->
-                    <Veins name='dnsoLapisPrefersParentVeins' block='denseores:block0:2' inherits='dnsoLapisBaseParentVeins'>
+                    <Veins name='dnsoLapisPrefersVeins' block='denseores:block0:2'  inherits='dnsoLapisBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -676,15 +704,6 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <WireframeColor>0x600646B1</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='ocean'/>
-                        <Veins name='dnsoLapisPrefersChildVeins' block='denseores:block0:2' inherits='dnsoLapisBaseChildVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x600646B1</WireframeColor>
-                            <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                            <BiomeType name='ocean'/>
-                        </Veins>
                     </Veins>
                     <!-- End Preferred Biome Distribution (Lapis Vertical Veins) Settings -->
                 
@@ -697,12 +716,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 
                     <Cloud name='dnsoLapisBaseCloud' block='denseores:block0:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x600646B1</WireframeColor>
@@ -717,10 +740,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <!-- Begin Lapis Strategic Cloud Hint Veins -->
                         <Veins name='dnsoLapisBaseHintVeins' block='denseores:block0:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x600646B1</WireframeColor>
@@ -764,34 +793,31 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin PipeVeins distribution of Diamond -->
                 <IfCondition condition=':= dnsoDiamondDist = "pipeVeins"'>
                 
-                    
-                    <!-- Begin Diamond Ore Configuration -->
-                    <Veins name='dnsoDiamondBaseVeins' block='denseores:block0:3' inherits='PresetPipeVeins' seed='0xB8D3'>
+                    <Veins name='dnsoDiamondBaseVeins' block='denseores:block0:3'  inherits='PresetPipeVeins' seed='0xB8D3'>
                         <Description>
-                            Short sparsely filled veins sloping up from near the bottom of the map.
+                            Short sparsely filled veins sloping up
+                            from near the bottom of the map.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608BF4E3</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 0.1 * 1 * dnsoDiamondSize * _default_' range=':= 0.1 * 1 * dnsoDiamondSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= 8' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 0.1 * 1 * dnsoDiamondSize * _default_' range=':= 0.1 * 1 * dnsoDiamondSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.4 * dnsoDiamondFreq * _default_'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
-                    <!-- End Diamond Ore Configuration -->
                     
-                    
-                    <!-- Begin Diamond Pipe Configuration -->
-                    <Veins name= 'dnsoDiamondBasePipe' block='minecraft:lava' inherits='dnsoDiamondBaseVeins' seed='0xB8D3'>
+                    <!-- Begin Pipe Filling (Diamond Pipe Veins) Settings -->
+                    <Veins name='dnsoDiamondPipeVeins' block='minecraft:lava'  inherits='dnsoDiamondBaseVeins' seed='0xB8D3'>
                         <Description>
-                            Fills center of each tube with Pipe material.
+                            Fills the vein with an additional material
+                            (minecraft:lava).
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608BF4E3</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 0.5 * 0.1 * 1 * dnsoDiamondSize * _default_' range=':= 0.5 * 0.1 * 1 * dnsoDiamondSize * _default_'/>
                         <Setting name='SegmentRadius' avg=':= 0.5 * 0.1 * 1 * dnsoDiamondSize * _default_' range=':= 0.5 * 0.1 * 1 * dnsoDiamondSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Replaces block='minecraft:stone'/>
                         <Replaces block='denseores:block0:3'/>
                         <Replaces block='minecraft:dirt'/>
@@ -800,8 +826,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <Replaces block='minecraft:netherrack'/>
                         <Replaces block='minecraft:end_stone'/>
                     </Veins>
-                    <!-- End Diamond Pipe Configuration -->
-                    
+                    <!-- End Pipe Filling (Diamond Pipe Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End PipeVeins distribution of Diamond -->
@@ -812,12 +837,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 
                     <Cloud name='dnsoDiamondBaseCloud' block='denseores:block0:3' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608BF4E3</WireframeColor>
@@ -832,10 +861,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <!-- Begin Diamond Strategic Cloud Hint Veins -->
                         <Veins name='dnsoDiamondBaseHintVeins' block='denseores:block0:3' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x608BF4E3</WireframeColor>
@@ -877,37 +912,34 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin PipeVeins distribution of Emerald -->
                 <IfCondition condition=':= dnsoEmeraldDist = "pipeVeins"'>
                 
-                    
-                    <!-- Begin Emerald Ore Configuration -->
-                    <Veins name='dnsoEmeraldBaseVeins' block='denseores:block0:4' inherits='PresetPipeVeins' seed='0x54B3'>
+                    <Veins name='dnsoEmeraldBaseVeins' block='denseores:block0:4'  inherits='PresetPipeVeins' seed='0x54B3'>
                         <Description>
-                            Short sparsely filled veins sloping up from near the bottom of the map.
+                            Short sparsely filled veins sloping up
+                            from near the bottom of the map.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x606CE391</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * dnsoEmeraldSize * _default_' range=':= 1 * 0.85 * dnsoEmeraldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 4' range=':= 14' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 4' range=':= 14' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.85 * dnsoEmeraldSize * _default_' range=':= 1 * 0.85 * dnsoEmeraldSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.2 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.45 * dnsoEmeraldFreq * _default_'/>
                         <Setting name='BranchInclination' avg=':= 0.55' range=':= 0.7'/>
                         <Setting name='SegmentRadius' avg=':= 1 * 0.85 * dnsoEmeraldSize * 0.85 * _default_' range=':= 1 * 0.85 * dnsoEmeraldSize * 0.7 * _default_'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
-                    <!-- End Emerald Ore Configuration -->
                     
-                    
-                    <!-- Begin Emerald Pipe Configuration -->
-                    <Veins name= 'dnsoEmeraldBasePipe' block='minecraft:monster_egg' inherits='dnsoEmeraldBaseVeins' seed='0x54B3'>
+                    <!-- Begin Pipe Filling (Emerald Pipe Veins) Settings -->
+                    <Veins name='dnsoEmeraldPipeVeins' block='minecraft:monster_egg'  inherits='dnsoEmeraldBaseVeins' seed='0x54B3'>
                         <Description>
-                            Fills center of each tube with Pipe material.
+                            Fills the vein with an additional material
+                            (minecraft:monster_egg).
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x606CE391</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 0.85 * dnsoEmeraldSize * _default_' range=':= 0.5 * 1 * 0.85 * dnsoEmeraldSize * _default_'/>
                         <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 0.85 * dnsoEmeraldSize * _default_' range=':= 0.5 * 1 * 0.85 * dnsoEmeraldSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.2 * _default_' range=':= _default_'/>
                         <Replaces block='minecraft:stone'/>
                         <Replaces block='denseores:block0:4'/>
                         <Replaces block='minecraft:dirt'/>
@@ -915,10 +947,8 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <Replaces block='minecraft:gravel'/>
                         <Replaces block='minecraft:netherrack'/>
                         <Replaces block='minecraft:end_stone'/>
-                        <BiomeType name='Mountain'/>
                     </Veins>
-                    <!-- End Emerald Pipe Configuration -->
-                    
+                    <!-- End Pipe Filling (Emerald Pipe Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End PipeVeins distribution of Emerald -->
@@ -929,12 +959,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 
                     <Cloud name='dnsoEmeraldBaseCloud' block='denseores:block0:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x606CE391</WireframeColor>
@@ -950,10 +984,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <!-- Begin Emerald Strategic Cloud Hint Veins -->
                         <Veins name='dnsoEmeraldBaseHintVeins' block='denseores:block0:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x606CE391</WireframeColor>
@@ -997,35 +1037,24 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin VerticalVeins distribution of Redstone -->
                 <IfCondition condition=':= dnsoRedstoneDist = "verticalVeins"'>
                 
-                    <Veins name='dnsoRedstoneBaseParentVeins' block='denseores:block0:5' inherits='PresetVerticalVeins'>
+                    <Veins name='dnsoRedstoneBaseVeins' block='denseores:block0:5'  inherits='PresetVerticalVeins' >
                         <Description>
-                            Single vertical veins that occur with no motherlodes.
+                            Single vertical veins that occur with no
+                            motherlodes.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C70D07</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoRedstoneSize * _default_' range=':= 1 * 1 * dnsoRedstoneSize * _default_'/>
                         <Setting name='MotherlodeHeight' avg=':= 8' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoRedstoneSize * _default_' range=':= 1 * 1 * dnsoRedstoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':=  1 * 1.17 * dnsoRedstoneFreq * _default_'/>
+                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.17 * dnsoRedstoneFreq * _default_'/>
                         <Replaces block='minecraft:stone'/>
                         <Replaces block='minecraft:sandstone'/>
-                        <Veins name='dnsoRedstoneBaseChildVeins' block='denseores:block0:5' inherits='PresetVerticalVeins'>
-                            <Description>
-                                Single vertical veins that occur with no motherlodes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60C70D07</WireframeColor>
-                            <Setting name='MotherlodeHeight' avg=':= 8' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
-                            <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoRedstoneSize * _default_' range=':= 1 * 1 * dnsoRedstoneSize * _default_'/>
-                            <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                            <Setting name='MotherlodeFrequency' avg=':= 1 * 1.17 * dnsoRedstoneFreq * 3 * _default_'/>
-                            <Replaces block='minecraft:stone'/>
-                            <Replaces block='minecraft:sandstone'/>
-                        </Veins>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Redstone Vertical Veins) Settings -->
-                    <Veins name='dnsoRedstonePrefersParentVeins' block='denseores:block0:5' inherits='dnsoRedstoneBaseParentVeins'>
+                    <Veins name='dnsoRedstonePrefersVeins' block='denseores:block0:5'  inherits='dnsoRedstoneBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1033,15 +1062,6 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <WireframeColor>0x60C70D07</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Desert'/>
-                        <Veins name='dnsoRedstonePrefersChildVeins' block='denseores:block0:5' inherits='dnsoRedstoneBaseChildVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60C70D07</WireframeColor>
-                            <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                            <BiomeType name='Desert'/>
-                        </Veins>
                     </Veins>
                     <!-- End Preferred Biome Distribution (Redstone Vertical Veins) Settings -->
                 
@@ -1054,12 +1074,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 
                     <Cloud name='dnsoRedstoneBaseCloud' block='denseores:block0:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C70D07</WireframeColor>
@@ -1075,10 +1099,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <!-- Begin Redstone Strategic Cloud Hint Veins -->
                         <Veins name='dnsoRedstoneBaseHintVeins' block='denseores:block0:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60C70D07</WireframeColor>
@@ -1124,17 +1154,21 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin SparseVeins distribution of Coal -->
                 <IfCondition condition=':= dnsoCoalDist = "sparseVeins"'>
                 
-                    <Veins name='dnsoCoalBaseVeins' block='denseores:block0:6' inherits='PresetSparseVeins'>
+                    <Veins name='dnsoCoalBaseVeins' block='denseores:block0:6'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60252525</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoCoalSize * _default_' range=':= 1 * 1 * dnsoCoalSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoCoalSize * _default_' range=':= 1 * 1 * dnsoCoalSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 5.35 * dnsoCoalFreq * _default_'/>
@@ -1145,7 +1179,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Coal Sparse Veins) Settings -->
-                    <Veins name='dnsoCoalPrefersVeins' block='denseores:block0:6' inherits='dnsoCoalBaseVeins'>
+                    <Veins name='dnsoCoalPrefersVeins' block='denseores:block0:6'  inherits='dnsoCoalBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1163,22 +1197,26 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin  Small Deposits distribution of Coal -->
                 <IfCondition condition=':= dnsoCoalDist = "smallDeposits"'>
                 
-                    <Veins name='dnsoCoalBaseVeins' block='denseores:block0:6' inherits='PresetSmallDeposits'>
+                    <Veins name='dnsoCoalBaseVeins' block='denseores:block0:6'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60252525</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoCoalSize * _default_' range=':= 1 * 1 * dnsoCoalSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoCoalSize * _default_' range=':= 1 * 1 * dnsoCoalSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 5.35 * dnsoCoalFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Coal Small Deposits) Settings -->
-                    <Veins name='dnsoCoalPrefersVeins' block='denseores:block0:6' inherits='dnsoCoalBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Coal Deposit Veins) Settings -->
+                    <Veins name='dnsoCoalPrefersVeins' block='denseores:block0:6'  inherits='dnsoCoalBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1187,7 +1225,7 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Swamp'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Coal Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Coal Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Coal -->
@@ -1198,12 +1236,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 
                     <Cloud name='dnsoCoalBaseCloud' block='denseores:block0:6' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60252525</WireframeColor>
@@ -1218,10 +1260,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <!-- Begin Coal Strategic Cloud Hint Veins -->
                         <Veins name='dnsoCoalBaseHintVeins' block='denseores:block0:6' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60252525</WireframeColor>
@@ -1286,14 +1334,15 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin Layered Veins distribution of Nether Quartz -->
                 <IfCondition condition=':= dnsoNetherQuartzDist = "layeredVeins"'>
                 
-                    <Veins name='dnsoNetherQuartzBaseVeins' block='denseores:block0:7' inherits='PresetLayeredVeins'>
+                    <Veins name='dnsoNetherQuartzBaseVeins' block='denseores:block0:7'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60CDC1B3</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoNetherQuartzSize * _default_' range=':= 1 * 1 * dnsoNetherQuartzSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoNetherQuartzSize * _default_' range=':= 1 * 1 * dnsoNetherQuartzSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * 1 * dnsoNetherQuartzFreq * _default_'/>
@@ -1307,16 +1356,26 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 <!-- Begin  Huge Veins distribution of Nether Quartz -->
                 <IfCondition condition=':= dnsoNetherQuartzDist = "hugeVeins"'>
                 
-                    <Veins name='dnsoNetherQuartzBaseVeins' block='denseores:block0:7' inherits='PresetHugeVeins'>
+                    <Veins name='dnsoNetherQuartzBaseVeins' block='denseores:block0:7'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60CDC1B3</WireframeColor>
@@ -1337,12 +1396,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                 
                     <Cloud name='dnsoNetherQuartzBaseCloud' block='denseores:block0:7' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60CDC1B3</WireframeColor>
@@ -1357,10 +1420,16 @@ Iron, Gold, Lapis, Diamond, Emerald, Redstone, Coal, Nether Quartz
                         <!-- Begin Nether Quartz Strategic Cloud Hint Veins -->
                         <Veins name='dnsoNetherQuartzBaseHintVeins' block='denseores:block0:7' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60CDC1B3</WireframeColor>

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -1,12 +1,8 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   ElectriCraft Module
-
-Generates: 
-Copper, Tin, Silver, Nickel, Aluminum, Platinum
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "ElectriCraft" Module: This configuration
+      covers copper, tin, silver, nickel, aluminum, and platinum.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="ElectriCraft">
@@ -271,7 +267,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='ElectriCraft:electricraft_block_ore:0' />
+                    <Replaces block='ElectriCraft:electricraft_block_ore' />
                     <Replaces block='ElectriCraft:electricraft_block_ore:1' />
                     <Replaces block='ElectriCraft:electricraft_block_ore:2' />
                     <Replaces block='ElectriCraft:electricraft_block_ore:3' />
@@ -287,14 +283,15 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin LayeredVeins distribution of Copper -->
                 <IfCondition condition=':= elcrCopperDist = "layeredVeins"'>
                 
-                    <Veins name='elcrCopperBaseVeins' block='ElectriCraft:electricraft_block_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='elcrCopperBaseVeins' block='ElectriCraft:electricraft_block_ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BB6E30</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.9 * elcrCopperSize * _default_' range=':= 1 * 0.9 * elcrCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 45' range=':= 10' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 45' range=':= 10' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.9 * elcrCopperSize * _default_' range=':= 1 * 0.9 * elcrCopperSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * elcrCopperFreq * _default_'/>
@@ -305,7 +302,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='elcrCopperPrefersVeins' block='ElectriCraft:electricraft_block_ore' inherits='elcrCopperBaseVeins'>
+                    <Veins name='elcrCopperPrefersVeins' block='ElectriCraft:electricraft_block_ore'  inherits='elcrCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -323,16 +320,26 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= elcrCopperDist = "hugeVeins"'>
                 
-                    <Veins name='elcrCopperBaseVeins' block='ElectriCraft:electricraft_block_ore' inherits='PresetHugeVeins'>
+                    <Veins name='elcrCopperBaseVeins' block='ElectriCraft:electricraft_block_ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BB6E30</WireframeColor>
@@ -348,7 +355,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                    <Veins name='elcrCopperPrefersVeins' block='ElectriCraft:electricraft_block_ore' inherits='elcrCopperBaseVeins'>
+                    <Veins name='elcrCopperPrefersVeins' block='ElectriCraft:electricraft_block_ore'  inherits='elcrCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -368,12 +375,16 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 
                     <Cloud name='elcrCopperBaseCloud' block='ElectriCraft:electricraft_block_ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BB6E30</WireframeColor>
@@ -388,10 +399,16 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <!-- Begin Copper Strategic Cloud Hint Veins -->
                         <Veins name='elcrCopperBaseHintVeins' block='ElectriCraft:electricraft_block_ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60BB6E30</WireframeColor>
@@ -435,14 +452,15 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin LayeredVeins distribution of Tin -->
                 <IfCondition condition=':= elcrTinDist = "layeredVeins"'>
                 
-                    <Veins name='elcrTinBaseVeins' block='ElectriCraft:electricraft_block_ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='elcrTinBaseVeins' block='ElectriCraft:electricraft_block_ore:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A9C7CF</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * elcrTinSize * _default_' range=':= 1 * 0.85 * elcrTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.85 * elcrTinSize * _default_' range=':= 1 * 0.85 * elcrTinSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * elcrTinFreq * _default_'/>
@@ -453,7 +471,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='elcrTinPrefersVeins' block='ElectriCraft:electricraft_block_ore:1' inherits='elcrTinBaseVeins'>
+                    <Veins name='elcrTinPrefersVeins' block='ElectriCraft:electricraft_block_ore:1'  inherits='elcrTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -471,16 +489,26 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= elcrTinDist = "hugeVeins"'>
                 
-                    <Veins name='elcrTinBaseVeins' block='ElectriCraft:electricraft_block_ore:1' inherits='PresetHugeVeins'>
+                    <Veins name='elcrTinBaseVeins' block='ElectriCraft:electricraft_block_ore:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A9C7CF</WireframeColor>
@@ -496,7 +524,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                    <Veins name='elcrTinPrefersVeins' block='ElectriCraft:electricraft_block_ore:1' inherits='elcrTinBaseVeins'>
+                    <Veins name='elcrTinPrefersVeins' block='ElectriCraft:electricraft_block_ore:1'  inherits='elcrTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -516,12 +544,16 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 
                     <Cloud name='elcrTinBaseCloud' block='ElectriCraft:electricraft_block_ore:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A9C7CF</WireframeColor>
@@ -536,10 +568,16 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <!-- Begin Tin Strategic Cloud Hint Veins -->
                         <Veins name='elcrTinBaseHintVeins' block='ElectriCraft:electricraft_block_ore:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60A9C7CF</WireframeColor>
@@ -583,14 +621,15 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin LayeredVeins distribution of Silver -->
                 <IfCondition condition=':= elcrSilverDist = "layeredVeins"'>
                 
-                    <Veins name='elcrSilverBaseVeins' block='ElectriCraft:electricraft_block_ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='elcrSilverBaseVeins' block='ElectriCraft:electricraft_block_ore:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B6D2EA</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * elcrSilverSize * _default_' range=':= 1 * 0.85 * elcrSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.85 * elcrSilverSize * _default_' range=':= 1 * 0.85 * elcrSilverSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * elcrSilverFreq * _default_'/>
@@ -601,7 +640,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                    <Veins name='elcrSilverPrefersVeins' block='ElectriCraft:electricraft_block_ore:2' inherits='elcrSilverBaseVeins'>
+                    <Veins name='elcrSilverPrefersVeins' block='ElectriCraft:electricraft_block_ore:2'  inherits='elcrSilverBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -619,16 +658,26 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin  Huge Veins distribution of Silver -->
                 <IfCondition condition=':= elcrSilverDist = "hugeVeins"'>
                 
-                    <Veins name='elcrSilverBaseVeins' block='ElectriCraft:electricraft_block_ore:2' inherits='PresetHugeVeins'>
+                    <Veins name='elcrSilverBaseVeins' block='ElectriCraft:electricraft_block_ore:2'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B6D2EA</WireframeColor>
@@ -644,7 +693,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Huge Veins) Settings -->
-                    <Veins name='elcrSilverPrefersVeins' block='ElectriCraft:electricraft_block_ore:2' inherits='elcrSilverBaseVeins'>
+                    <Veins name='elcrSilverPrefersVeins' block='ElectriCraft:electricraft_block_ore:2'  inherits='elcrSilverBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -664,12 +713,16 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 
                     <Cloud name='elcrSilverBaseCloud' block='ElectriCraft:electricraft_block_ore:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B6D2EA</WireframeColor>
@@ -684,10 +737,16 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <!-- Begin Silver Strategic Cloud Hint Veins -->
                         <Veins name='elcrSilverBaseHintVeins' block='ElectriCraft:electricraft_block_ore:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60B6D2EA</WireframeColor>
@@ -731,14 +790,15 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin LayeredVeins distribution of Nickel -->
                 <IfCondition condition=':= elcrNickelDist = "layeredVeins"'>
                 
-                    <Veins name='elcrNickelBaseVeins' block='ElectriCraft:electricraft_block_ore:3' inherits='PresetLayeredVeins'>
+                    <Veins name='elcrNickelBaseVeins' block='ElectriCraft:electricraft_block_ore:3'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D2D1B6</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * elcrNickelSize * _default_' range=':= 1 * 0.85 * elcrNickelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.85 * elcrNickelSize * _default_' range=':= 1 * 0.85 * elcrNickelSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * elcrNickelFreq * _default_'/>
@@ -749,7 +809,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Nickel Layered Veins) Settings -->
-                    <Veins name='elcrNickelPrefersVeins' block='ElectriCraft:electricraft_block_ore:3' inherits='elcrNickelBaseVeins'>
+                    <Veins name='elcrNickelPrefersVeins' block='ElectriCraft:electricraft_block_ore:3'  inherits='elcrNickelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -767,16 +827,26 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin  Huge Veins distribution of Nickel -->
                 <IfCondition condition=':= elcrNickelDist = "hugeVeins"'>
                 
-                    <Veins name='elcrNickelBaseVeins' block='ElectriCraft:electricraft_block_ore:3' inherits='PresetHugeVeins'>
+                    <Veins name='elcrNickelBaseVeins' block='ElectriCraft:electricraft_block_ore:3'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D2D1B6</WireframeColor>
@@ -792,7 +862,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Nickel Huge Veins) Settings -->
-                    <Veins name='elcrNickelPrefersVeins' block='ElectriCraft:electricraft_block_ore:3' inherits='elcrNickelBaseVeins'>
+                    <Veins name='elcrNickelPrefersVeins' block='ElectriCraft:electricraft_block_ore:3'  inherits='elcrNickelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -812,12 +882,16 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 
                     <Cloud name='elcrNickelBaseCloud' block='ElectriCraft:electricraft_block_ore:3' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D2D1B6</WireframeColor>
@@ -832,10 +906,16 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <!-- Begin Nickel Strategic Cloud Hint Veins -->
                         <Veins name='elcrNickelBaseHintVeins' block='ElectriCraft:electricraft_block_ore:3' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60D2D1B6</WireframeColor>
@@ -879,14 +959,15 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin LayeredVeins distribution of Aluminum -->
                 <IfCondition condition=':= elcrAluminumDist = "layeredVeins"'>
                 
-                    <Veins name='elcrAluminumBaseVeins' block='ElectriCraft:electricraft_block_ore:4' inherits='PresetLayeredVeins'>
+                    <Veins name='elcrAluminumBaseVeins' block='ElectriCraft:electricraft_block_ore:4'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DAD9DB</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.6 * elcrAluminumSize * _default_' range=':= 1 * 0.6 * elcrAluminumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.6 * elcrAluminumSize * _default_' range=':= 1 * 0.6 * elcrAluminumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * elcrAluminumFreq * _default_'/>
@@ -897,7 +978,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Aluminum Layered Veins) Settings -->
-                    <Veins name='elcrAluminumPrefersVeins' block='ElectriCraft:electricraft_block_ore:4' inherits='elcrAluminumBaseVeins'>
+                    <Veins name='elcrAluminumPrefersVeins' block='ElectriCraft:electricraft_block_ore:4'  inherits='elcrAluminumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -915,16 +996,26 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin  Huge Veins distribution of Aluminum -->
                 <IfCondition condition=':= elcrAluminumDist = "hugeVeins"'>
                 
-                    <Veins name='elcrAluminumBaseVeins' block='ElectriCraft:electricraft_block_ore:4' inherits='PresetHugeVeins'>
+                    <Veins name='elcrAluminumBaseVeins' block='ElectriCraft:electricraft_block_ore:4'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DAD9DB</WireframeColor>
@@ -940,7 +1031,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Aluminum Huge Veins) Settings -->
-                    <Veins name='elcrAluminumPrefersVeins' block='ElectriCraft:electricraft_block_ore:4' inherits='elcrAluminumBaseVeins'>
+                    <Veins name='elcrAluminumPrefersVeins' block='ElectriCraft:electricraft_block_ore:4'  inherits='elcrAluminumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -960,12 +1051,16 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 
                     <Cloud name='elcrAluminumBaseCloud' block='ElectriCraft:electricraft_block_ore:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DAD9DB</WireframeColor>
@@ -980,10 +1075,16 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <!-- Begin Aluminum Strategic Cloud Hint Veins -->
                         <Veins name='elcrAluminumBaseHintVeins' block='ElectriCraft:electricraft_block_ore:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60DAD9DB</WireframeColor>
@@ -1027,14 +1128,15 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin LayeredVeins distribution of Platinum -->
                 <IfCondition condition=':= elcrPlatinumDist = "layeredVeins"'>
                 
-                    <Veins name='elcrPlatinumBaseVeins' block='ElectriCraft:electricraft_block_ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='elcrPlatinumBaseVeins' block='ElectriCraft:electricraft_block_ore:5'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602D84E7</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.80 * elcrPlatinumSize * _default_' range=':= 1 * 0.80 * elcrPlatinumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 16' range=':= 8' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 16' range=':= 8' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.80 * elcrPlatinumSize * _default_' range=':= 1 * 0.80 * elcrPlatinumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * elcrPlatinumFreq * _default_'/>
@@ -1045,7 +1147,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Platinum Layered Veins) Settings -->
-                    <Veins name='elcrPlatinumPrefersVeins' block='ElectriCraft:electricraft_block_ore:5' inherits='elcrPlatinumBaseVeins'>
+                    <Veins name='elcrPlatinumPrefersVeins' block='ElectriCraft:electricraft_block_ore:5'  inherits='elcrPlatinumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1063,16 +1165,26 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 <!-- Begin  Huge Veins distribution of Platinum -->
                 <IfCondition condition=':= elcrPlatinumDist = "hugeVeins"'>
                 
-                    <Veins name='elcrPlatinumBaseVeins' block='ElectriCraft:electricraft_block_ore:5' inherits='PresetHugeVeins'>
+                    <Veins name='elcrPlatinumBaseVeins' block='ElectriCraft:electricraft_block_ore:5'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602D84E7</WireframeColor>
@@ -1088,7 +1200,7 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Platinum Huge Veins) Settings -->
-                    <Veins name='elcrPlatinumPrefersVeins' block='ElectriCraft:electricraft_block_ore:5' inherits='elcrPlatinumBaseVeins'>
+                    <Veins name='elcrPlatinumPrefersVeins' block='ElectriCraft:electricraft_block_ore:5'  inherits='elcrPlatinumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1108,12 +1220,16 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                 
                     <Cloud name='elcrPlatinumBaseCloud' block='ElectriCraft:electricraft_block_ore:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602D84E7</WireframeColor>
@@ -1128,10 +1244,16 @@ Copper, Tin, Silver, Nickel, Aluminum, Platinum
                         <!-- Begin Platinum Strategic Cloud Hint Veins -->
                         <Veins name='elcrPlatinumBaseHintVeins' block='ElectriCraft:electricraft_block_ore:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x602D84E7</WireframeColor>

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -1,12 +1,8 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Factorization Module
-
-Generates: 
-Silver, Dark Iron
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Factorization" Module: This configuration
+      covers silver and dark iron.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="factorization">
@@ -110,8 +106,8 @@ Silver, Dark Iron
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='factorization:ResourceBlock:0' />
-                    <Replaces block='factorization:DarkIronOre:0' />
+                    <Replaces block='factorization:ResourceBlock' />
+                    <Replaces block='factorization:DarkIronOre' />
                 </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
                 
@@ -122,14 +118,15 @@ Silver, Dark Iron
                 <!-- Begin Layered Veins distribution of Silver -->
                 <IfCondition condition=':= fctrSilverDist = "layeredVeins"'>
                 
-                    <Veins name='fctrSilverBaseVeins' block='factorization:ResourceBlock' inherits='PresetLayeredVeins'>
+                    <Veins name='fctrSilverBaseVeins' block='factorization:ResourceBlock'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608C9EBE</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * fctrSilverSize * _default_' range=':= 1 * 0.8 * fctrSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * fctrSilverSize * _default_' range=':= 1 * 0.8 * fctrSilverSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * fctrSilverFreq * _default_'/>
@@ -140,7 +137,7 @@ Silver, Dark Iron
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                    <Veins name='fctrSilverPrefersVeins' block='factorization:ResourceBlock' inherits='fctrSilverBaseVeins'>
+                    <Veins name='fctrSilverPrefersVeins' block='factorization:ResourceBlock'  inherits='fctrSilverBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -158,22 +155,26 @@ Silver, Dark Iron
                 <!-- Begin  Small Deposits distribution of Silver -->
                 <IfCondition condition=':= fctrSilverDist = "smallDeposits"'>
                 
-                    <Veins name='fctrSilverBaseVeins' block='factorization:ResourceBlock' inherits='PresetSmallDeposits'>
+                    <Veins name='fctrSilverBaseVeins' block='factorization:ResourceBlock'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608C9EBE</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * fctrSilverSize * _default_' range=':= 1 * 0.8 * fctrSilverSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * fctrSilverSize * _default_' range=':= 1 * 0.8 * fctrSilverSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * fctrSilverFreq * _default_'/>
+                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Silver Small Deposits) Settings -->
-                    <Veins name='fctrSilverPrefersVeins' block='factorization:ResourceBlock' inherits='fctrSilverBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Silver Deposit Veins) Settings -->
+                    <Veins name='fctrSilverPrefersVeins' block='factorization:ResourceBlock'  inherits='fctrSilverBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -182,7 +183,7 @@ Silver, Dark Iron
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='mountain'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Silver Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Silver Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Silver -->
@@ -193,12 +194,16 @@ Silver, Dark Iron
                 
                     <Cloud name='fctrSilverBaseCloud' block='factorization:ResourceBlock' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608C9EBE</WireframeColor>
@@ -213,10 +218,16 @@ Silver, Dark Iron
                         <!-- Begin Silver Strategic Cloud Hint Veins -->
                         <Veins name='fctrSilverBaseHintVeins' block='factorization:ResourceBlock' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x608C9EBE</WireframeColor>
@@ -260,24 +271,28 @@ Silver, Dark Iron
                 <!-- Begin Sparse Veins distribution of Dark Iron -->
                 <IfCondition condition=':= fctrDarkIronDist = "sparseVeins"'>
                 
-                    <Veins name='fctrDarkIronBaseVeins' block='factorization:DarkIronOre' inherits='PresetSparseVeins'>
+                    <Veins name='fctrDarkIronBaseVeins' block='factorization:DarkIronOre'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60781CCB</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * fctrDarkIronSize * _default_' range=':= 1 * 1 * fctrDarkIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= 3' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= 3' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * fctrDarkIronSize * _default_' range=':= 1 * 1 * fctrDarkIronSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * fctrDarkIronFreq * _default_'/>
+                        <PlacesBeside block='minecraft:bedrock'/>
                         <Replaces block='minecraft:stone'/>
                         <Replaces block='minecraft:dirt'/>
                         <Replaces block='minecraft:gravel'/>
-                        <PlacesBeside block='minecraft:bedrock'/>
                     </Veins>
                 
                 </IfCondition>
@@ -287,21 +302,22 @@ Silver, Dark Iron
                 <!-- Begin  Small Deposits distribution of Dark Iron -->
                 <IfCondition condition=':= fctrDarkIronDist = "smallDeposits"'>
                 
-                    <Veins name='fctrDarkIronBaseVeins' block='factorization:DarkIronOre' inherits='PresetSmallDeposits'>
+                    <Veins name='fctrDarkIronBaseVeins' block='factorization:DarkIronOre'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60781CCB</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= 3' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * fctrDarkIronSize * _default_' range=':= 1 * 1 * fctrDarkIronSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= 3' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * fctrDarkIronSize * _default_' range=':= 1 * 1 * fctrDarkIronSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * fctrDarkIronFreq * _default_'/>
+                        <PlacesBeside block='minecraft:bedrock'/>
                         <Replaces block='minecraft:stone'/>
                         <Replaces block='minecraft:dirt'/>
                         <Replaces block='minecraft:gravel'/>
-                        <PlacesBeside block='minecraft:bedrock'/>
                     </Veins>
                 
                 </IfCondition>

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -1,12 +1,8 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Forestry Module
-
-Generates: 
-Apatite, Copper, Tin
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Forestry" Module: This configuration
+      covers apatite, copper, and tin.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="Forestry">
@@ -144,7 +140,7 @@ Apatite, Copper, Tin
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='Forestry:resources:0' />
+                    <Replaces block='Forestry:resources' />
                     <Replaces block='Forestry:resources:1' />
                     <Replaces block='Forestry:resources:2' />
                 </Substitute>
@@ -157,43 +153,16 @@ Apatite, Copper, Tin
                 <!-- Begin SparseVeins distribution of Apatite -->
                 <IfCondition condition=':= frstApatiteDist = "sparseVeins"'>
                 
-                    <Veins name='frstApatiteBaseVeins' block='Forestry:resources' inherits='PresetSparseVeins'>
+                    <Veins name='frstApatiteBaseVeins' block='Forestry:resources'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6052BBEF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * frstApatiteSize * _default_' range=':= 1 * 1 * frstApatiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 4' type='normal' scaleTo='Biome' />
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * frstApatiteSize * _default_' range=':= 1 * 1 * frstApatiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * frstApatiteFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 1.2 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchInclination' avg=':= -_default_' range=':= 0'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Apatite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Apatite -->
-                <IfCondition condition=':= frstApatiteDist = "hugeVeins"'>
-                
-                    <Veins name='frstApatiteBaseVeins' block='Forestry:resources' inherits='PresetHugeVeins'>
-                        <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6052BBEF</WireframeColor>
@@ -204,8 +173,49 @@ Apatite, Copper, Tin
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * frstApatiteFreq * _default_'/>
                         <Setting name='BranchLength' avg=':= 1.2 * _default_' range=':= 1 * _default_'/>
                         <Setting name='BranchInclination' avg=':= -_default_' range=':= 0'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Forest'/>
+                        <Replaces block='minecraft:stone'/>
+                    </Veins>
+                
+                </IfCondition>
+                <!-- End SparseVeins distribution of Apatite -->
+                
+                
+                <!-- Begin  Huge Veins distribution of Apatite -->
+                <IfCondition condition=':= frstApatiteDist = "hugeVeins"'>
+                
+                    <Veins name='frstApatiteBaseVeins' block='Forestry:resources'  inherits='PresetHugeVeins' >
+                        <Description>
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x6052BBEF</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * frstApatiteSize * _default_' range=':= 1 * 1 * frstApatiteSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 4' type='normal' scaleTo='Biome' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * frstApatiteSize * _default_' range=':= 1 * 1 * frstApatiteSize * _default_'/>
+                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
+                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * frstApatiteFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 1.2 * _default_' range=':= 1 * _default_'/>
+                        <Setting name='BranchInclination' avg=':= -_default_' range=':= 0'/>
+                        <BiomeType name='Forest'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -217,12 +227,16 @@ Apatite, Copper, Tin
                 
                     <Cloud name='frstApatiteBaseCloud' block='Forestry:resources' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6052BBEF</WireframeColor>
@@ -238,10 +252,16 @@ Apatite, Copper, Tin
                         <!-- Begin Apatite Strategic Cloud Hint Veins -->
                         <Veins name='frstApatiteBaseHintVeins' block='Forestry:resources' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6052BBEF</WireframeColor>
@@ -285,14 +305,15 @@ Apatite, Copper, Tin
                 <!-- Begin LayeredVeins distribution of Copper -->
                 <IfCondition condition=':= frstCopperDist = "layeredVeins"'>
                 
-                    <Veins name='frstCopperBaseVeins' block='Forestry:resources:1' inherits='PresetLayeredVeins'>
+                    <Veins name='frstCopperBaseVeins' block='Forestry:resources:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3B78E</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * frstCopperSize * _default_' range=':= 1 * 1 * frstCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 40' range=':= 12' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 40' range=':= 12' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * frstCopperSize * _default_' range=':= 1 * 1 * frstCopperSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.75 * frstCopperFreq * _default_'/>
@@ -302,7 +323,7 @@ Apatite, Copper, Tin
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='frstCopperPrefersVeins' block='Forestry:resources:1' inherits='frstCopperBaseVeins'>
+                    <Veins name='frstCopperPrefersVeins' block='Forestry:resources:1'  inherits='frstCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -323,12 +344,16 @@ Apatite, Copper, Tin
                 
                     <Cloud name='frstCopperBaseCloud' block='Forestry:resources:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3B78E</WireframeColor>
@@ -343,10 +368,16 @@ Apatite, Copper, Tin
                         <!-- Begin Copper Strategic Cloud Hint Veins -->
                         <Veins name='frstCopperBaseHintVeins' block='Forestry:resources:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E3B78E</WireframeColor>
@@ -390,14 +421,15 @@ Apatite, Copper, Tin
                 <!-- Begin LayeredVeins distribution of Tin -->
                 <IfCondition condition=':= frstTinDist = "layeredVeins"'>
                 
-                    <Veins name='frstTinBaseVeins' block='Forestry:resources:2' inherits='PresetLayeredVeins'>
+                    <Veins name='frstTinBaseVeins' block='Forestry:resources:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D1EDF1</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * frstTinSize * _default_' range=':= 1 * 1 * frstTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * frstTinSize * _default_' range=':= 1 * 1 * frstTinSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.70 * frstTinFreq * _default_'/>
@@ -408,7 +440,7 @@ Apatite, Copper, Tin
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='frstTinPrefersVeins' block='Forestry:resources:2' inherits='frstTinBaseVeins'>
+                    <Veins name='frstTinPrefersVeins' block='Forestry:resources:2'  inherits='frstTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -428,12 +460,16 @@ Apatite, Copper, Tin
                 
                     <Cloud name='frstTinBaseCloud' block='Forestry:resources:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D1EDF1</WireframeColor>
@@ -448,10 +484,16 @@ Apatite, Copper, Tin
                         <!-- Begin Tin Strategic Cloud Hint Veins -->
                         <Veins name='frstTinBaseHintVeins' block='Forestry:resources:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60D1EDF1</WireframeColor>

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -1,12 +1,8 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Fossils and Archaeology Module
-
-Generates: 
-Fossils, Permafrost
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Fossils and Archaeology" Module: This
+      configuration covers fossils and permafrost.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="fossil">
@@ -115,8 +111,8 @@ Fossils, Permafrost
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='fossil:fossil:0' />
-                    <Replaces block='fossil:permafrost:0' />
+                    <Replaces block='fossil:fossil' />
+                    <Replaces block='fossil:permafrost' />
                 </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
                 
@@ -127,17 +123,21 @@ Fossils, Permafrost
                 <!-- Begin SparseVeins distribution of Fossils -->
                 <IfCondition condition=':= fsarFossilsDist = "sparseVeins"'>
                 
-                    <Veins name='fsarFossilsBaseVeins' block='fossil:fossil' inherits='PresetSparseVeins'>
+                    <Veins name='fsarFossilsBaseVeins' block='fossil:fossil'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FEFDDF</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * fsarFossilsSize * _default_' range=':= 1 * 1 * fsarFossilsSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * fsarFossilsSize * _default_' range=':= 1 * 1 * fsarFossilsSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 5.3 * fsarFossilsFreq * _default_'/>
@@ -148,7 +148,7 @@ Fossils, Permafrost
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Fossils Sparse Veins) Settings -->
-                    <Veins name='fsarFossilsPrefersVeins' block='fossil:fossil' inherits='fsarFossilsBaseVeins'>
+                    <Veins name='fsarFossilsPrefersVeins' block='fossil:fossil'  inherits='fsarFossilsBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -167,22 +167,26 @@ Fossils, Permafrost
                 <!-- Begin  Small Deposits distribution of Fossils -->
                 <IfCondition condition=':= fsarFossilsDist = "smallDeposits"'>
                 
-                    <Veins name='fsarFossilsBaseVeins' block='fossil:fossil' inherits='PresetSmallDeposits'>
+                    <Veins name='fsarFossilsBaseVeins' block='fossil:fossil'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FEFDDF</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * fsarFossilsSize * _default_' range=':= 1 * 1 * fsarFossilsSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * fsarFossilsSize * _default_' range=':= 1 * 1 * fsarFossilsSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 5.3 * fsarFossilsFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Fossils Small Deposits) Settings -->
-                    <Veins name='fsarFossilsPrefersVeins' block='fossil:fossil' inherits='fsarFossilsBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Fossils Deposit Veins) Settings -->
+                    <Veins name='fsarFossilsPrefersVeins' block='fossil:fossil'  inherits='fsarFossilsBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -192,7 +196,7 @@ Fossils, Permafrost
                         <BiomeType name='Swamp'/>
                         <BiomeType name='desert'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Fossils Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Fossils Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Fossils -->
@@ -203,12 +207,16 @@ Fossils, Permafrost
                 
                     <Cloud name='fsarFossilsBaseCloud' block='fossil:fossil' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FEFDDF</WireframeColor>
@@ -223,10 +231,16 @@ Fossils, Permafrost
                         <!-- Begin Fossils Strategic Cloud Hint Veins -->
                         <Veins name='fsarFossilsBaseHintVeins' block='fossil:fossil' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FEFDDF</WireframeColor>
@@ -270,25 +284,29 @@ Fossils, Permafrost
                 <!-- Begin SparseVeins distribution of Permafrost -->
                 <IfCondition condition=':= fsarPermafrostDist = "sparseVeins"'>
                 
-                    <Veins name='fsarPermafrostBaseVeins' block='fossil:permafrost' inherits='PresetSparseVeins'>
+                    <Veins name='fsarPermafrostBaseVeins' block='fossil:permafrost'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A5C3F5</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * fsarPermafrostSize * _default_' range=':= 1 * 1 * fsarPermafrostSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * fsarPermafrostSize * _default_' range=':= 1 * 1 * fsarPermafrostSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 5.3 * fsarPermafrostFreq * _default_'/>
                         <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Frozen'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -298,19 +316,23 @@ Fossils, Permafrost
                 <!-- Begin  Small Deposits distribution of Permafrost -->
                 <IfCondition condition=':= fsarPermafrostDist = "smallDeposits"'>
                 
-                    <Veins name='fsarPermafrostBaseVeins' block='fossil:permafrost' inherits='PresetSmallDeposits'>
+                    <Veins name='fsarPermafrostBaseVeins' block='fossil:permafrost'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A5C3F5</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * fsarPermafrostSize * _default_' range=':= 1 * 1 * fsarPermafrostSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * fsarPermafrostSize * _default_' range=':= 1 * 1 * fsarPermafrostSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 5.3 * fsarPermafrostFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
+                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <BiomeType name='Frozen'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -322,12 +344,16 @@ Fossils, Permafrost
                 
                     <Cloud name='fsarPermafrostBaseCloud' block='fossil:permafrost' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A5C3F5</WireframeColor>
@@ -343,10 +369,16 @@ Fossils, Permafrost
                         <!-- Begin Permafrost Strategic Cloud Hint Veins -->
                         <Veins name='fsarPermafrostBaseHintVeins' block='fossil:permafrost' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60A5C3F5</WireframeColor>

--- a/src/main/resources/config/modules/GeoStrata.xml
+++ b/src/main/resources/config/modules/GeoStrata.xml
@@ -1,14 +1,10 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   GeoStrata Module
-
-Generates: 
-Shale, Sandstone, Limestone, Pumice, Opal, Slate, Gneiss, Peridotite,
-Granulite, Migmatite, Schist, Basalt, Onyx, Quartz, Marble, Granite,
-Hornfel
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "GeoStrata" Module: This configuration
+      covers shale, sandstone, limestone, pumice, opal, slate, gneiss,
+      peridotite,  granulite, migmatite, schist, basalt, onyx, quartz,
+      marble, granite,  and hornfel.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="GeoStrata">
@@ -447,23 +443,23 @@ Hornfel
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='GeoStrata:geostrata_rock_shale_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_sandstone_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_limestone_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_pumice_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_opal_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_slate_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_gneiss_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_peridotite_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_granulite_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_migmatite_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_schist_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_basalt_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_onyx_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_quartz_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_marble_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_granite_smooth:0' />
-                    <Replaces block='GeoStrata:geostrata_rock_hornfel_smooth:0' />
+                    <Replaces block='GeoStrata:geostrata_rock_shale_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_sandstone_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_limestone_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_pumice_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_opal_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_slate_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_gneiss_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_peridotite_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_granulite_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_migmatite_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_schist_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_basalt_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_onyx_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_quartz_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_marble_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_granite_smooth' />
+                    <Replaces block='GeoStrata:geostrata_rock_hornfel_smooth' />
                 </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
                 
@@ -474,14 +470,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Shale -->
                 <IfCondition condition=':= gstaShaleDist = "layeredVeins"'>
                 
-                    <Veins name='gstaShaleBaseVeins' block='GeoStrata:geostrata_rock_shale_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaShaleBaseVeins' block='GeoStrata:geostrata_rock_shale_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60676970</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaShaleSize * _default_' range=':= 1 * 1 * gstaShaleSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaShaleSize * _default_' range=':= 1 * 1 * gstaShaleSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaShaleFreq * _default_'/>
@@ -489,7 +486,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Shale Layered Veins) Settings -->
-                    <Veins name='gstaShalePrefersVeins' block='GeoStrata:geostrata_rock_shale_smooth' inherits='gstaShaleBaseVeins'>
+                    <Veins name='gstaShalePrefersVeins' block='GeoStrata:geostrata_rock_shale_smooth'  inherits='gstaShaleBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -511,14 +508,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Sandstone -->
                 <IfCondition condition=':= gstaSandstoneDist = "layeredVeins"'>
                 
-                    <Veins name='gstaSandstoneBaseVeins' block='GeoStrata:geostrata_rock_sandstone_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaSandstoneBaseVeins' block='GeoStrata:geostrata_rock_sandstone_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BA9D80</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaSandstoneSize * _default_' range=':= 1 * 1 * gstaSandstoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaSandstoneSize * _default_' range=':= 1 * 1 * gstaSandstoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaSandstoneFreq * _default_'/>
@@ -526,7 +524,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Sandstone Layered Veins) Settings -->
-                    <Veins name='gstaSandstonePrefersVeins' block='GeoStrata:geostrata_rock_sandstone_smooth' inherits='gstaSandstoneBaseVeins'>
+                    <Veins name='gstaSandstonePrefersVeins' block='GeoStrata:geostrata_rock_sandstone_smooth'  inherits='gstaSandstoneBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -548,14 +546,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Limestone -->
                 <IfCondition condition=':= gstaLimestoneDist = "layeredVeins"'>
                 
-                    <Veins name='gstaLimestoneBaseVeins' block='GeoStrata:geostrata_rock_limestone_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaLimestoneBaseVeins' block='GeoStrata:geostrata_rock_limestone_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60CBBFAD</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaLimestoneSize * _default_' range=':= 1 * 1 * gstaLimestoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaLimestoneSize * _default_' range=':= 1 * 1 * gstaLimestoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaLimestoneFreq * _default_'/>
@@ -563,7 +562,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Limestone Layered Veins) Settings -->
-                    <Veins name='gstaLimestonePrefersVeins' block='GeoStrata:geostrata_rock_limestone_smooth' inherits='gstaLimestoneBaseVeins'>
+                    <Veins name='gstaLimestonePrefersVeins' block='GeoStrata:geostrata_rock_limestone_smooth'  inherits='gstaLimestoneBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -585,14 +584,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Pumice -->
                 <IfCondition condition=':= gstaPumiceDist = "layeredVeins"'>
                 
-                    <Veins name='gstaPumiceBaseVeins' block='GeoStrata:geostrata_rock_pumice_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaPumiceBaseVeins' block='GeoStrata:geostrata_rock_pumice_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C4C1BA</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaPumiceSize * _default_' range=':= 1 * 1 * gstaPumiceSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaPumiceSize * _default_' range=':= 1 * 1 * gstaPumiceSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaPumiceFreq * _default_'/>
@@ -600,7 +600,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Pumice Layered Veins) Settings -->
-                    <Veins name='gstaPumicePrefersVeins' block='GeoStrata:geostrata_rock_pumice_smooth' inherits='gstaPumiceBaseVeins'>
+                    <Veins name='gstaPumicePrefersVeins' block='GeoStrata:geostrata_rock_pumice_smooth'  inherits='gstaPumiceBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -622,14 +622,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Opal -->
                 <IfCondition condition=':= gstaOpalDist = "layeredVeins"'>
                 
-                    <Veins name='gstaOpalBaseVeins' block='GeoStrata:geostrata_rock_opal_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaOpalBaseVeins' block='GeoStrata:geostrata_rock_opal_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60CAFFFF</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaOpalSize * _default_' range=':= 1 * 1 * gstaOpalSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaOpalSize * _default_' range=':= 1 * 1 * gstaOpalSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaOpalFreq * _default_'/>
@@ -637,7 +638,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Opal Layered Veins) Settings -->
-                    <Veins name='gstaOpalPrefersVeins' block='GeoStrata:geostrata_rock_opal_smooth' inherits='gstaOpalBaseVeins'>
+                    <Veins name='gstaOpalPrefersVeins' block='GeoStrata:geostrata_rock_opal_smooth'  inherits='gstaOpalBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -659,14 +660,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Slate -->
                 <IfCondition condition=':= gstaSlateDist = "layeredVeins"'>
                 
-                    <Veins name='gstaSlateBaseVeins' block='GeoStrata:geostrata_rock_slate_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaSlateBaseVeins' block='GeoStrata:geostrata_rock_slate_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60494B53</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaSlateSize * _default_' range=':= 1 * 1 * gstaSlateSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaSlateSize * _default_' range=':= 1 * 1 * gstaSlateSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaSlateFreq * _default_'/>
@@ -674,7 +676,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Slate Layered Veins) Settings -->
-                    <Veins name='gstaSlatePrefersVeins' block='GeoStrata:geostrata_rock_slate_smooth' inherits='gstaSlateBaseVeins'>
+                    <Veins name='gstaSlatePrefersVeins' block='GeoStrata:geostrata_rock_slate_smooth'  inherits='gstaSlateBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -696,14 +698,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Gneiss -->
                 <IfCondition condition=':= gstaGneissDist = "layeredVeins"'>
                 
-                    <Veins name='gstaGneissBaseVeins' block='GeoStrata:geostrata_rock_gneiss_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaGneissBaseVeins' block='GeoStrata:geostrata_rock_gneiss_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BFBDBC</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaGneissSize * _default_' range=':= 1 * 1 * gstaGneissSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaGneissSize * _default_' range=':= 1 * 1 * gstaGneissSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaGneissFreq * _default_'/>
@@ -711,7 +714,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Gneiss Layered Veins) Settings -->
-                    <Veins name='gstaGneissPrefersVeins' block='GeoStrata:geostrata_rock_gneiss_smooth' inherits='gstaGneissBaseVeins'>
+                    <Veins name='gstaGneissPrefersVeins' block='GeoStrata:geostrata_rock_gneiss_smooth'  inherits='gstaGneissBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -733,14 +736,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Peridotite -->
                 <IfCondition condition=':= gstaPeridotiteDist = "layeredVeins"'>
                 
-                    <Veins name='gstaPeridotiteBaseVeins' block='GeoStrata:geostrata_rock_peridotite_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaPeridotiteBaseVeins' block='GeoStrata:geostrata_rock_peridotite_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60617361</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaPeridotiteSize * _default_' range=':= 1 * 1 * gstaPeridotiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaPeridotiteSize * _default_' range=':= 1 * 1 * gstaPeridotiteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaPeridotiteFreq * _default_'/>
@@ -748,7 +752,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Peridotite Layered Veins) Settings -->
-                    <Veins name='gstaPeridotitePrefersVeins' block='GeoStrata:geostrata_rock_peridotite_smooth' inherits='gstaPeridotiteBaseVeins'>
+                    <Veins name='gstaPeridotitePrefersVeins' block='GeoStrata:geostrata_rock_peridotite_smooth'  inherits='gstaPeridotiteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -770,14 +774,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Granulite -->
                 <IfCondition condition=':= gstaGranuliteDist = "layeredVeins"'>
                 
-                    <Veins name='gstaGranuliteBaseVeins' block='GeoStrata:geostrata_rock_granulite_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaGranuliteBaseVeins' block='GeoStrata:geostrata_rock_granulite_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60AEB3AB</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaGranuliteSize * _default_' range=':= 1 * 1 * gstaGranuliteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaGranuliteSize * _default_' range=':= 1 * 1 * gstaGranuliteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaGranuliteFreq * _default_'/>
@@ -785,7 +790,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Granulite Layered Veins) Settings -->
-                    <Veins name='gstaGranulitePrefersVeins' block='GeoStrata:geostrata_rock_granulite_smooth' inherits='gstaGranuliteBaseVeins'>
+                    <Veins name='gstaGranulitePrefersVeins' block='GeoStrata:geostrata_rock_granulite_smooth'  inherits='gstaGranuliteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -807,14 +812,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Migmatite -->
                 <IfCondition condition=':= gstaMigmatiteDist = "layeredVeins"'>
                 
-                    <Veins name='gstaMigmatiteBaseVeins' block='GeoStrata:geostrata_rock_migmatite_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaMigmatiteBaseVeins' block='GeoStrata:geostrata_rock_migmatite_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6092958C</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaMigmatiteSize * _default_' range=':= 1 * 1 * gstaMigmatiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaMigmatiteSize * _default_' range=':= 1 * 1 * gstaMigmatiteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaMigmatiteFreq * _default_'/>
@@ -822,7 +828,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Migmatite Layered Veins) Settings -->
-                    <Veins name='gstaMigmatitePrefersVeins' block='GeoStrata:geostrata_rock_migmatite_smooth' inherits='gstaMigmatiteBaseVeins'>
+                    <Veins name='gstaMigmatitePrefersVeins' block='GeoStrata:geostrata_rock_migmatite_smooth'  inherits='gstaMigmatiteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -844,14 +850,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Schist -->
                 <IfCondition condition=':= gstaSchistDist = "layeredVeins"'>
                 
-                    <Veins name='gstaSchistBaseVeins' block='GeoStrata:geostrata_rock_schist_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaSchistBaseVeins' block='GeoStrata:geostrata_rock_schist_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x604B4C52</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaSchistSize * _default_' range=':= 1 * 1 * gstaSchistSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaSchistSize * _default_' range=':= 1 * 1 * gstaSchistSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaSchistFreq * _default_'/>
@@ -859,7 +866,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Schist Layered Veins) Settings -->
-                    <Veins name='gstaSchistPrefersVeins' block='GeoStrata:geostrata_rock_schist_smooth' inherits='gstaSchistBaseVeins'>
+                    <Veins name='gstaSchistPrefersVeins' block='GeoStrata:geostrata_rock_schist_smooth'  inherits='gstaSchistBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -881,14 +888,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Basalt -->
                 <IfCondition condition=':= gstaBasaltDist = "layeredVeins"'>
                 
-                    <Veins name='gstaBasaltBaseVeins' block='GeoStrata:geostrata_rock_basalt_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaBasaltBaseVeins' block='GeoStrata:geostrata_rock_basalt_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60383844</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaBasaltSize * _default_' range=':= 1 * 1 * gstaBasaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaBasaltSize * _default_' range=':= 1 * 1 * gstaBasaltSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaBasaltFreq * _default_'/>
@@ -896,7 +904,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Basalt Layered Veins) Settings -->
-                    <Veins name='gstaBasaltPrefersVeins' block='GeoStrata:geostrata_rock_basalt_smooth' inherits='gstaBasaltBaseVeins'>
+                    <Veins name='gstaBasaltPrefersVeins' block='GeoStrata:geostrata_rock_basalt_smooth'  inherits='gstaBasaltBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -918,14 +926,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Onyx -->
                 <IfCondition condition=':= gstaOnyxDist = "layeredVeins"'>
                 
-                    <Veins name='gstaOnyxBaseVeins' block='GeoStrata:geostrata_rock_onyx_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaOnyxBaseVeins' block='GeoStrata:geostrata_rock_onyx_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60303030</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaOnyxSize * _default_' range=':= 1 * 1 * gstaOnyxSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaOnyxSize * _default_' range=':= 1 * 1 * gstaOnyxSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaOnyxFreq * _default_'/>
@@ -933,7 +942,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Onyx Layered Veins) Settings -->
-                    <Veins name='gstaOnyxPrefersVeins' block='GeoStrata:geostrata_rock_onyx_smooth' inherits='gstaOnyxBaseVeins'>
+                    <Veins name='gstaOnyxPrefersVeins' block='GeoStrata:geostrata_rock_onyx_smooth'  inherits='gstaOnyxBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -955,14 +964,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Quartz -->
                 <IfCondition condition=':= gstaQuartzDist = "layeredVeins"'>
                 
-                    <Veins name='gstaQuartzBaseVeins' block='GeoStrata:geostrata_rock_quartz_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaQuartzBaseVeins' block='GeoStrata:geostrata_rock_quartz_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C9D2D9</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaQuartzSize * _default_' range=':= 1 * 1 * gstaQuartzSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaQuartzSize * _default_' range=':= 1 * 1 * gstaQuartzSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaQuartzFreq * _default_'/>
@@ -970,7 +980,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Quartz Layered Veins) Settings -->
-                    <Veins name='gstaQuartzPrefersVeins' block='GeoStrata:geostrata_rock_quartz_smooth' inherits='gstaQuartzBaseVeins'>
+                    <Veins name='gstaQuartzPrefersVeins' block='GeoStrata:geostrata_rock_quartz_smooth'  inherits='gstaQuartzBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -992,14 +1002,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Marble -->
                 <IfCondition condition=':= gstaMarbleDist = "layeredVeins"'>
                 
-                    <Veins name='gstaMarbleBaseVeins' block='GeoStrata:geostrata_rock_marble_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaMarbleBaseVeins' block='GeoStrata:geostrata_rock_marble_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B4B4BC</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaMarbleSize * _default_' range=':= 1 * 1 * gstaMarbleSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaMarbleSize * _default_' range=':= 1 * 1 * gstaMarbleSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaMarbleFreq * _default_'/>
@@ -1007,7 +1018,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Marble Layered Veins) Settings -->
-                    <Veins name='gstaMarblePrefersVeins' block='GeoStrata:geostrata_rock_marble_smooth' inherits='gstaMarbleBaseVeins'>
+                    <Veins name='gstaMarblePrefersVeins' block='GeoStrata:geostrata_rock_marble_smooth'  inherits='gstaMarbleBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1029,14 +1040,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Granite -->
                 <IfCondition condition=':= gstaGraniteDist = "layeredVeins"'>
                 
-                    <Veins name='gstaGraniteBaseVeins' block='GeoStrata:geostrata_rock_granite_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaGraniteBaseVeins' block='GeoStrata:geostrata_rock_granite_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60CA9C7F</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaGraniteSize * _default_' range=':= 1 * 1 * gstaGraniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaGraniteSize * _default_' range=':= 1 * 1 * gstaGraniteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaGraniteFreq * _default_'/>
@@ -1044,7 +1056,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Granite Layered Veins) Settings -->
-                    <Veins name='gstaGranitePrefersVeins' block='GeoStrata:geostrata_rock_granite_smooth' inherits='gstaGraniteBaseVeins'>
+                    <Veins name='gstaGranitePrefersVeins' block='GeoStrata:geostrata_rock_granite_smooth'  inherits='gstaGraniteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1066,14 +1078,15 @@ Hornfel
                 <!-- Begin Layered Veins distribution of Hornfel -->
                 <IfCondition condition=':= gstaHornfelDist = "layeredVeins"'>
                 
-                    <Veins name='gstaHornfelBaseVeins' block='GeoStrata:geostrata_rock_hornfel_smooth' inherits='PresetLayeredVeins'>
+                    <Veins name='gstaHornfelBaseVeins' block='GeoStrata:geostrata_rock_hornfel_smooth'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A4A7B0</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaHornfelSize * _default_' range=':= 1 * 1 * gstaHornfelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaHornfelSize * _default_' range=':= 1 * 1 * gstaHornfelSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaHornfelFreq * _default_'/>
@@ -1081,7 +1094,7 @@ Hornfel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Hornfel Layered Veins) Settings -->
-                    <Veins name='gstaHornfelPrefersVeins' block='GeoStrata:geostrata_rock_hornfel_smooth' inherits='gstaHornfelBaseVeins'>
+                    <Veins name='gstaHornfelPrefersVeins' block='GeoStrata:geostrata_rock_hornfel_smooth'  inherits='gstaHornfelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -1,17 +1,14 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Metallurgy 4 Module
-
-Generates: 
-Sulfur, Phosphorite, Saltpeter, Magnesium, Bitumen, Potash, Copper,
-Tin, Manganese, Zinc, Silver, Platinum, Promethium, Deep Iron,
-Infuscolium, Oureclase, Astral Silver, Carmot, Mithril, Rubracium,
-Orichalcum, Adamantine, Atlarus, Ignatius, Shadow Iron, Lemurite,
-Midasium, Vyroxeres, Ceruclase, Alduorite, Kalendrite, Vulcanite,
-Sanguinite, Eximite, Meutoite
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Metallurgy 4" Module: This configuration
+      covers sulfur, phosphorite, saltpeter, magnesium, bitumen,
+      potash, copper,  tin, manganese, zinc, silver, platinum,
+      promethium, deep iron,  infuscolium, oureclase, astral silver,
+      carmot, mithril, rubracium,  orichalcum, adamantine, atlarus,
+      ignatius, shadow iron, lemurite,  midasium, vyroxeres,
+      ceruclase, alduorite, kalendrite, vulcanite,  sanguinite,
+      eximite, and meutoite.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="Metallurgy">
@@ -1407,19 +1404,19 @@ Sanguinite, Eximite, Meutoite
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='Metallurgy:utility.ore:0' />
+                    <Replaces block='Metallurgy:utility.ore' />
                     <Replaces block='Metallurgy:utility.ore:1' />
                     <Replaces block='Metallurgy:utility.ore:2' />
                     <Replaces block='Metallurgy:utility.ore:3' />
                     <Replaces block='Metallurgy:utility.ore:4' />
                     <Replaces block='Metallurgy:utility.ore:5' />
-                    <Replaces block='Metallurgy:base.ore:0' />
+                    <Replaces block='Metallurgy:base.ore' />
                     <Replaces block='Metallurgy:base.ore:1' />
                     <Replaces block='Metallurgy:base.ore:2' />
-                    <Replaces block='Metallurgy:precious.ore:0' />
+                    <Replaces block='Metallurgy:precious.ore' />
                     <Replaces block='Metallurgy:precious.ore:1' />
                     <Replaces block='Metallurgy:precious.ore:2' />
-                    <Replaces block='Metallurgy:fantasy.ore:0' />
+                    <Replaces block='Metallurgy:fantasy.ore' />
                     <Replaces block='Metallurgy:fantasy.ore:1' />
                     <Replaces block='Metallurgy:fantasy.ore:2' />
                     <Replaces block='Metallurgy:fantasy.ore:4' />
@@ -1440,17 +1437,21 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin SparseVeins distribution of Sulfur -->
                 <IfCondition condition=':= mtlgSulfurDist = "sparseVeins"'>
                 
-                    <Veins name='mtlgSulfurBaseVeins' block='Metallurgy:utility.ore' inherits='PresetSparseVeins'>
+                    <Veins name='mtlgSulfurBaseVeins' block='Metallurgy:utility.ore'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FCF570</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgSulfurSize * _default_' range=':= 1 * 1 * mtlgSulfurSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgSulfurSize * _default_' range=':= 1 * 1 * mtlgSulfurSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgSulfurFreq * _default_'/>
@@ -1461,7 +1462,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Sulfur Sparse Veins) Settings -->
-                    <Veins name='mtlgSulfurPrefersVeins' block='Metallurgy:utility.ore' inherits='mtlgSulfurBaseVeins'>
+                    <Veins name='mtlgSulfurPrefersVeins' block='Metallurgy:utility.ore'  inherits='mtlgSulfurBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1479,22 +1480,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Small Deposits distribution of Sulfur -->
                 <IfCondition condition=':= mtlgSulfurDist = "smallDeposits"'>
                 
-                    <Veins name='mtlgSulfurBaseVeins' block='Metallurgy:utility.ore' inherits='PresetSmallDeposits'>
+                    <Veins name='mtlgSulfurBaseVeins' block='Metallurgy:utility.ore'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FCF570</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgSulfurSize * _default_' range=':= 1 * 1 * mtlgSulfurSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgSulfurSize * _default_' range=':= 1 * 1 * mtlgSulfurSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgSulfurFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Sulfur Small Deposits) Settings -->
-                    <Veins name='mtlgSulfurPrefersVeins' block='Metallurgy:utility.ore' inherits='mtlgSulfurBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Sulfur Deposit Veins) Settings -->
+                    <Veins name='mtlgSulfurPrefersVeins' block='Metallurgy:utility.ore'  inherits='mtlgSulfurBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1503,7 +1508,7 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Desert'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Sulfur Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Sulfur Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Sulfur -->
@@ -1514,12 +1519,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgSulfurBaseCloud' block='Metallurgy:utility.ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FCF570</WireframeColor>
@@ -1534,10 +1543,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Sulfur Strategic Cloud Hint Veins -->
                         <Veins name='mtlgSulfurBaseHintVeins' block='Metallurgy:utility.ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FCF570</WireframeColor>
@@ -1581,17 +1596,21 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin SparseVeins distribution of Phosphorite -->
                 <IfCondition condition=':= mtlgPhosphoriteDist = "sparseVeins"'>
                 
-                    <Veins name='mtlgPhosphoriteBaseVeins' block='Metallurgy:utility.ore:1' inherits='PresetSparseVeins'>
+                    <Veins name='mtlgPhosphoriteBaseVeins' block='Metallurgy:utility.ore:1'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608D6161</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgPhosphoriteSize * _default_' range=':= 1 * 1 * mtlgPhosphoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgPhosphoriteSize * _default_' range=':= 1 * 1 * mtlgPhosphoriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgPhosphoriteFreq * _default_'/>
@@ -1602,7 +1621,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Phosphorite Sparse Veins) Settings -->
-                    <Veins name='mtlgPhosphoritePrefersVeins' block='Metallurgy:utility.ore:1' inherits='mtlgPhosphoriteBaseVeins'>
+                    <Veins name='mtlgPhosphoritePrefersVeins' block='Metallurgy:utility.ore:1'  inherits='mtlgPhosphoriteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1620,22 +1639,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Small Deposits distribution of Phosphorite -->
                 <IfCondition condition=':= mtlgPhosphoriteDist = "smallDeposits"'>
                 
-                    <Veins name='mtlgPhosphoriteBaseVeins' block='Metallurgy:utility.ore:1' inherits='PresetSmallDeposits'>
+                    <Veins name='mtlgPhosphoriteBaseVeins' block='Metallurgy:utility.ore:1'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608D6161</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgPhosphoriteSize * _default_' range=':= 1 * 1 * mtlgPhosphoriteSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgPhosphoriteSize * _default_' range=':= 1 * 1 * mtlgPhosphoriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgPhosphoriteFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Phosphorite Small Deposits) Settings -->
-                    <Veins name='mtlgPhosphoritePrefersVeins' block='Metallurgy:utility.ore:1' inherits='mtlgPhosphoriteBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Phosphorite Deposit Veins) Settings -->
+                    <Veins name='mtlgPhosphoritePrefersVeins' block='Metallurgy:utility.ore:1'  inherits='mtlgPhosphoriteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1644,7 +1667,7 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Phosphorite Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Phosphorite Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Phosphorite -->
@@ -1655,12 +1678,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgPhosphoriteBaseCloud' block='Metallurgy:utility.ore:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608D6161</WireframeColor>
@@ -1675,10 +1702,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Phosphorite Strategic Cloud Hint Veins -->
                         <Veins name='mtlgPhosphoriteBaseHintVeins' block='Metallurgy:utility.ore:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x608D6161</WireframeColor>
@@ -1722,17 +1755,21 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin SparseVeins distribution of Saltpeter -->
                 <IfCondition condition=':= mtlgSaltpeterDist = "sparseVeins"'>
                 
-                    <Veins name='mtlgSaltpeterBaseVeins' block='Metallurgy:utility.ore:2' inherits='PresetSparseVeins'>
+                    <Veins name='mtlgSaltpeterBaseVeins' block='Metallurgy:utility.ore:2'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEAEA</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgSaltpeterSize * _default_' range=':= 1 * 1 * mtlgSaltpeterSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgSaltpeterSize * _default_' range=':= 1 * 1 * mtlgSaltpeterSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgSaltpeterFreq * _default_'/>
@@ -1743,7 +1780,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Saltpeter Sparse Veins) Settings -->
-                    <Veins name='mtlgSaltpeterPrefersVeins' block='Metallurgy:utility.ore:2' inherits='mtlgSaltpeterBaseVeins'>
+                    <Veins name='mtlgSaltpeterPrefersVeins' block='Metallurgy:utility.ore:2'  inherits='mtlgSaltpeterBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1761,22 +1798,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Small Deposits distribution of Saltpeter -->
                 <IfCondition condition=':= mtlgSaltpeterDist = "smallDeposits"'>
                 
-                    <Veins name='mtlgSaltpeterBaseVeins' block='Metallurgy:utility.ore:2' inherits='PresetSmallDeposits'>
+                    <Veins name='mtlgSaltpeterBaseVeins' block='Metallurgy:utility.ore:2'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEAEA</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgSaltpeterSize * _default_' range=':= 1 * 1 * mtlgSaltpeterSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgSaltpeterSize * _default_' range=':= 1 * 1 * mtlgSaltpeterSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgSaltpeterFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Saltpeter Small Deposits) Settings -->
-                    <Veins name='mtlgSaltpeterPrefersVeins' block='Metallurgy:utility.ore:2' inherits='mtlgSaltpeterBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Saltpeter Deposit Veins) Settings -->
+                    <Veins name='mtlgSaltpeterPrefersVeins' block='Metallurgy:utility.ore:2'  inherits='mtlgSaltpeterBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1785,7 +1826,7 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Desert'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Saltpeter Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Saltpeter Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Saltpeter -->
@@ -1796,12 +1837,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgSaltpeterBaseCloud' block='Metallurgy:utility.ore:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEAEA</WireframeColor>
@@ -1816,10 +1861,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Saltpeter Strategic Cloud Hint Veins -->
                         <Veins name='mtlgSaltpeterBaseHintVeins' block='Metallurgy:utility.ore:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60EAEAEA</WireframeColor>
@@ -1863,17 +1914,21 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin SparseVeins distribution of Magnesium -->
                 <IfCondition condition=':= mtlgMagnesiumDist = "sparseVeins"'>
                 
-                    <Veins name='mtlgMagnesiumBaseVeins' block='Metallurgy:utility.ore:3' inherits='PresetSparseVeins'>
+                    <Veins name='mtlgMagnesiumBaseVeins' block='Metallurgy:utility.ore:3'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60927C6C</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgMagnesiumSize * _default_' range=':= 1 * 1 * mtlgMagnesiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgMagnesiumSize * _default_' range=':= 1 * 1 * mtlgMagnesiumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgMagnesiumFreq * _default_'/>
@@ -1884,7 +1939,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Magnesium Sparse Veins) Settings -->
-                    <Veins name='mtlgMagnesiumPrefersVeins' block='Metallurgy:utility.ore:3' inherits='mtlgMagnesiumBaseVeins'>
+                    <Veins name='mtlgMagnesiumPrefersVeins' block='Metallurgy:utility.ore:3'  inherits='mtlgMagnesiumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1902,22 +1957,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Small Deposits distribution of Magnesium -->
                 <IfCondition condition=':= mtlgMagnesiumDist = "smallDeposits"'>
                 
-                    <Veins name='mtlgMagnesiumBaseVeins' block='Metallurgy:utility.ore:3' inherits='PresetSmallDeposits'>
+                    <Veins name='mtlgMagnesiumBaseVeins' block='Metallurgy:utility.ore:3'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60927C6C</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgMagnesiumSize * _default_' range=':= 1 * 1 * mtlgMagnesiumSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgMagnesiumSize * _default_' range=':= 1 * 1 * mtlgMagnesiumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgMagnesiumFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Magnesium Small Deposits) Settings -->
-                    <Veins name='mtlgMagnesiumPrefersVeins' block='Metallurgy:utility.ore:3' inherits='mtlgMagnesiumBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Magnesium Deposit Veins) Settings -->
+                    <Veins name='mtlgMagnesiumPrefersVeins' block='Metallurgy:utility.ore:3'  inherits='mtlgMagnesiumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1926,7 +1985,7 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Magnesium Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Magnesium Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Magnesium -->
@@ -1937,12 +1996,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgMagnesiumBaseCloud' block='Metallurgy:utility.ore:3' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60927C6C</WireframeColor>
@@ -1957,10 +2020,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Magnesium Strategic Cloud Hint Veins -->
                         <Veins name='mtlgMagnesiumBaseHintVeins' block='Metallurgy:utility.ore:3' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60927C6C</WireframeColor>
@@ -2004,17 +2073,21 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin SparseVeins distribution of Bitumen -->
                 <IfCondition condition=':= mtlgBitumenDist = "sparseVeins"'>
                 
-                    <Veins name='mtlgBitumenBaseVeins' block='Metallurgy:utility.ore:4' inherits='PresetSparseVeins'>
+                    <Veins name='mtlgBitumenBaseVeins' block='Metallurgy:utility.ore:4'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602A2A2A</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgBitumenSize * _default_' range=':= 1 * 1 * mtlgBitumenSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgBitumenSize * _default_' range=':= 1 * 1 * mtlgBitumenSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgBitumenFreq * _default_'/>
@@ -2025,7 +2098,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Bitumen Sparse Veins) Settings -->
-                    <Veins name='mtlgBitumenPrefersVeins' block='Metallurgy:utility.ore:4' inherits='mtlgBitumenBaseVeins'>
+                    <Veins name='mtlgBitumenPrefersVeins' block='Metallurgy:utility.ore:4'  inherits='mtlgBitumenBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2043,22 +2116,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Small Deposits distribution of Bitumen -->
                 <IfCondition condition=':= mtlgBitumenDist = "smallDeposits"'>
                 
-                    <Veins name='mtlgBitumenBaseVeins' block='Metallurgy:utility.ore:4' inherits='PresetSmallDeposits'>
+                    <Veins name='mtlgBitumenBaseVeins' block='Metallurgy:utility.ore:4'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602A2A2A</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgBitumenSize * _default_' range=':= 1 * 1 * mtlgBitumenSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgBitumenSize * _default_' range=':= 1 * 1 * mtlgBitumenSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgBitumenFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Bitumen Small Deposits) Settings -->
-                    <Veins name='mtlgBitumenPrefersVeins' block='Metallurgy:utility.ore:4' inherits='mtlgBitumenBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Bitumen Deposit Veins) Settings -->
+                    <Veins name='mtlgBitumenPrefersVeins' block='Metallurgy:utility.ore:4'  inherits='mtlgBitumenBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2067,7 +2144,7 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Swamp'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Bitumen Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Bitumen Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Bitumen -->
@@ -2078,12 +2155,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgBitumenBaseCloud' block='Metallurgy:utility.ore:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602A2A2A</WireframeColor>
@@ -2098,10 +2179,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Bitumen Strategic Cloud Hint Veins -->
                         <Veins name='mtlgBitumenBaseHintVeins' block='Metallurgy:utility.ore:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x602A2A2A</WireframeColor>
@@ -2145,17 +2232,21 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin SparseVeins distribution of Potash -->
                 <IfCondition condition=':= mtlgPotashDist = "sparseVeins"'>
                 
-                    <Veins name='mtlgPotashBaseVeins' block='Metallurgy:utility.ore:5' inherits='PresetSparseVeins'>
+                    <Veins name='mtlgPotashBaseVeins' block='Metallurgy:utility.ore:5'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFAA00</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgPotashSize * _default_' range=':= 1 * 1 * mtlgPotashSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgPotashSize * _default_' range=':= 1 * 1 * mtlgPotashSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgPotashFreq * _default_'/>
@@ -2166,7 +2257,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Potash Sparse Veins) Settings -->
-                    <Veins name='mtlgPotashPrefersVeins' block='Metallurgy:utility.ore:5' inherits='mtlgPotashBaseVeins'>
+                    <Veins name='mtlgPotashPrefersVeins' block='Metallurgy:utility.ore:5'  inherits='mtlgPotashBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2184,22 +2275,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Small Deposits distribution of Potash -->
                 <IfCondition condition=':= mtlgPotashDist = "smallDeposits"'>
                 
-                    <Veins name='mtlgPotashBaseVeins' block='Metallurgy:utility.ore:5' inherits='PresetSmallDeposits'>
+                    <Veins name='mtlgPotashBaseVeins' block='Metallurgy:utility.ore:5'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFAA00</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgPotashSize * _default_' range=':= 1 * 1 * mtlgPotashSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgPotashSize * _default_' range=':= 1 * 1 * mtlgPotashSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgPotashFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Potash Small Deposits) Settings -->
-                    <Veins name='mtlgPotashPrefersVeins' block='Metallurgy:utility.ore:5' inherits='mtlgPotashBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Potash Deposit Veins) Settings -->
+                    <Veins name='mtlgPotashPrefersVeins' block='Metallurgy:utility.ore:5'  inherits='mtlgPotashBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2208,7 +2303,7 @@ Sanguinite, Eximite, Meutoite
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Swamp'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Potash Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Potash Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Potash -->
@@ -2219,12 +2314,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgPotashBaseCloud' block='Metallurgy:utility.ore:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFAA00</WireframeColor>
@@ -2239,10 +2338,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Potash Strategic Cloud Hint Veins -->
                         <Veins name='mtlgPotashBaseHintVeins' block='Metallurgy:utility.ore:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FFAA00</WireframeColor>
@@ -2286,14 +2391,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Copper -->
                 <IfCondition condition=':= mtlgCopperDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgCopperBaseVeins' block='Metallurgy:base.ore' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgCopperBaseVeins' block='Metallurgy:base.ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EA6515</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgCopperSize * _default_' range=':= 1 * 1 * mtlgCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgCopperSize * _default_' range=':= 1 * 1 * mtlgCopperSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * mtlgCopperFreq * _default_'/>
@@ -2302,7 +2408,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='mtlgCopperPrefersVeins' block='Metallurgy:base.ore' inherits='mtlgCopperBaseVeins'>
+                    <Veins name='mtlgCopperPrefersVeins' block='Metallurgy:base.ore'  inherits='mtlgCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2321,16 +2427,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= mtlgCopperDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgCopperBaseVeins' block='Metallurgy:base.ore' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgCopperBaseVeins' block='Metallurgy:base.ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EA6515</WireframeColor>
@@ -2344,7 +2460,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                    <Veins name='mtlgCopperPrefersVeins' block='Metallurgy:base.ore' inherits='mtlgCopperBaseVeins'>
+                    <Veins name='mtlgCopperPrefersVeins' block='Metallurgy:base.ore'  inherits='mtlgCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2365,12 +2481,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgCopperBaseCloud' block='Metallurgy:base.ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EA6515</WireframeColor>
@@ -2385,10 +2505,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Copper Strategic Cloud Hint Veins -->
                         <Veins name='mtlgCopperBaseHintVeins' block='Metallurgy:base.ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60EA6515</WireframeColor>
@@ -2432,14 +2558,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Tin -->
                 <IfCondition condition=':= mtlgTinDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgTinBaseVeins' block='Metallurgy:base.ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgTinBaseVeins' block='Metallurgy:base.ore:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BDBDBD</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgTinSize * _default_' range=':= 1 * 1 * mtlgTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgTinSize * _default_' range=':= 1 * 1 * mtlgTinSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * mtlgTinFreq * _default_'/>
@@ -2448,7 +2575,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='mtlgTinPrefersVeins' block='Metallurgy:base.ore:1' inherits='mtlgTinBaseVeins'>
+                    <Veins name='mtlgTinPrefersVeins' block='Metallurgy:base.ore:1'  inherits='mtlgTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2467,16 +2594,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= mtlgTinDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgTinBaseVeins' block='Metallurgy:base.ore:1' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgTinBaseVeins' block='Metallurgy:base.ore:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BDBDBD</WireframeColor>
@@ -2490,7 +2627,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                    <Veins name='mtlgTinPrefersVeins' block='Metallurgy:base.ore:1' inherits='mtlgTinBaseVeins'>
+                    <Veins name='mtlgTinPrefersVeins' block='Metallurgy:base.ore:1'  inherits='mtlgTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2511,12 +2648,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgTinBaseCloud' block='Metallurgy:base.ore:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BDBDBD</WireframeColor>
@@ -2531,10 +2672,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Tin Strategic Cloud Hint Veins -->
                         <Veins name='mtlgTinBaseHintVeins' block='Metallurgy:base.ore:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60BDBDBD</WireframeColor>
@@ -2578,14 +2725,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Manganese -->
                 <IfCondition condition=':= mtlgManganeseDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgManganeseBaseVeins' block='Metallurgy:base.ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgManganeseBaseVeins' block='Metallurgy:base.ore:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FCC7C7</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgManganeseSize * _default_' range=':= 1 * 1 * mtlgManganeseSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgManganeseSize * _default_' range=':= 1 * 1 * mtlgManganeseSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * mtlgManganeseFreq * _default_'/>
@@ -2594,7 +2742,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Manganese Layered Veins) Settings -->
-                    <Veins name='mtlgManganesePrefersVeins' block='Metallurgy:base.ore:2' inherits='mtlgManganeseBaseVeins'>
+                    <Veins name='mtlgManganesePrefersVeins' block='Metallurgy:base.ore:2'  inherits='mtlgManganeseBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2613,16 +2761,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Manganese -->
                 <IfCondition condition=':= mtlgManganeseDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgManganeseBaseVeins' block='Metallurgy:base.ore:2' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgManganeseBaseVeins' block='Metallurgy:base.ore:2'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FCC7C7</WireframeColor>
@@ -2636,7 +2794,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Manganese Huge Veins) Settings -->
-                    <Veins name='mtlgManganesePrefersVeins' block='Metallurgy:base.ore:2' inherits='mtlgManganeseBaseVeins'>
+                    <Veins name='mtlgManganesePrefersVeins' block='Metallurgy:base.ore:2'  inherits='mtlgManganeseBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2657,12 +2815,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgManganeseBaseCloud' block='Metallurgy:base.ore:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FCC7C7</WireframeColor>
@@ -2677,10 +2839,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Manganese Strategic Cloud Hint Veins -->
                         <Veins name='mtlgManganeseBaseHintVeins' block='Metallurgy:base.ore:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FCC7C7</WireframeColor>
@@ -2724,14 +2892,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Zinc -->
                 <IfCondition condition=':= mtlgZincDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgZincBaseVeins' block='Metallurgy:precious.ore' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgZincBaseVeins' block='Metallurgy:precious.ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BFC55C</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgZincSize * _default_' range=':= 1 * 0.8 * mtlgZincSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgZincSize * _default_' range=':= 1 * 0.8 * mtlgZincSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgZincFreq * _default_'/>
@@ -2742,7 +2911,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Zinc Layered Veins) Settings -->
-                    <Veins name='mtlgZincPrefersVeins' block='Metallurgy:precious.ore' inherits='mtlgZincBaseVeins'>
+                    <Veins name='mtlgZincPrefersVeins' block='Metallurgy:precious.ore'  inherits='mtlgZincBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2760,16 +2929,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Zinc -->
                 <IfCondition condition=':= mtlgZincDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgZincBaseVeins' block='Metallurgy:precious.ore' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgZincBaseVeins' block='Metallurgy:precious.ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BFC55C</WireframeColor>
@@ -2785,7 +2964,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Zinc Huge Veins) Settings -->
-                    <Veins name='mtlgZincPrefersVeins' block='Metallurgy:precious.ore' inherits='mtlgZincBaseVeins'>
+                    <Veins name='mtlgZincPrefersVeins' block='Metallurgy:precious.ore'  inherits='mtlgZincBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2805,12 +2984,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgZincBaseCloud' block='Metallurgy:precious.ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BFC55C</WireframeColor>
@@ -2825,10 +3008,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Zinc Strategic Cloud Hint Veins -->
                         <Veins name='mtlgZincBaseHintVeins' block='Metallurgy:precious.ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60BFC55C</WireframeColor>
@@ -2872,14 +3061,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Silver -->
                 <IfCondition condition=':= mtlgSilverDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgSilverBaseVeins' block='Metallurgy:precious.ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgSilverBaseVeins' block='Metallurgy:precious.ore:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E1E1E1</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * mtlgSilverSize * _default_' range=':= 1 * 0.85 * mtlgSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.85 * mtlgSilverSize * _default_' range=':= 1 * 0.85 * mtlgSilverSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgSilverFreq * _default_'/>
@@ -2890,7 +3080,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                    <Veins name='mtlgSilverPrefersVeins' block='Metallurgy:precious.ore:1' inherits='mtlgSilverBaseVeins'>
+                    <Veins name='mtlgSilverPrefersVeins' block='Metallurgy:precious.ore:1'  inherits='mtlgSilverBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2908,16 +3098,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Silver -->
                 <IfCondition condition=':= mtlgSilverDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgSilverBaseVeins' block='Metallurgy:precious.ore:1' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgSilverBaseVeins' block='Metallurgy:precious.ore:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E1E1E1</WireframeColor>
@@ -2933,7 +3133,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Huge Veins) Settings -->
-                    <Veins name='mtlgSilverPrefersVeins' block='Metallurgy:precious.ore:1' inherits='mtlgSilverBaseVeins'>
+                    <Veins name='mtlgSilverPrefersVeins' block='Metallurgy:precious.ore:1'  inherits='mtlgSilverBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -2953,12 +3153,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgSilverBaseCloud' block='Metallurgy:precious.ore:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E1E1E1</WireframeColor>
@@ -2973,10 +3177,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Silver Strategic Cloud Hint Veins -->
                         <Veins name='mtlgSilverBaseHintVeins' block='Metallurgy:precious.ore:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E1E1E1</WireframeColor>
@@ -3020,14 +3230,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Platinum -->
                 <IfCondition condition=':= mtlgPlatinumDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgPlatinumBaseVeins' block='Metallurgy:precious.ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgPlatinumBaseVeins' block='Metallurgy:precious.ore:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B8D6DB</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgPlatinumSize * _default_' range=':= 1 * 0.8 * mtlgPlatinumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgPlatinumSize * _default_' range=':= 1 * 0.8 * mtlgPlatinumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgPlatinumFreq * _default_'/>
@@ -3038,7 +3249,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Platinum Layered Veins) Settings -->
-                    <Veins name='mtlgPlatinumPrefersVeins' block='Metallurgy:precious.ore:2' inherits='mtlgPlatinumBaseVeins'>
+                    <Veins name='mtlgPlatinumPrefersVeins' block='Metallurgy:precious.ore:2'  inherits='mtlgPlatinumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3056,16 +3267,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Platinum -->
                 <IfCondition condition=':= mtlgPlatinumDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgPlatinumBaseVeins' block='Metallurgy:precious.ore:2' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgPlatinumBaseVeins' block='Metallurgy:precious.ore:2'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B8D6DB</WireframeColor>
@@ -3081,7 +3302,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Platinum Huge Veins) Settings -->
-                    <Veins name='mtlgPlatinumPrefersVeins' block='Metallurgy:precious.ore:2' inherits='mtlgPlatinumBaseVeins'>
+                    <Veins name='mtlgPlatinumPrefersVeins' block='Metallurgy:precious.ore:2'  inherits='mtlgPlatinumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3101,12 +3322,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgPlatinumBaseCloud' block='Metallurgy:precious.ore:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B8D6DB</WireframeColor>
@@ -3121,10 +3346,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Platinum Strategic Cloud Hint Veins -->
                         <Veins name='mtlgPlatinumBaseHintVeins' block='Metallurgy:precious.ore:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60B8D6DB</WireframeColor>
@@ -3168,14 +3399,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Promethium -->
                 <IfCondition condition=':= mtlgPromethiumDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgPromethiumBaseVeins' block='Metallurgy:fantasy.ore' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgPromethiumBaseVeins' block='Metallurgy:fantasy.ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x605D8258</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgPromethiumSize * _default_' range=':= 1 * 0.8 * mtlgPromethiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgPromethiumSize * _default_' range=':= 1 * 0.8 * mtlgPromethiumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgPromethiumFreq * _default_'/>
@@ -3186,7 +3418,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Promethium Layered Veins) Settings -->
-                    <Veins name='mtlgPromethiumPrefersVeins' block='Metallurgy:fantasy.ore' inherits='mtlgPromethiumBaseVeins'>
+                    <Veins name='mtlgPromethiumPrefersVeins' block='Metallurgy:fantasy.ore'  inherits='mtlgPromethiumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3204,16 +3436,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Promethium -->
                 <IfCondition condition=':= mtlgPromethiumDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgPromethiumBaseVeins' block='Metallurgy:fantasy.ore' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgPromethiumBaseVeins' block='Metallurgy:fantasy.ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x605D8258</WireframeColor>
@@ -3229,7 +3471,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Promethium Huge Veins) Settings -->
-                    <Veins name='mtlgPromethiumPrefersVeins' block='Metallurgy:fantasy.ore' inherits='mtlgPromethiumBaseVeins'>
+                    <Veins name='mtlgPromethiumPrefersVeins' block='Metallurgy:fantasy.ore'  inherits='mtlgPromethiumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3249,12 +3491,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgPromethiumBaseCloud' block='Metallurgy:fantasy.ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x605D8258</WireframeColor>
@@ -3269,10 +3515,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Promethium Strategic Cloud Hint Veins -->
                         <Veins name='mtlgPromethiumBaseHintVeins' block='Metallurgy:fantasy.ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x605D8258</WireframeColor>
@@ -3316,14 +3568,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Deep Iron -->
                 <IfCondition condition=':= mtlgDeepIronDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgDeepIronBaseVeins' block='Metallurgy:fantasy.ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgDeepIronBaseVeins' block='Metallurgy:fantasy.ore:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x604C5E6C</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgDeepIronSize * _default_' range=':= 1 * 0.8 * mtlgDeepIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgDeepIronSize * _default_' range=':= 1 * 0.8 * mtlgDeepIronSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgDeepIronFreq * _default_'/>
@@ -3334,7 +3587,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Deep Iron Layered Veins) Settings -->
-                    <Veins name='mtlgDeepIronPrefersVeins' block='Metallurgy:fantasy.ore:1' inherits='mtlgDeepIronBaseVeins'>
+                    <Veins name='mtlgDeepIronPrefersVeins' block='Metallurgy:fantasy.ore:1'  inherits='mtlgDeepIronBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3352,16 +3605,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Deep Iron -->
                 <IfCondition condition=':= mtlgDeepIronDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgDeepIronBaseVeins' block='Metallurgy:fantasy.ore:1' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgDeepIronBaseVeins' block='Metallurgy:fantasy.ore:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x604C5E6C</WireframeColor>
@@ -3377,7 +3640,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Deep Iron Huge Veins) Settings -->
-                    <Veins name='mtlgDeepIronPrefersVeins' block='Metallurgy:fantasy.ore:1' inherits='mtlgDeepIronBaseVeins'>
+                    <Veins name='mtlgDeepIronPrefersVeins' block='Metallurgy:fantasy.ore:1'  inherits='mtlgDeepIronBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3397,12 +3660,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgDeepIronBaseCloud' block='Metallurgy:fantasy.ore:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x604C5E6C</WireframeColor>
@@ -3417,10 +3684,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Deep Iron Strategic Cloud Hint Veins -->
                         <Veins name='mtlgDeepIronBaseHintVeins' block='Metallurgy:fantasy.ore:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x604C5E6C</WireframeColor>
@@ -3464,14 +3737,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Infuscolium -->
                 <IfCondition condition=':= mtlgInfuscoliumDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgInfuscoliumBaseVeins' block='Metallurgy:fantasy.ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgInfuscoliumBaseVeins' block='Metallurgy:fantasy.ore:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608B2656</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_' range=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_' range=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgInfuscoliumFreq * _default_'/>
@@ -3482,7 +3756,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Infuscolium Layered Veins) Settings -->
-                    <Veins name='mtlgInfuscoliumPrefersVeins' block='Metallurgy:fantasy.ore:2' inherits='mtlgInfuscoliumBaseVeins'>
+                    <Veins name='mtlgInfuscoliumPrefersVeins' block='Metallurgy:fantasy.ore:2'  inherits='mtlgInfuscoliumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3500,16 +3774,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Infuscolium -->
                 <IfCondition condition=':= mtlgInfuscoliumDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgInfuscoliumBaseVeins' block='Metallurgy:fantasy.ore:2' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgInfuscoliumBaseVeins' block='Metallurgy:fantasy.ore:2'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608B2656</WireframeColor>
@@ -3525,7 +3809,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Infuscolium Huge Veins) Settings -->
-                    <Veins name='mtlgInfuscoliumPrefersVeins' block='Metallurgy:fantasy.ore:2' inherits='mtlgInfuscoliumBaseVeins'>
+                    <Veins name='mtlgInfuscoliumPrefersVeins' block='Metallurgy:fantasy.ore:2'  inherits='mtlgInfuscoliumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3545,12 +3829,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgInfuscoliumBaseCloud' block='Metallurgy:fantasy.ore:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608B2656</WireframeColor>
@@ -3565,10 +3853,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Infuscolium Strategic Cloud Hint Veins -->
                         <Veins name='mtlgInfuscoliumBaseHintVeins' block='Metallurgy:fantasy.ore:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x608B2656</WireframeColor>
@@ -3612,14 +3906,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Oureclase -->
                 <IfCondition condition=':= mtlgOureclaseDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgOureclaseBaseVeins' block='Metallurgy:fantasy.ore:4' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgOureclaseBaseVeins' block='Metallurgy:fantasy.ore:4'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609A7607</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgOureclaseSize * _default_' range=':= 1 * 0.8 * mtlgOureclaseSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgOureclaseSize * _default_' range=':= 1 * 0.8 * mtlgOureclaseSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgOureclaseFreq * _default_'/>
@@ -3630,7 +3925,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Oureclase Layered Veins) Settings -->
-                    <Veins name='mtlgOureclasePrefersVeins' block='Metallurgy:fantasy.ore:4' inherits='mtlgOureclaseBaseVeins'>
+                    <Veins name='mtlgOureclasePrefersVeins' block='Metallurgy:fantasy.ore:4'  inherits='mtlgOureclaseBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3648,16 +3943,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Oureclase -->
                 <IfCondition condition=':= mtlgOureclaseDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgOureclaseBaseVeins' block='Metallurgy:fantasy.ore:4' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgOureclaseBaseVeins' block='Metallurgy:fantasy.ore:4'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609A7607</WireframeColor>
@@ -3673,7 +3978,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Oureclase Huge Veins) Settings -->
-                    <Veins name='mtlgOureclasePrefersVeins' block='Metallurgy:fantasy.ore:4' inherits='mtlgOureclaseBaseVeins'>
+                    <Veins name='mtlgOureclasePrefersVeins' block='Metallurgy:fantasy.ore:4'  inherits='mtlgOureclaseBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3693,12 +3998,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgOureclaseBaseCloud' block='Metallurgy:fantasy.ore:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609A7607</WireframeColor>
@@ -3713,10 +4022,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Oureclase Strategic Cloud Hint Veins -->
                         <Veins name='mtlgOureclaseBaseHintVeins' block='Metallurgy:fantasy.ore:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x609A7607</WireframeColor>
@@ -3760,14 +4075,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Astral Silver -->
                 <IfCondition condition=':= mtlgAstralSilverDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgAstralSilverBaseVeins' block='Metallurgy:fantasy.ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgAstralSilverBaseVeins' block='Metallurgy:fantasy.ore:5'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60ADC3C3</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgAstralSilverSize * _default_' range=':= 1 * 0.8 * mtlgAstralSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgAstralSilverSize * _default_' range=':= 1 * 0.8 * mtlgAstralSilverSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgAstralSilverFreq * _default_'/>
@@ -3778,7 +4094,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Astral Silver Layered Veins) Settings -->
-                    <Veins name='mtlgAstralSilverPrefersVeins' block='Metallurgy:fantasy.ore:5' inherits='mtlgAstralSilverBaseVeins'>
+                    <Veins name='mtlgAstralSilverPrefersVeins' block='Metallurgy:fantasy.ore:5'  inherits='mtlgAstralSilverBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3796,16 +4112,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Astral Silver -->
                 <IfCondition condition=':= mtlgAstralSilverDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgAstralSilverBaseVeins' block='Metallurgy:fantasy.ore:5' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgAstralSilverBaseVeins' block='Metallurgy:fantasy.ore:5'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60ADC3C3</WireframeColor>
@@ -3821,7 +4147,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Astral Silver Huge Veins) Settings -->
-                    <Veins name='mtlgAstralSilverPrefersVeins' block='Metallurgy:fantasy.ore:5' inherits='mtlgAstralSilverBaseVeins'>
+                    <Veins name='mtlgAstralSilverPrefersVeins' block='Metallurgy:fantasy.ore:5'  inherits='mtlgAstralSilverBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3841,12 +4167,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgAstralSilverBaseCloud' block='Metallurgy:fantasy.ore:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60ADC3C3</WireframeColor>
@@ -3861,10 +4191,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Astral Silver Strategic Cloud Hint Veins -->
                         <Veins name='mtlgAstralSilverBaseHintVeins' block='Metallurgy:fantasy.ore:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60ADC3C3</WireframeColor>
@@ -3908,14 +4244,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Carmot -->
                 <IfCondition condition=':= mtlgCarmotDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgCarmotBaseVeins' block='Metallurgy:fantasy.ore:6' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgCarmotBaseVeins' block='Metallurgy:fantasy.ore:6'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D7C986</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgCarmotSize * _default_' range=':= 1 * 0.8 * mtlgCarmotSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgCarmotSize * _default_' range=':= 1 * 0.8 * mtlgCarmotSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgCarmotFreq * _default_'/>
@@ -3926,7 +4263,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Carmot Layered Veins) Settings -->
-                    <Veins name='mtlgCarmotPrefersVeins' block='Metallurgy:fantasy.ore:6' inherits='mtlgCarmotBaseVeins'>
+                    <Veins name='mtlgCarmotPrefersVeins' block='Metallurgy:fantasy.ore:6'  inherits='mtlgCarmotBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3944,16 +4281,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Carmot -->
                 <IfCondition condition=':= mtlgCarmotDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgCarmotBaseVeins' block='Metallurgy:fantasy.ore:6' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgCarmotBaseVeins' block='Metallurgy:fantasy.ore:6'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D7C986</WireframeColor>
@@ -3969,7 +4316,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Carmot Huge Veins) Settings -->
-                    <Veins name='mtlgCarmotPrefersVeins' block='Metallurgy:fantasy.ore:6' inherits='mtlgCarmotBaseVeins'>
+                    <Veins name='mtlgCarmotPrefersVeins' block='Metallurgy:fantasy.ore:6'  inherits='mtlgCarmotBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -3989,12 +4336,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgCarmotBaseCloud' block='Metallurgy:fantasy.ore:6' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D7C986</WireframeColor>
@@ -4009,10 +4360,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Carmot Strategic Cloud Hint Veins -->
                         <Veins name='mtlgCarmotBaseHintVeins' block='Metallurgy:fantasy.ore:6' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60D7C986</WireframeColor>
@@ -4056,14 +4413,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Mithril -->
                 <IfCondition condition=':= mtlgMithrilDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgMithrilBaseVeins' block='Metallurgy:fantasy.ore:7' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgMithrilBaseVeins' block='Metallurgy:fantasy.ore:7'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609AF3F7</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgMithrilSize * _default_' range=':= 1 * 0.8 * mtlgMithrilSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgMithrilSize * _default_' range=':= 1 * 0.8 * mtlgMithrilSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgMithrilFreq * _default_'/>
@@ -4074,7 +4432,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Mithril Layered Veins) Settings -->
-                    <Veins name='mtlgMithrilPrefersVeins' block='Metallurgy:fantasy.ore:7' inherits='mtlgMithrilBaseVeins'>
+                    <Veins name='mtlgMithrilPrefersVeins' block='Metallurgy:fantasy.ore:7'  inherits='mtlgMithrilBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -4092,16 +4450,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Mithril -->
                 <IfCondition condition=':= mtlgMithrilDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgMithrilBaseVeins' block='Metallurgy:fantasy.ore:7' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgMithrilBaseVeins' block='Metallurgy:fantasy.ore:7'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609AF3F7</WireframeColor>
@@ -4117,7 +4485,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Mithril Huge Veins) Settings -->
-                    <Veins name='mtlgMithrilPrefersVeins' block='Metallurgy:fantasy.ore:7' inherits='mtlgMithrilBaseVeins'>
+                    <Veins name='mtlgMithrilPrefersVeins' block='Metallurgy:fantasy.ore:7'  inherits='mtlgMithrilBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -4137,12 +4505,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgMithrilBaseCloud' block='Metallurgy:fantasy.ore:7' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609AF3F7</WireframeColor>
@@ -4157,10 +4529,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Mithril Strategic Cloud Hint Veins -->
                         <Veins name='mtlgMithrilBaseHintVeins' block='Metallurgy:fantasy.ore:7' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x609AF3F7</WireframeColor>
@@ -4204,14 +4582,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Rubracium -->
                 <IfCondition condition=':= mtlgRubraciumDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgRubraciumBaseVeins' block='Metallurgy:fantasy.ore:8' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgRubraciumBaseVeins' block='Metallurgy:fantasy.ore:8'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A1363C</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgRubraciumSize * _default_' range=':= 1 * 0.8 * mtlgRubraciumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgRubraciumSize * _default_' range=':= 1 * 0.8 * mtlgRubraciumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgRubraciumFreq * _default_'/>
@@ -4222,7 +4601,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Rubracium Layered Veins) Settings -->
-                    <Veins name='mtlgRubraciumPrefersVeins' block='Metallurgy:fantasy.ore:8' inherits='mtlgRubraciumBaseVeins'>
+                    <Veins name='mtlgRubraciumPrefersVeins' block='Metallurgy:fantasy.ore:8'  inherits='mtlgRubraciumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -4240,16 +4619,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Rubracium -->
                 <IfCondition condition=':= mtlgRubraciumDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgRubraciumBaseVeins' block='Metallurgy:fantasy.ore:8' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgRubraciumBaseVeins' block='Metallurgy:fantasy.ore:8'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A1363C</WireframeColor>
@@ -4265,7 +4654,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Rubracium Huge Veins) Settings -->
-                    <Veins name='mtlgRubraciumPrefersVeins' block='Metallurgy:fantasy.ore:8' inherits='mtlgRubraciumBaseVeins'>
+                    <Veins name='mtlgRubraciumPrefersVeins' block='Metallurgy:fantasy.ore:8'  inherits='mtlgRubraciumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -4285,12 +4674,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgRubraciumBaseCloud' block='Metallurgy:fantasy.ore:8' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A1363C</WireframeColor>
@@ -4305,10 +4698,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Rubracium Strategic Cloud Hint Veins -->
                         <Veins name='mtlgRubraciumBaseHintVeins' block='Metallurgy:fantasy.ore:8' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60A1363C</WireframeColor>
@@ -4352,14 +4751,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Orichalcum -->
                 <IfCondition condition=':= mtlgOrichalcumDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgOrichalcumBaseVeins' block='Metallurgy:fantasy.ore:11' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgOrichalcumBaseVeins' block='Metallurgy:fantasy.ore:11'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60466432</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgOrichalcumSize * _default_' range=':= 1 * 0.8 * mtlgOrichalcumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgOrichalcumSize * _default_' range=':= 1 * 0.8 * mtlgOrichalcumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgOrichalcumFreq * _default_'/>
@@ -4370,7 +4770,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Orichalcum Layered Veins) Settings -->
-                    <Veins name='mtlgOrichalcumPrefersVeins' block='Metallurgy:fantasy.ore:11' inherits='mtlgOrichalcumBaseVeins'>
+                    <Veins name='mtlgOrichalcumPrefersVeins' block='Metallurgy:fantasy.ore:11'  inherits='mtlgOrichalcumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -4388,16 +4788,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Orichalcum -->
                 <IfCondition condition=':= mtlgOrichalcumDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgOrichalcumBaseVeins' block='Metallurgy:fantasy.ore:11' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgOrichalcumBaseVeins' block='Metallurgy:fantasy.ore:11'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60466432</WireframeColor>
@@ -4413,7 +4823,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Orichalcum Huge Veins) Settings -->
-                    <Veins name='mtlgOrichalcumPrefersVeins' block='Metallurgy:fantasy.ore:11' inherits='mtlgOrichalcumBaseVeins'>
+                    <Veins name='mtlgOrichalcumPrefersVeins' block='Metallurgy:fantasy.ore:11'  inherits='mtlgOrichalcumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -4433,12 +4843,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgOrichalcumBaseCloud' block='Metallurgy:fantasy.ore:11' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60466432</WireframeColor>
@@ -4453,10 +4867,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Orichalcum Strategic Cloud Hint Veins -->
                         <Veins name='mtlgOrichalcumBaseHintVeins' block='Metallurgy:fantasy.ore:11' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60466432</WireframeColor>
@@ -4500,14 +4920,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Adamantine -->
                 <IfCondition condition=':= mtlgAdamantineDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgAdamantineBaseVeins' block='Metallurgy:fantasy.ore:13' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgAdamantineBaseVeins' block='Metallurgy:fantasy.ore:13'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60AC0C0D</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgAdamantineSize * _default_' range=':= 1 * 0.8 * mtlgAdamantineSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgAdamantineSize * _default_' range=':= 1 * 0.8 * mtlgAdamantineSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgAdamantineFreq * _default_'/>
@@ -4518,7 +4939,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Adamantine Layered Veins) Settings -->
-                    <Veins name='mtlgAdamantinePrefersVeins' block='Metallurgy:fantasy.ore:13' inherits='mtlgAdamantineBaseVeins'>
+                    <Veins name='mtlgAdamantinePrefersVeins' block='Metallurgy:fantasy.ore:13'  inherits='mtlgAdamantineBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -4536,16 +4957,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Adamantine -->
                 <IfCondition condition=':= mtlgAdamantineDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgAdamantineBaseVeins' block='Metallurgy:fantasy.ore:13' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgAdamantineBaseVeins' block='Metallurgy:fantasy.ore:13'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60AC0C0D</WireframeColor>
@@ -4561,7 +4992,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Adamantine Huge Veins) Settings -->
-                    <Veins name='mtlgAdamantinePrefersVeins' block='Metallurgy:fantasy.ore:13' inherits='mtlgAdamantineBaseVeins'>
+                    <Veins name='mtlgAdamantinePrefersVeins' block='Metallurgy:fantasy.ore:13'  inherits='mtlgAdamantineBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -4581,12 +5012,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgAdamantineBaseCloud' block='Metallurgy:fantasy.ore:13' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60AC0C0D</WireframeColor>
@@ -4601,10 +5036,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Adamantine Strategic Cloud Hint Veins -->
                         <Veins name='mtlgAdamantineBaseHintVeins' block='Metallurgy:fantasy.ore:13' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60AC0C0D</WireframeColor>
@@ -4648,14 +5089,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Atlarus -->
                 <IfCondition condition=':= mtlgAtlarusDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgAtlarusBaseVeins' block='Metallurgy:fantasy.ore:14' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgAtlarusBaseVeins' block='Metallurgy:fantasy.ore:14'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C4B117</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgAtlarusSize * _default_' range=':= 1 * 0.8 * mtlgAtlarusSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgAtlarusSize * _default_' range=':= 1 * 0.8 * mtlgAtlarusSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgAtlarusFreq * _default_'/>
@@ -4666,7 +5108,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Atlarus Layered Veins) Settings -->
-                    <Veins name='mtlgAtlarusPrefersVeins' block='Metallurgy:fantasy.ore:14' inherits='mtlgAtlarusBaseVeins'>
+                    <Veins name='mtlgAtlarusPrefersVeins' block='Metallurgy:fantasy.ore:14'  inherits='mtlgAtlarusBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -4684,16 +5126,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Atlarus -->
                 <IfCondition condition=':= mtlgAtlarusDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgAtlarusBaseVeins' block='Metallurgy:fantasy.ore:14' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgAtlarusBaseVeins' block='Metallurgy:fantasy.ore:14'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C4B117</WireframeColor>
@@ -4709,7 +5161,7 @@ Sanguinite, Eximite, Meutoite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Atlarus Huge Veins) Settings -->
-                    <Veins name='mtlgAtlarusPrefersVeins' block='Metallurgy:fantasy.ore:14' inherits='mtlgAtlarusBaseVeins'>
+                    <Veins name='mtlgAtlarusPrefersVeins' block='Metallurgy:fantasy.ore:14'  inherits='mtlgAtlarusBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -4729,12 +5181,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgAtlarusBaseCloud' block='Metallurgy:fantasy.ore:14' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C4B117</WireframeColor>
@@ -4749,10 +5205,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Atlarus Strategic Cloud Hint Veins -->
                         <Veins name='mtlgAtlarusBaseHintVeins' block='Metallurgy:fantasy.ore:14' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60C4B117</WireframeColor>
@@ -4806,7 +5268,7 @@ Sanguinite, Eximite, Meutoite
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='Metallurgy:nether.ore:0' />
+                    <Replaces block='Metallurgy:nether.ore' />
                     <Replaces block='Metallurgy:nether.ore:1' />
                     <Replaces block='Metallurgy:nether.ore:2' />
                     <Replaces block='Metallurgy:nether.ore:3' />
@@ -4826,14 +5288,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Ignatius -->
                 <IfCondition condition=':= mtlgIgnatiusDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgIgnatiusBaseVeins' block='Metallurgy:nether.ore' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgIgnatiusBaseVeins' block='Metallurgy:nether.ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EE810A</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgIgnatiusSize * _default_' range=':= 1 * 1 * mtlgIgnatiusSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgIgnatiusSize * _default_' range=':= 1 * 1 * mtlgIgnatiusSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgIgnatiusFreq * _default_'/>
@@ -4847,16 +5310,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Ignatius -->
                 <IfCondition condition=':= mtlgIgnatiusDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgIgnatiusBaseVeins' block='Metallurgy:nether.ore' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgIgnatiusBaseVeins' block='Metallurgy:nether.ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EE810A</WireframeColor>
@@ -4877,12 +5350,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgIgnatiusBaseCloud' block='Metallurgy:nether.ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EE810A</WireframeColor>
@@ -4897,10 +5374,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Ignatius Strategic Cloud Hint Veins -->
                         <Veins name='mtlgIgnatiusBaseHintVeins' block='Metallurgy:nether.ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60EE810A</WireframeColor>
@@ -4942,14 +5425,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Shadow Iron -->
                 <IfCondition condition=':= mtlgShadowIronDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgShadowIronBaseVeins' block='Metallurgy:nether.ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgShadowIronBaseVeins' block='Metallurgy:nether.ore:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60634C3F</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgShadowIronSize * _default_' range=':= 1 * 1 * mtlgShadowIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgShadowIronSize * _default_' range=':= 1 * 1 * mtlgShadowIronSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgShadowIronFreq * _default_'/>
@@ -4963,16 +5447,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Shadow Iron -->
                 <IfCondition condition=':= mtlgShadowIronDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgShadowIronBaseVeins' block='Metallurgy:nether.ore:1' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgShadowIronBaseVeins' block='Metallurgy:nether.ore:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60634C3F</WireframeColor>
@@ -4993,12 +5487,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgShadowIronBaseCloud' block='Metallurgy:nether.ore:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60634C3F</WireframeColor>
@@ -5013,10 +5511,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Shadow Iron Strategic Cloud Hint Veins -->
                         <Veins name='mtlgShadowIronBaseHintVeins' block='Metallurgy:nether.ore:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60634C3F</WireframeColor>
@@ -5058,14 +5562,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Lemurite -->
                 <IfCondition condition=':= mtlgLemuriteDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgLemuriteBaseVeins' block='Metallurgy:nether.ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgLemuriteBaseVeins' block='Metallurgy:nether.ore:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B1B1B4</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgLemuriteSize * _default_' range=':= 1 * 1 * mtlgLemuriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgLemuriteSize * _default_' range=':= 1 * 1 * mtlgLemuriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgLemuriteFreq * _default_'/>
@@ -5079,16 +5584,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Lemurite -->
                 <IfCondition condition=':= mtlgLemuriteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgLemuriteBaseVeins' block='Metallurgy:nether.ore:2' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgLemuriteBaseVeins' block='Metallurgy:nether.ore:2'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B1B1B4</WireframeColor>
@@ -5109,12 +5624,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgLemuriteBaseCloud' block='Metallurgy:nether.ore:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60B1B1B4</WireframeColor>
@@ -5129,10 +5648,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Lemurite Strategic Cloud Hint Veins -->
                         <Veins name='mtlgLemuriteBaseHintVeins' block='Metallurgy:nether.ore:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60B1B1B4</WireframeColor>
@@ -5174,14 +5699,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Midasium -->
                 <IfCondition condition=':= mtlgMidasiumDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgMidasiumBaseVeins' block='Metallurgy:nether.ore:3' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgMidasiumBaseVeins' block='Metallurgy:nether.ore:3'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60F6B237</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgMidasiumSize * _default_' range=':= 1 * 1 * mtlgMidasiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgMidasiumSize * _default_' range=':= 1 * 1 * mtlgMidasiumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgMidasiumFreq * _default_'/>
@@ -5195,16 +5721,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Midasium -->
                 <IfCondition condition=':= mtlgMidasiumDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgMidasiumBaseVeins' block='Metallurgy:nether.ore:3' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgMidasiumBaseVeins' block='Metallurgy:nether.ore:3'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60F6B237</WireframeColor>
@@ -5225,12 +5761,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgMidasiumBaseCloud' block='Metallurgy:nether.ore:3' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60F6B237</WireframeColor>
@@ -5245,10 +5785,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Midasium Strategic Cloud Hint Veins -->
                         <Veins name='mtlgMidasiumBaseHintVeins' block='Metallurgy:nether.ore:3' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60F6B237</WireframeColor>
@@ -5290,14 +5836,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Vyroxeres -->
                 <IfCondition condition=':= mtlgVyroxeresDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgVyroxeresBaseVeins' block='Metallurgy:nether.ore:4' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgVyroxeresBaseVeins' block='Metallurgy:nether.ore:4'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6057D411</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgVyroxeresSize * _default_' range=':= 1 * 1 * mtlgVyroxeresSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgVyroxeresSize * _default_' range=':= 1 * 1 * mtlgVyroxeresSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgVyroxeresFreq * _default_'/>
@@ -5311,16 +5858,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Vyroxeres -->
                 <IfCondition condition=':= mtlgVyroxeresDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgVyroxeresBaseVeins' block='Metallurgy:nether.ore:4' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgVyroxeresBaseVeins' block='Metallurgy:nether.ore:4'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6057D411</WireframeColor>
@@ -5341,12 +5898,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgVyroxeresBaseCloud' block='Metallurgy:nether.ore:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6057D411</WireframeColor>
@@ -5361,10 +5922,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Vyroxeres Strategic Cloud Hint Veins -->
                         <Veins name='mtlgVyroxeresBaseHintVeins' block='Metallurgy:nether.ore:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6057D411</WireframeColor>
@@ -5406,14 +5973,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Ceruclase -->
                 <IfCondition condition=':= mtlgCeruclaseDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgCeruclaseBaseVeins' block='Metallurgy:nether.ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgCeruclaseBaseVeins' block='Metallurgy:nether.ore:5'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x603F869C</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgCeruclaseSize * _default_' range=':= 1 * 1 * mtlgCeruclaseSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgCeruclaseSize * _default_' range=':= 1 * 1 * mtlgCeruclaseSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgCeruclaseFreq * _default_'/>
@@ -5427,16 +5995,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Ceruclase -->
                 <IfCondition condition=':= mtlgCeruclaseDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgCeruclaseBaseVeins' block='Metallurgy:nether.ore:5' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgCeruclaseBaseVeins' block='Metallurgy:nether.ore:5'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x603F869C</WireframeColor>
@@ -5457,12 +6035,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgCeruclaseBaseCloud' block='Metallurgy:nether.ore:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x603F869C</WireframeColor>
@@ -5477,10 +6059,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Ceruclase Strategic Cloud Hint Veins -->
                         <Veins name='mtlgCeruclaseBaseHintVeins' block='Metallurgy:nether.ore:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x603F869C</WireframeColor>
@@ -5522,14 +6110,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Alduorite -->
                 <IfCondition condition=':= mtlgAlduoriteDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgAlduoriteBaseVeins' block='Metallurgy:nether.ore:6' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgAlduoriteBaseVeins' block='Metallurgy:nether.ore:6'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609FCED2</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgAlduoriteSize * _default_' range=':= 1 * 1 * mtlgAlduoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgAlduoriteSize * _default_' range=':= 1 * 1 * mtlgAlduoriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgAlduoriteFreq * _default_'/>
@@ -5543,16 +6132,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Alduorite -->
                 <IfCondition condition=':= mtlgAlduoriteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgAlduoriteBaseVeins' block='Metallurgy:nether.ore:6' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgAlduoriteBaseVeins' block='Metallurgy:nether.ore:6'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609FCED2</WireframeColor>
@@ -5573,12 +6172,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgAlduoriteBaseCloud' block='Metallurgy:nether.ore:6' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609FCED2</WireframeColor>
@@ -5593,10 +6196,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Alduorite Strategic Cloud Hint Veins -->
                         <Veins name='mtlgAlduoriteBaseHintVeins' block='Metallurgy:nether.ore:6' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x609FCED2</WireframeColor>
@@ -5638,14 +6247,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Kalendrite -->
                 <IfCondition condition=':= mtlgKalendriteDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgKalendriteBaseVeins' block='Metallurgy:nether.ore:7' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgKalendriteBaseVeins' block='Metallurgy:nether.ore:7'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60AB6AB9</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgKalendriteSize * _default_' range=':= 1 * 1 * mtlgKalendriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgKalendriteSize * _default_' range=':= 1 * 1 * mtlgKalendriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgKalendriteFreq * _default_'/>
@@ -5659,16 +6269,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Kalendrite -->
                 <IfCondition condition=':= mtlgKalendriteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgKalendriteBaseVeins' block='Metallurgy:nether.ore:7' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgKalendriteBaseVeins' block='Metallurgy:nether.ore:7'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60AB6AB9</WireframeColor>
@@ -5689,12 +6309,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgKalendriteBaseCloud' block='Metallurgy:nether.ore:7' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60AB6AB9</WireframeColor>
@@ -5709,10 +6333,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Kalendrite Strategic Cloud Hint Veins -->
                         <Veins name='mtlgKalendriteBaseHintVeins' block='Metallurgy:nether.ore:7' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60AB6AB9</WireframeColor>
@@ -5754,14 +6384,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Vulcanite -->
                 <IfCondition condition=':= mtlgVulcaniteDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgVulcaniteBaseVeins' block='Metallurgy:nether.ore:8' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgVulcaniteBaseVeins' block='Metallurgy:nether.ore:8'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E66922</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgVulcaniteSize * _default_' range=':= 1 * 1 * mtlgVulcaniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgVulcaniteSize * _default_' range=':= 1 * 1 * mtlgVulcaniteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgVulcaniteFreq * _default_'/>
@@ -5775,16 +6406,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Vulcanite -->
                 <IfCondition condition=':= mtlgVulcaniteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgVulcaniteBaseVeins' block='Metallurgy:nether.ore:8' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgVulcaniteBaseVeins' block='Metallurgy:nether.ore:8'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E66922</WireframeColor>
@@ -5805,12 +6446,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgVulcaniteBaseCloud' block='Metallurgy:nether.ore:8' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E66922</WireframeColor>
@@ -5825,10 +6470,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Vulcanite Strategic Cloud Hint Veins -->
                         <Veins name='mtlgVulcaniteBaseHintVeins' block='Metallurgy:nether.ore:8' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E66922</WireframeColor>
@@ -5870,14 +6521,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Sanguinite -->
                 <IfCondition condition=':= mtlgSanguiniteDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgSanguiniteBaseVeins' block='Metallurgy:nether.ore:9' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgSanguiniteBaseVeins' block='Metallurgy:nether.ore:9'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C30506</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgSanguiniteSize * _default_' range=':= 1 * 1 * mtlgSanguiniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgSanguiniteSize * _default_' range=':= 1 * 1 * mtlgSanguiniteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgSanguiniteFreq * _default_'/>
@@ -5891,16 +6543,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Sanguinite -->
                 <IfCondition condition=':= mtlgSanguiniteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgSanguiniteBaseVeins' block='Metallurgy:nether.ore:9' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgSanguiniteBaseVeins' block='Metallurgy:nether.ore:9'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C30506</WireframeColor>
@@ -5921,12 +6583,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgSanguiniteBaseCloud' block='Metallurgy:nether.ore:9' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C30506</WireframeColor>
@@ -5941,10 +6607,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Sanguinite Strategic Cloud Hint Veins -->
                         <Veins name='mtlgSanguiniteBaseHintVeins' block='Metallurgy:nether.ore:9' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60C30506</WireframeColor>
@@ -5996,7 +6668,7 @@ Sanguinite, Eximite, Meutoite
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='Metallurgy:ender.ore:0' />
+                    <Replaces block='Metallurgy:ender.ore' />
                     <Replaces block='Metallurgy:ender.ore:1' />
                 </Substitute>
                 <!-- Original End Ore Removal Complete -->
@@ -6008,14 +6680,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Eximite -->
                 <IfCondition condition=':= mtlgEximiteDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgEximiteBaseVeins' block='Metallurgy:ender.ore' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgEximiteBaseVeins' block='Metallurgy:ender.ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607B5994</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgEximiteSize * _default_' range=':= 1 * 1 * mtlgEximiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgEximiteSize * _default_' range=':= 1 * 1 * mtlgEximiteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgEximiteFreq * _default_'/>
@@ -6029,16 +6702,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Eximite -->
                 <IfCondition condition=':= mtlgEximiteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgEximiteBaseVeins' block='Metallurgy:ender.ore' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgEximiteBaseVeins' block='Metallurgy:ender.ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607B5994</WireframeColor>
@@ -6059,12 +6742,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgEximiteBaseCloud' block='Metallurgy:ender.ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607B5994</WireframeColor>
@@ -6079,10 +6766,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Eximite Strategic Cloud Hint Veins -->
                         <Veins name='mtlgEximiteBaseHintVeins' block='Metallurgy:ender.ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x607B5994</WireframeColor>
@@ -6124,14 +6817,15 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin Layered Veins distribution of Meutoite -->
                 <IfCondition condition=':= mtlgMeutoiteDist = "layeredVeins"'>
                 
-                    <Veins name='mtlgMeutoiteBaseVeins' block='Metallurgy:ender.ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='mtlgMeutoiteBaseVeins' block='Metallurgy:ender.ore:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x605E5168</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgMeutoiteSize * _default_' range=':= 1 * 1 * mtlgMeutoiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgMeutoiteSize * _default_' range=':= 1 * 1 * mtlgMeutoiteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgMeutoiteFreq * _default_'/>
@@ -6145,16 +6839,26 @@ Sanguinite, Eximite, Meutoite
                 <!-- Begin  Huge Veins distribution of Meutoite -->
                 <IfCondition condition=':= mtlgMeutoiteDist = "hugeVeins"'>
                 
-                    <Veins name='mtlgMeutoiteBaseVeins' block='Metallurgy:ender.ore:1' inherits='PresetHugeVeins'>
+                    <Veins name='mtlgMeutoiteBaseVeins' block='Metallurgy:ender.ore:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x605E5168</WireframeColor>
@@ -6175,12 +6879,16 @@ Sanguinite, Eximite, Meutoite
                 
                     <Cloud name='mtlgMeutoiteBaseCloud' block='Metallurgy:ender.ore:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x605E5168</WireframeColor>
@@ -6195,10 +6903,16 @@ Sanguinite, Eximite, Meutoite
                         <!-- Begin Meutoite Strategic Cloud Hint Veins -->
                         <Veins name='mtlgMeutoiteBaseHintVeins' block='Metallurgy:ender.ore:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x605E5168</WireframeColor>

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -1,12 +1,8 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   MineChem Module
-
-Generates: 
-Uranium
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "MineChem" Module: This configuration
+      covers uranium.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="minechem">
@@ -76,7 +72,7 @@ Uranium
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='minechem:tile.oreUranium:0' />
+                    <Replaces block='minechem:tile.oreUranium' />
                 </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
                 
@@ -87,34 +83,31 @@ Uranium
                 <!-- Begin PipeVeins distribution of Uranium -->
                 <IfCondition condition=':= mchmUraniumDist = "pipeVeins"'>
                 
-                    
-                    <!-- Begin Uranium Ore Configuration -->
-                    <Veins name='mchmUraniumBaseVeins' block='minechem:tile.oreUranium' inherits='PresetPipeVeins' seed='0x38D0'>
+                    <Veins name='mchmUraniumBaseVeins' block='minechem:tile.oreUranium'  inherits='PresetPipeVeins' seed='0x38D0'>
                         <Description>
-                            Short sparsely filled veins sloping up from near the bottom of the map.
+                            Short sparsely filled veins sloping up
+                            from near the bottom of the map.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60ACFE91</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * mchmUraniumSize * _default_' range=':= 1 * 1 * mchmUraniumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= _default_' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * mchmUraniumSize * _default_' range=':= 1 * 1 * mchmUraniumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * mchmUraniumFreq * _default_'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
-                    <!-- End Uranium Ore Configuration -->
                     
-                    
-                    <!-- Begin Uranium Pipe Configuration -->
-                    <Veins name= 'mchmUraniumBasePipe' block='minecraft:lava' inherits='mchmUraniumBaseVeins' seed='0x38D0'>
+                    <!-- Begin Pipe Filling (Uranium Pipe Veins) Settings -->
+                    <Veins name='mchmUraniumPipeVeins' block='minecraft:lava'  inherits='mchmUraniumBaseVeins' seed='0x38D0'>
                         <Description>
-                            Fills center of each tube with Pipe material.
+                            Fills the vein with an additional material
+                            (minecraft:lava).
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60ACFE91</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 1 * mchmUraniumSize * _default_' range=':= 0.5 * 1 * 1 * mchmUraniumSize * _default_'/>
                         <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 1 * mchmUraniumSize * _default_' range=':= 0.5 * 1 * 1 * mchmUraniumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Replaces block='minecraft:stone'/>
                         <Replaces block='minechem:tile.oreUranium'/>
                         <Replaces block='minecraft:dirt'/>
@@ -123,8 +116,7 @@ Uranium
                         <Replaces block='minecraft:netherrack'/>
                         <Replaces block='minecraft:end_stone'/>
                     </Veins>
-                    <!-- End Uranium Pipe Configuration -->
-                    
+                    <!-- End Pipe Filling (Uranium Pipe Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End PipeVeins distribution of Uranium -->
@@ -133,16 +125,26 @@ Uranium
                 <!-- Begin  Huge Veins distribution of Uranium -->
                 <IfCondition condition=':= mchmUraniumDist = "hugeVeins"'>
                 
-                    <Veins name='mchmUraniumBaseVeins' block='minechem:tile.oreUranium' inherits='PresetHugeVeins'>
+                    <Veins name='mchmUraniumBaseVeins' block='minechem:tile.oreUranium'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60ACFE91</WireframeColor>
@@ -163,12 +165,16 @@ Uranium
                 
                     <Cloud name='mchmUraniumBaseCloud' block='minechem:tile.oreUranium' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60ACFE91</WireframeColor>
@@ -183,10 +189,16 @@ Uranium
                         <!-- Begin Uranium Strategic Cloud Hint Veins -->
                         <Veins name='mchmUraniumBaseHintVeins' block='minechem:tile.oreUranium' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60ACFE91</WireframeColor>

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -1,12 +1,8 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Minecraft Comes Alive Module
-
-Generates: 
-Rose Gold
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Minecraft Comes Alive" Module: This
+      configuration covers rose gold.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="MCA">
@@ -76,7 +72,7 @@ Rose Gold
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='MCA:tile.roseGoldOre:0' />
+                    <Replaces block='MCA:tile.roseGoldOre' />
                 </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
                 
@@ -87,14 +83,15 @@ Rose Gold
                 <!-- Begin LayeredVeins distribution of Rose Gold -->
                 <IfCondition condition=':= mccaRoseGoldDist = "layeredVeins"'>
                 
-                    <Veins name='mccaRoseGoldBaseVeins' block='MCA:tile.roseGoldOre' inherits='PresetLayeredVeins'>
+                    <Veins name='mccaRoseGoldBaseVeins' block='MCA:tile.roseGoldOre'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFDDA2</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mccaRoseGoldSize * _default_' range=':= 1 * 0.8 * mccaRoseGoldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mccaRoseGoldSize * _default_' range=':= 1 * 0.8 * mccaRoseGoldSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mccaRoseGoldFreq * _default_'/>
@@ -105,7 +102,7 @@ Rose Gold
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Rose Gold Layered Veins) Settings -->
-                    <Veins name='mccaRoseGoldPrefersVeins' block='MCA:tile.roseGoldOre' inherits='mccaRoseGoldBaseVeins'>
+                    <Veins name='mccaRoseGoldPrefersVeins' block='MCA:tile.roseGoldOre'  inherits='mccaRoseGoldBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -123,22 +120,26 @@ Rose Gold
                 <!-- Begin  Small Deposits distribution of Rose Gold -->
                 <IfCondition condition=':= mccaRoseGoldDist = "smallDeposits"'>
                 
-                    <Veins name='mccaRoseGoldBaseVeins' block='MCA:tile.roseGoldOre' inherits='PresetSmallDeposits'>
+                    <Veins name='mccaRoseGoldBaseVeins' block='MCA:tile.roseGoldOre'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFDDA2</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mccaRoseGoldSize * _default_' range=':= 1 * 0.8 * mccaRoseGoldSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mccaRoseGoldSize * _default_' range=':= 1 * 0.8 * mccaRoseGoldSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mccaRoseGoldFreq * _default_'/>
+                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 10'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Rose Gold Small Deposits) Settings -->
-                    <Veins name='mccaRoseGoldPrefersVeins' block='MCA:tile.roseGoldOre' inherits='mccaRoseGoldBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Rose Gold Deposit Veins) Settings -->
+                    <Veins name='mccaRoseGoldPrefersVeins' block='MCA:tile.roseGoldOre'  inherits='mccaRoseGoldBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -147,7 +148,7 @@ Rose Gold
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Forest'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Rose Gold Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Rose Gold Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Rose Gold -->
@@ -158,12 +159,16 @@ Rose Gold
                 
                     <Cloud name='mccaRoseGoldBaseCloud' block='MCA:tile.roseGoldOre' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFDDA2</WireframeColor>
@@ -178,10 +183,16 @@ Rose Gold
                         <!-- Begin Rose Gold Strategic Cloud Hint Veins -->
                         <Veins name='mccaRoseGoldBaseHintVeins' block='MCA:tile.roseGoldOre' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FFDDA2</WireframeColor>

--- a/src/main/resources/config/modules/NetherOres.xml
+++ b/src/main/resources/config/modules/NetherOres.xml
@@ -1,16 +1,12 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Nether Ores Module
-
-Generates: 
-Coal, Diamond, Gold, Iron, Lapis Lazuli, Redstone, Copper, Tin,
-Emerald, Silver, Lead, Uranium, Nikolite, Ruby, Peridot, Sapphire,
-Platinum, Ferrous, Pig Iron, Iridium, Osmium, Sulphur, Titanium,
-Mithril, Adamantium, Rutile, Tungsten, Amber, Tennantite, Salt,
-Saltpeter, Magnesium
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Nether Ores" Module: This configuration
+      covers coal, diamond, gold, iron, lapis lazuli, redstone,
+      copper, tin,  emerald, silver, lead, uranium, nikolite, ruby,
+      peridot, sapphire,  platinum, ferrous, pig iron, iridium,
+      osmium, sulphur, titanium,  mithril, adamantium, rutile,
+      tungsten, amber, tennantite, salt,  saltpeter, and magnesium.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="NetherOres">
@@ -1289,7 +1285,7 @@ Saltpeter, Magnesium
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='NetherOres:tile.netherores.ore.0:0' />
+                    <Replaces block='NetherOres:tile.netherores.ore.0' />
                     <Replaces block='NetherOres:tile.netherores.ore.0:1' />
                     <Replaces block='NetherOres:tile.netherores.ore.0:2' />
                     <Replaces block='NetherOres:tile.netherores.ore.0:3' />
@@ -1305,7 +1301,7 @@ Saltpeter, Magnesium
                     <Replaces block='NetherOres:tile.netherores.ore.0:13' />
                     <Replaces block='NetherOres:tile.netherores.ore.0:14' />
                     <Replaces block='NetherOres:tile.netherores.ore.0:15' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:0' />
+                    <Replaces block='NetherOres:tile.netherores.ore.1' />
                     <Replaces block='NetherOres:tile.netherores.ore.1:1' />
                     <Replaces block='NetherOres:tile.netherores.ore.1:2' />
                     <Replaces block='NetherOres:tile.netherores.ore.1:3' />
@@ -1331,14 +1327,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Coal -->
                 <IfCondition condition=':= nthoCoalDist = "layeredVeins"'>
                 
-                    <Veins name='nthoCoalBaseVeins' block='NetherOres:tile.netherores.ore.0' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoCoalBaseVeins' block='NetherOres:tile.netherores.ore.0'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602D2D2D</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoCoalSize * _default_' range=':= 1 * 1 * nthoCoalSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoCoalSize * _default_' range=':= 1 * 1 * nthoCoalSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoCoalFreq * _default_'/>
@@ -1352,16 +1349,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Coal -->
                 <IfCondition condition=':= nthoCoalDist = "hugeVeins"'>
                 
-                    <Veins name='nthoCoalBaseVeins' block='NetherOres:tile.netherores.ore.0' inherits='PresetHugeVeins'>
+                    <Veins name='nthoCoalBaseVeins' block='NetherOres:tile.netherores.ore.0'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602D2D2D</WireframeColor>
@@ -1382,12 +1389,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoCoalBaseCloud' block='NetherOres:tile.netherores.ore.0' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602D2D2D</WireframeColor>
@@ -1402,10 +1413,16 @@ Saltpeter, Magnesium
                         <!-- Begin Coal Strategic Cloud Hint Veins -->
                         <Veins name='nthoCoalBaseHintVeins' block='NetherOres:tile.netherores.ore.0' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x602D2D2D</WireframeColor>
@@ -1447,14 +1464,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Diamond -->
                 <IfCondition condition=':= nthoDiamondDist = "layeredVeins"'>
                 
-                    <Veins name='nthoDiamondBaseVeins' block='NetherOres:tile.netherores.ore.0:1' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoDiamondBaseVeins' block='NetherOres:tile.netherores.ore.0:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608BF4E3</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoDiamondSize * _default_' range=':= 1 * 1 * nthoDiamondSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoDiamondSize * _default_' range=':= 1 * 1 * nthoDiamondSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoDiamondFreq * _default_'/>
@@ -1468,16 +1486,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Diamond -->
                 <IfCondition condition=':= nthoDiamondDist = "hugeVeins"'>
                 
-                    <Veins name='nthoDiamondBaseVeins' block='NetherOres:tile.netherores.ore.0:1' inherits='PresetHugeVeins'>
+                    <Veins name='nthoDiamondBaseVeins' block='NetherOres:tile.netherores.ore.0:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608BF4E3</WireframeColor>
@@ -1498,12 +1526,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoDiamondBaseCloud' block='NetherOres:tile.netherores.ore.0:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608BF4E3</WireframeColor>
@@ -1518,10 +1550,16 @@ Saltpeter, Magnesium
                         <!-- Begin Diamond Strategic Cloud Hint Veins -->
                         <Veins name='nthoDiamondBaseHintVeins' block='NetherOres:tile.netherores.ore.0:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x608BF4E3</WireframeColor>
@@ -1563,14 +1601,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Gold -->
                 <IfCondition condition=':= nthoGoldDist = "layeredVeins"'>
                 
-                    <Veins name='nthoGoldBaseVeins' block='NetherOres:tile.netherores.ore.0:2' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoGoldBaseVeins' block='NetherOres:tile.netherores.ore.0:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoGoldSize * _default_' range=':= 1 * 1 * nthoGoldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoGoldSize * _default_' range=':= 1 * 1 * nthoGoldSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoGoldFreq * _default_'/>
@@ -1584,16 +1623,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Gold -->
                 <IfCondition condition=':= nthoGoldDist = "hugeVeins"'>
                 
-                    <Veins name='nthoGoldBaseVeins' block='NetherOres:tile.netherores.ore.0:2' inherits='PresetHugeVeins'>
+                    <Veins name='nthoGoldBaseVeins' block='NetherOres:tile.netherores.ore.0:2'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
@@ -1614,12 +1663,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoGoldBaseCloud' block='NetherOres:tile.netherores.ore.0:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
@@ -1634,10 +1687,16 @@ Saltpeter, Magnesium
                         <!-- Begin Gold Strategic Cloud Hint Veins -->
                         <Veins name='nthoGoldBaseHintVeins' block='NetherOres:tile.netherores.ore.0:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60EAEF57</WireframeColor>
@@ -1679,14 +1738,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Iron -->
                 <IfCondition condition=':= nthoIronDist = "layeredVeins"'>
                 
-                    <Veins name='nthoIronBaseVeins' block='NetherOres:tile.netherores.ore.0:3' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoIronBaseVeins' block='NetherOres:tile.netherores.ore.0:3'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoIronSize * _default_' range=':= 1 * 1 * nthoIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoIronSize * _default_' range=':= 1 * 1 * nthoIronSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoIronFreq * _default_'/>
@@ -1700,16 +1760,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Iron -->
                 <IfCondition condition=':= nthoIronDist = "hugeVeins"'>
                 
-                    <Veins name='nthoIronBaseVeins' block='NetherOres:tile.netherores.ore.0:3' inherits='PresetHugeVeins'>
+                    <Veins name='nthoIronBaseVeins' block='NetherOres:tile.netherores.ore.0:3'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -1730,12 +1800,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoIronBaseCloud' block='NetherOres:tile.netherores.ore.0:3' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -1750,10 +1824,16 @@ Saltpeter, Magnesium
                         <!-- Begin Iron Strategic Cloud Hint Veins -->
                         <Veins name='nthoIronBaseHintVeins' block='NetherOres:tile.netherores.ore.0:3' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -1795,14 +1875,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Lapis Lazuli -->
                 <IfCondition condition=':= nthoLapisLazuliDist = "layeredVeins"'>
                 
-                    <Veins name='nthoLapisLazuliBaseVeins' block='NetherOres:tile.netherores.ore.0:4' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoLapisLazuliBaseVeins' block='NetherOres:tile.netherores.ore.0:4'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x601442BA</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoLapisLazuliSize * _default_' range=':= 1 * 1 * nthoLapisLazuliSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoLapisLazuliSize * _default_' range=':= 1 * 1 * nthoLapisLazuliSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoLapisLazuliFreq * _default_'/>
@@ -1816,16 +1897,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Lapis Lazuli -->
                 <IfCondition condition=':= nthoLapisLazuliDist = "hugeVeins"'>
                 
-                    <Veins name='nthoLapisLazuliBaseVeins' block='NetherOres:tile.netherores.ore.0:4' inherits='PresetHugeVeins'>
+                    <Veins name='nthoLapisLazuliBaseVeins' block='NetherOres:tile.netherores.ore.0:4'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x601442BA</WireframeColor>
@@ -1846,12 +1937,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoLapisLazuliBaseCloud' block='NetherOres:tile.netherores.ore.0:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x601442BA</WireframeColor>
@@ -1866,10 +1961,16 @@ Saltpeter, Magnesium
                         <!-- Begin Lapis Lazuli Strategic Cloud Hint Veins -->
                         <Veins name='nthoLapisLazuliBaseHintVeins' block='NetherOres:tile.netherores.ore.0:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x601442BA</WireframeColor>
@@ -1911,14 +2012,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Redstone -->
                 <IfCondition condition=':= nthoRedstoneDist = "layeredVeins"'>
                 
-                    <Veins name='nthoRedstoneBaseVeins' block='NetherOres:tile.netherores.ore.0:5' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoRedstoneBaseVeins' block='NetherOres:tile.netherores.ore.0:5'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A80002</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoRedstoneSize * _default_' range=':= 1 * 1 * nthoRedstoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoRedstoneSize * _default_' range=':= 1 * 1 * nthoRedstoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoRedstoneFreq * _default_'/>
@@ -1932,16 +2034,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Redstone -->
                 <IfCondition condition=':= nthoRedstoneDist = "hugeVeins"'>
                 
-                    <Veins name='nthoRedstoneBaseVeins' block='NetherOres:tile.netherores.ore.0:5' inherits='PresetHugeVeins'>
+                    <Veins name='nthoRedstoneBaseVeins' block='NetherOres:tile.netherores.ore.0:5'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A80002</WireframeColor>
@@ -1962,12 +2074,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoRedstoneBaseCloud' block='NetherOres:tile.netherores.ore.0:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A80002</WireframeColor>
@@ -1982,10 +2098,16 @@ Saltpeter, Magnesium
                         <!-- Begin Redstone Strategic Cloud Hint Veins -->
                         <Veins name='nthoRedstoneBaseHintVeins' block='NetherOres:tile.netherores.ore.0:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60A80002</WireframeColor>
@@ -2027,14 +2149,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Copper -->
                 <IfCondition condition=':= nthoCopperDist = "layeredVeins"'>
                 
-                    <Veins name='nthoCopperBaseVeins' block='NetherOres:tile.netherores.ore.0:6' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoCopperBaseVeins' block='NetherOres:tile.netherores.ore.0:6'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoCopperSize * _default_' range=':= 1 * 1 * nthoCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoCopperSize * _default_' range=':= 1 * 1 * nthoCopperSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoCopperFreq * _default_'/>
@@ -2048,16 +2171,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= nthoCopperDist = "hugeVeins"'>
                 
-                    <Veins name='nthoCopperBaseVeins' block='NetherOres:tile.netherores.ore.0:6' inherits='PresetHugeVeins'>
+                    <Veins name='nthoCopperBaseVeins' block='NetherOres:tile.netherores.ore.0:6'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -2078,12 +2211,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoCopperBaseCloud' block='NetherOres:tile.netherores.ore.0:6' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -2098,10 +2235,16 @@ Saltpeter, Magnesium
                         <!-- Begin Copper Strategic Cloud Hint Veins -->
                         <Veins name='nthoCopperBaseHintVeins' block='NetherOres:tile.netherores.ore.0:6' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -2143,14 +2286,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Tin -->
                 <IfCondition condition=':= nthoTinDist = "layeredVeins"'>
                 
-                    <Veins name='nthoTinBaseVeins' block='NetherOres:tile.netherores.ore.0:7' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoTinBaseVeins' block='NetherOres:tile.netherores.ore.0:7'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoTinSize * _default_' range=':= 1 * 1 * nthoTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoTinSize * _default_' range=':= 1 * 1 * nthoTinSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTinFreq * _default_'/>
@@ -2164,16 +2308,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= nthoTinDist = "hugeVeins"'>
                 
-                    <Veins name='nthoTinBaseVeins' block='NetherOres:tile.netherores.ore.0:7' inherits='PresetHugeVeins'>
+                    <Veins name='nthoTinBaseVeins' block='NetherOres:tile.netherores.ore.0:7'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -2194,12 +2348,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoTinBaseCloud' block='NetherOres:tile.netherores.ore.0:7' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -2214,10 +2372,16 @@ Saltpeter, Magnesium
                         <!-- Begin Tin Strategic Cloud Hint Veins -->
                         <Veins name='nthoTinBaseHintVeins' block='NetherOres:tile.netherores.ore.0:7' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -2259,14 +2423,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Emerald -->
                 <IfCondition condition=':= nthoEmeraldDist = "layeredVeins"'>
                 
-                    <Veins name='nthoEmeraldBaseVeins' block='NetherOres:tile.netherores.ore.0:8' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoEmeraldBaseVeins' block='NetherOres:tile.netherores.ore.0:8'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x606CE391</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoEmeraldSize * _default_' range=':= 1 * 1 * nthoEmeraldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoEmeraldSize * _default_' range=':= 1 * 1 * nthoEmeraldSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoEmeraldFreq * _default_'/>
@@ -2280,16 +2445,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Emerald -->
                 <IfCondition condition=':= nthoEmeraldDist = "hugeVeins"'>
                 
-                    <Veins name='nthoEmeraldBaseVeins' block='NetherOres:tile.netherores.ore.0:8' inherits='PresetHugeVeins'>
+                    <Veins name='nthoEmeraldBaseVeins' block='NetherOres:tile.netherores.ore.0:8'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x606CE391</WireframeColor>
@@ -2310,12 +2485,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoEmeraldBaseCloud' block='NetherOres:tile.netherores.ore.0:8' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x606CE391</WireframeColor>
@@ -2330,10 +2509,16 @@ Saltpeter, Magnesium
                         <!-- Begin Emerald Strategic Cloud Hint Veins -->
                         <Veins name='nthoEmeraldBaseHintVeins' block='NetherOres:tile.netherores.ore.0:8' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x606CE391</WireframeColor>
@@ -2375,14 +2560,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Silver -->
                 <IfCondition condition=':= nthoSilverDist = "layeredVeins"'>
                 
-                    <Veins name='nthoSilverBaseVeins' block='NetherOres:tile.netherores.ore.0:9' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoSilverBaseVeins' block='NetherOres:tile.netherores.ore.0:9'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3F2F7</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSilverSize * _default_' range=':= 1 * 1 * nthoSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSilverSize * _default_' range=':= 1 * 1 * nthoSilverSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSilverFreq * _default_'/>
@@ -2396,16 +2582,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Silver -->
                 <IfCondition condition=':= nthoSilverDist = "hugeVeins"'>
                 
-                    <Veins name='nthoSilverBaseVeins' block='NetherOres:tile.netherores.ore.0:9' inherits='PresetHugeVeins'>
+                    <Veins name='nthoSilverBaseVeins' block='NetherOres:tile.netherores.ore.0:9'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3F2F7</WireframeColor>
@@ -2426,12 +2622,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoSilverBaseCloud' block='NetherOres:tile.netherores.ore.0:9' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3F2F7</WireframeColor>
@@ -2446,10 +2646,16 @@ Saltpeter, Magnesium
                         <!-- Begin Silver Strategic Cloud Hint Veins -->
                         <Veins name='nthoSilverBaseHintVeins' block='NetherOres:tile.netherores.ore.0:9' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E3F2F7</WireframeColor>
@@ -2491,14 +2697,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Lead -->
                 <IfCondition condition=':= nthoLeadDist = "layeredVeins"'>
                 
-                    <Veins name='nthoLeadBaseVeins' block='NetherOres:tile.netherores.ore.0:10' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoLeadBaseVeins' block='NetherOres:tile.netherores.ore.0:10'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60818EBE</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoLeadSize * _default_' range=':= 1 * 1 * nthoLeadSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoLeadSize * _default_' range=':= 1 * 1 * nthoLeadSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoLeadFreq * _default_'/>
@@ -2512,16 +2719,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Lead -->
                 <IfCondition condition=':= nthoLeadDist = "hugeVeins"'>
                 
-                    <Veins name='nthoLeadBaseVeins' block='NetherOres:tile.netherores.ore.0:10' inherits='PresetHugeVeins'>
+                    <Veins name='nthoLeadBaseVeins' block='NetherOres:tile.netherores.ore.0:10'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60818EBE</WireframeColor>
@@ -2542,12 +2759,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoLeadBaseCloud' block='NetherOres:tile.netherores.ore.0:10' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60818EBE</WireframeColor>
@@ -2562,10 +2783,16 @@ Saltpeter, Magnesium
                         <!-- Begin Lead Strategic Cloud Hint Veins -->
                         <Veins name='nthoLeadBaseHintVeins' block='NetherOres:tile.netherores.ore.0:10' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60818EBE</WireframeColor>
@@ -2607,14 +2834,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Uranium -->
                 <IfCondition condition=':= nthoUraniumDist = "layeredVeins"'>
                 
-                    <Veins name='nthoUraniumBaseVeins' block='NetherOres:tile.netherores.ore.0:11' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoUraniumBaseVeins' block='NetherOres:tile.netherores.ore.0:11'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60ACFE91</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoUraniumSize * _default_' range=':= 1 * 1 * nthoUraniumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoUraniumSize * _default_' range=':= 1 * 1 * nthoUraniumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoUraniumFreq * _default_'/>
@@ -2628,16 +2856,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Uranium -->
                 <IfCondition condition=':= nthoUraniumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoUraniumBaseVeins' block='NetherOres:tile.netherores.ore.0:11' inherits='PresetHugeVeins'>
+                    <Veins name='nthoUraniumBaseVeins' block='NetherOres:tile.netherores.ore.0:11'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60ACFE91</WireframeColor>
@@ -2658,12 +2896,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoUraniumBaseCloud' block='NetherOres:tile.netherores.ore.0:11' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60ACFE91</WireframeColor>
@@ -2678,10 +2920,16 @@ Saltpeter, Magnesium
                         <!-- Begin Uranium Strategic Cloud Hint Veins -->
                         <Veins name='nthoUraniumBaseHintVeins' block='NetherOres:tile.netherores.ore.0:11' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60ACFE91</WireframeColor>
@@ -2723,14 +2971,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Nikolite -->
                 <IfCondition condition=':= nthoNikoliteDist = "layeredVeins"'>
                 
-                    <Veins name='nthoNikoliteBaseVeins' block='NetherOres:tile.netherores.ore.0:12' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoNikoliteBaseVeins' block='NetherOres:tile.netherores.ore.0:12'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6001FFFC</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoNikoliteSize * _default_' range=':= 1 * 1 * nthoNikoliteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoNikoliteSize * _default_' range=':= 1 * 1 * nthoNikoliteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoNikoliteFreq * _default_'/>
@@ -2744,16 +2993,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Nikolite -->
                 <IfCondition condition=':= nthoNikoliteDist = "hugeVeins"'>
                 
-                    <Veins name='nthoNikoliteBaseVeins' block='NetherOres:tile.netherores.ore.0:12' inherits='PresetHugeVeins'>
+                    <Veins name='nthoNikoliteBaseVeins' block='NetherOres:tile.netherores.ore.0:12'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6001FFFC</WireframeColor>
@@ -2774,12 +3033,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoNikoliteBaseCloud' block='NetherOres:tile.netherores.ore.0:12' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6001FFFC</WireframeColor>
@@ -2794,10 +3057,16 @@ Saltpeter, Magnesium
                         <!-- Begin Nikolite Strategic Cloud Hint Veins -->
                         <Veins name='nthoNikoliteBaseHintVeins' block='NetherOres:tile.netherores.ore.0:12' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6001FFFC</WireframeColor>
@@ -2839,14 +3108,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Ruby -->
                 <IfCondition condition=':= nthoRubyDist = "layeredVeins"'>
                 
-                    <Veins name='nthoRubyBaseVeins' block='NetherOres:tile.netherores.ore.0:13' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoRubyBaseVeins' block='NetherOres:tile.netherores.ore.0:13'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D10415</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoRubySize * _default_' range=':= 1 * 1 * nthoRubySize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoRubySize * _default_' range=':= 1 * 1 * nthoRubySize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoRubyFreq * _default_'/>
@@ -2860,16 +3130,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Ruby -->
                 <IfCondition condition=':= nthoRubyDist = "hugeVeins"'>
                 
-                    <Veins name='nthoRubyBaseVeins' block='NetherOres:tile.netherores.ore.0:13' inherits='PresetHugeVeins'>
+                    <Veins name='nthoRubyBaseVeins' block='NetherOres:tile.netherores.ore.0:13'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D10415</WireframeColor>
@@ -2890,12 +3170,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoRubyBaseCloud' block='NetherOres:tile.netherores.ore.0:13' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D10415</WireframeColor>
@@ -2910,10 +3194,16 @@ Saltpeter, Magnesium
                         <!-- Begin Ruby Strategic Cloud Hint Veins -->
                         <Veins name='nthoRubyBaseHintVeins' block='NetherOres:tile.netherores.ore.0:13' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60D10415</WireframeColor>
@@ -2955,14 +3245,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Peridot -->
                 <IfCondition condition=':= nthoPeridotDist = "layeredVeins"'>
                 
-                    <Veins name='nthoPeridotBaseVeins' block='NetherOres:tile.netherores.ore.0:14' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoPeridotBaseVeins' block='NetherOres:tile.netherores.ore.0:14'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6054A228</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoPeridotSize * _default_' range=':= 1 * 1 * nthoPeridotSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoPeridotSize * _default_' range=':= 1 * 1 * nthoPeridotSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoPeridotFreq * _default_'/>
@@ -2976,16 +3267,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Peridot -->
                 <IfCondition condition=':= nthoPeridotDist = "hugeVeins"'>
                 
-                    <Veins name='nthoPeridotBaseVeins' block='NetherOres:tile.netherores.ore.0:14' inherits='PresetHugeVeins'>
+                    <Veins name='nthoPeridotBaseVeins' block='NetherOres:tile.netherores.ore.0:14'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6054A228</WireframeColor>
@@ -3006,12 +3307,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoPeridotBaseCloud' block='NetherOres:tile.netherores.ore.0:14' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6054A228</WireframeColor>
@@ -3026,10 +3331,16 @@ Saltpeter, Magnesium
                         <!-- Begin Peridot Strategic Cloud Hint Veins -->
                         <Veins name='nthoPeridotBaseHintVeins' block='NetherOres:tile.netherores.ore.0:14' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6054A228</WireframeColor>
@@ -3071,14 +3382,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Sapphire -->
                 <IfCondition condition=':= nthoSapphireDist = "layeredVeins"'>
                 
-                    <Veins name='nthoSapphireBaseVeins' block='NetherOres:tile.netherores.ore.0:15' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoSapphireBaseVeins' block='NetherOres:tile.netherores.ore.0:15'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60554DB4</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSapphireSize * _default_' range=':= 1 * 1 * nthoSapphireSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSapphireSize * _default_' range=':= 1 * 1 * nthoSapphireSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSapphireFreq * _default_'/>
@@ -3092,16 +3404,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Sapphire -->
                 <IfCondition condition=':= nthoSapphireDist = "hugeVeins"'>
                 
-                    <Veins name='nthoSapphireBaseVeins' block='NetherOres:tile.netherores.ore.0:15' inherits='PresetHugeVeins'>
+                    <Veins name='nthoSapphireBaseVeins' block='NetherOres:tile.netherores.ore.0:15'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60554DB4</WireframeColor>
@@ -3122,12 +3444,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoSapphireBaseCloud' block='NetherOres:tile.netherores.ore.0:15' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60554DB4</WireframeColor>
@@ -3142,10 +3468,16 @@ Saltpeter, Magnesium
                         <!-- Begin Sapphire Strategic Cloud Hint Veins -->
                         <Veins name='nthoSapphireBaseHintVeins' block='NetherOres:tile.netherores.ore.0:15' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60554DB4</WireframeColor>
@@ -3187,14 +3519,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Platinum -->
                 <IfCondition condition=':= nthoPlatinumDist = "layeredVeins"'>
                 
-                    <Veins name='nthoPlatinumBaseVeins' block='NetherOres:tile.netherores.ore.1' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoPlatinumBaseVeins' block='NetherOres:tile.netherores.ore.1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6072A0D2</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoPlatinumSize * _default_' range=':= 1 * 1 * nthoPlatinumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoPlatinumSize * _default_' range=':= 1 * 1 * nthoPlatinumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoPlatinumFreq * _default_'/>
@@ -3208,16 +3541,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Platinum -->
                 <IfCondition condition=':= nthoPlatinumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoPlatinumBaseVeins' block='NetherOres:tile.netherores.ore.1' inherits='PresetHugeVeins'>
+                    <Veins name='nthoPlatinumBaseVeins' block='NetherOres:tile.netherores.ore.1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6072A0D2</WireframeColor>
@@ -3238,12 +3581,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoPlatinumBaseCloud' block='NetherOres:tile.netherores.ore.1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6072A0D2</WireframeColor>
@@ -3258,10 +3605,16 @@ Saltpeter, Magnesium
                         <!-- Begin Platinum Strategic Cloud Hint Veins -->
                         <Veins name='nthoPlatinumBaseHintVeins' block='NetherOres:tile.netherores.ore.1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6072A0D2</WireframeColor>
@@ -3303,14 +3656,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Ferrous -->
                 <IfCondition condition=':= nthoFerrousDist = "layeredVeins"'>
                 
-                    <Veins name='nthoFerrousBaseVeins' block='NetherOres:tile.netherores.ore.1:1' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoFerrousBaseVeins' block='NetherOres:tile.netherores.ore.1:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDD396</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoFerrousSize * _default_' range=':= 1 * 1 * nthoFerrousSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoFerrousSize * _default_' range=':= 1 * 1 * nthoFerrousSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoFerrousFreq * _default_'/>
@@ -3324,16 +3678,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Ferrous -->
                 <IfCondition condition=':= nthoFerrousDist = "hugeVeins"'>
                 
-                    <Veins name='nthoFerrousBaseVeins' block='NetherOres:tile.netherores.ore.1:1' inherits='PresetHugeVeins'>
+                    <Veins name='nthoFerrousBaseVeins' block='NetherOres:tile.netherores.ore.1:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDD396</WireframeColor>
@@ -3354,12 +3718,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoFerrousBaseCloud' block='NetherOres:tile.netherores.ore.1:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDD396</WireframeColor>
@@ -3374,10 +3742,16 @@ Saltpeter, Magnesium
                         <!-- Begin Ferrous Strategic Cloud Hint Veins -->
                         <Veins name='nthoFerrousBaseHintVeins' block='NetherOres:tile.netherores.ore.1:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60DDD396</WireframeColor>
@@ -3419,14 +3793,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Pig Iron -->
                 <IfCondition condition=':= nthoPigIronDist = "layeredVeins"'>
                 
-                    <Veins name='nthoPigIronBaseVeins' block='NetherOres:tile.netherores.ore.1:2' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoPigIronBaseVeins' block='NetherOres:tile.netherores.ore.1:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E89D97</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoPigIronSize * _default_' range=':= 1 * 1 * nthoPigIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoPigIronSize * _default_' range=':= 1 * 1 * nthoPigIronSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoPigIronFreq * _default_'/>
@@ -3440,16 +3815,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Pig Iron -->
                 <IfCondition condition=':= nthoPigIronDist = "hugeVeins"'>
                 
-                    <Veins name='nthoPigIronBaseVeins' block='NetherOres:tile.netherores.ore.1:2' inherits='PresetHugeVeins'>
+                    <Veins name='nthoPigIronBaseVeins' block='NetherOres:tile.netherores.ore.1:2'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E89D97</WireframeColor>
@@ -3470,12 +3855,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoPigIronBaseCloud' block='NetherOres:tile.netherores.ore.1:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E89D97</WireframeColor>
@@ -3490,10 +3879,16 @@ Saltpeter, Magnesium
                         <!-- Begin Pig Iron Strategic Cloud Hint Veins -->
                         <Veins name='nthoPigIronBaseHintVeins' block='NetherOres:tile.netherores.ore.1:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E89D97</WireframeColor>
@@ -3535,14 +3930,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Iridium -->
                 <IfCondition condition=':= nthoIridiumDist = "layeredVeins"'>
                 
-                    <Veins name='nthoIridiumBaseVeins' block='NetherOres:tile.netherores.ore.1:3' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoIridiumBaseVeins' block='NetherOres:tile.netherores.ore.1:3'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60CECECE</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoIridiumSize * _default_' range=':= 1 * 1 * nthoIridiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoIridiumSize * _default_' range=':= 1 * 1 * nthoIridiumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoIridiumFreq * _default_'/>
@@ -3556,16 +3952,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Iridium -->
                 <IfCondition condition=':= nthoIridiumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoIridiumBaseVeins' block='NetherOres:tile.netherores.ore.1:3' inherits='PresetHugeVeins'>
+                    <Veins name='nthoIridiumBaseVeins' block='NetherOres:tile.netherores.ore.1:3'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60CECECE</WireframeColor>
@@ -3586,12 +3992,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoIridiumBaseCloud' block='NetherOres:tile.netherores.ore.1:3' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60CECECE</WireframeColor>
@@ -3606,10 +4016,16 @@ Saltpeter, Magnesium
                         <!-- Begin Iridium Strategic Cloud Hint Veins -->
                         <Veins name='nthoIridiumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:3' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60CECECE</WireframeColor>
@@ -3651,14 +4067,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Osmium -->
                 <IfCondition condition=':= nthoOsmiumDist = "layeredVeins"'>
                 
-                    <Veins name='nthoOsmiumBaseVeins' block='NetherOres:tile.netherores.ore.1:4' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoOsmiumBaseVeins' block='NetherOres:tile.netherores.ore.1:4'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6043638A</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoOsmiumSize * _default_' range=':= 1 * 1 * nthoOsmiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoOsmiumSize * _default_' range=':= 1 * 1 * nthoOsmiumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoOsmiumFreq * _default_'/>
@@ -3672,16 +4089,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Osmium -->
                 <IfCondition condition=':= nthoOsmiumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoOsmiumBaseVeins' block='NetherOres:tile.netherores.ore.1:4' inherits='PresetHugeVeins'>
+                    <Veins name='nthoOsmiumBaseVeins' block='NetherOres:tile.netherores.ore.1:4'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6043638A</WireframeColor>
@@ -3702,12 +4129,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoOsmiumBaseCloud' block='NetherOres:tile.netherores.ore.1:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6043638A</WireframeColor>
@@ -3722,10 +4153,16 @@ Saltpeter, Magnesium
                         <!-- Begin Osmium Strategic Cloud Hint Veins -->
                         <Veins name='nthoOsmiumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6043638A</WireframeColor>
@@ -3767,14 +4204,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Sulphur -->
                 <IfCondition condition=':= nthoSulphurDist = "layeredVeins"'>
                 
-                    <Veins name='nthoSulphurBaseVeins' block='NetherOres:tile.netherores.ore.1:5' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoSulphurBaseVeins' block='NetherOres:tile.netherores.ore.1:5'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FDFD11</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSulphurSize * _default_' range=':= 1 * 1 * nthoSulphurSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSulphurSize * _default_' range=':= 1 * 1 * nthoSulphurSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSulphurFreq * _default_'/>
@@ -3788,16 +4226,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Sulphur -->
                 <IfCondition condition=':= nthoSulphurDist = "hugeVeins"'>
                 
-                    <Veins name='nthoSulphurBaseVeins' block='NetherOres:tile.netherores.ore.1:5' inherits='PresetHugeVeins'>
+                    <Veins name='nthoSulphurBaseVeins' block='NetherOres:tile.netherores.ore.1:5'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FDFD11</WireframeColor>
@@ -3818,12 +4266,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoSulphurBaseCloud' block='NetherOres:tile.netherores.ore.1:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FDFD11</WireframeColor>
@@ -3838,10 +4290,16 @@ Saltpeter, Magnesium
                         <!-- Begin Sulphur Strategic Cloud Hint Veins -->
                         <Veins name='nthoSulphurBaseHintVeins' block='NetherOres:tile.netherores.ore.1:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FDFD11</WireframeColor>
@@ -3883,14 +4341,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Titanium -->
                 <IfCondition condition=':= nthoTitaniumDist = "layeredVeins"'>
                 
-                    <Veins name='nthoTitaniumBaseVeins' block='NetherOres:tile.netherores.ore.1:6' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoTitaniumBaseVeins' block='NetherOres:tile.netherores.ore.1:6'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60686868</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoTitaniumSize * _default_' range=':= 1 * 1 * nthoTitaniumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoTitaniumSize * _default_' range=':= 1 * 1 * nthoTitaniumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTitaniumFreq * _default_'/>
@@ -3904,16 +4363,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Titanium -->
                 <IfCondition condition=':= nthoTitaniumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoTitaniumBaseVeins' block='NetherOres:tile.netherores.ore.1:6' inherits='PresetHugeVeins'>
+                    <Veins name='nthoTitaniumBaseVeins' block='NetherOres:tile.netherores.ore.1:6'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60686868</WireframeColor>
@@ -3934,12 +4403,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoTitaniumBaseCloud' block='NetherOres:tile.netherores.ore.1:6' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60686868</WireframeColor>
@@ -3954,10 +4427,16 @@ Saltpeter, Magnesium
                         <!-- Begin Titanium Strategic Cloud Hint Veins -->
                         <Veins name='nthoTitaniumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:6' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60686868</WireframeColor>
@@ -3999,14 +4478,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Mithril -->
                 <IfCondition condition=':= nthoMithrilDist = "layeredVeins"'>
                 
-                    <Veins name='nthoMithrilBaseVeins' block='NetherOres:tile.netherores.ore.1:7' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoMithrilBaseVeins' block='NetherOres:tile.netherores.ore.1:7'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6075E0F6</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoMithrilSize * _default_' range=':= 1 * 1 * nthoMithrilSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoMithrilSize * _default_' range=':= 1 * 1 * nthoMithrilSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoMithrilFreq * _default_'/>
@@ -4020,16 +4500,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Mithril -->
                 <IfCondition condition=':= nthoMithrilDist = "hugeVeins"'>
                 
-                    <Veins name='nthoMithrilBaseVeins' block='NetherOres:tile.netherores.ore.1:7' inherits='PresetHugeVeins'>
+                    <Veins name='nthoMithrilBaseVeins' block='NetherOres:tile.netherores.ore.1:7'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6075E0F6</WireframeColor>
@@ -4050,12 +4540,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoMithrilBaseCloud' block='NetherOres:tile.netherores.ore.1:7' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6075E0F6</WireframeColor>
@@ -4070,10 +4564,16 @@ Saltpeter, Magnesium
                         <!-- Begin Mithril Strategic Cloud Hint Veins -->
                         <Veins name='nthoMithrilBaseHintVeins' block='NetherOres:tile.netherores.ore.1:7' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6075E0F6</WireframeColor>
@@ -4115,14 +4615,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Adamantium -->
                 <IfCondition condition=':= nthoAdamantiumDist = "layeredVeins"'>
                 
-                    <Veins name='nthoAdamantiumBaseVeins' block='NetherOres:tile.netherores.ore.1:8' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoAdamantiumBaseVeins' block='NetherOres:tile.netherores.ore.1:8'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609CA6B0</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoAdamantiumSize * _default_' range=':= 1 * 1 * nthoAdamantiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoAdamantiumSize * _default_' range=':= 1 * 1 * nthoAdamantiumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoAdamantiumFreq * _default_'/>
@@ -4136,16 +4637,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Adamantium -->
                 <IfCondition condition=':= nthoAdamantiumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoAdamantiumBaseVeins' block='NetherOres:tile.netherores.ore.1:8' inherits='PresetHugeVeins'>
+                    <Veins name='nthoAdamantiumBaseVeins' block='NetherOres:tile.netherores.ore.1:8'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609CA6B0</WireframeColor>
@@ -4166,12 +4677,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoAdamantiumBaseCloud' block='NetherOres:tile.netherores.ore.1:8' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609CA6B0</WireframeColor>
@@ -4186,10 +4701,16 @@ Saltpeter, Magnesium
                         <!-- Begin Adamantium Strategic Cloud Hint Veins -->
                         <Veins name='nthoAdamantiumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:8' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x609CA6B0</WireframeColor>
@@ -4231,14 +4752,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Rutile -->
                 <IfCondition condition=':= nthoRutileDist = "layeredVeins"'>
                 
-                    <Veins name='nthoRutileBaseVeins' block='NetherOres:tile.netherores.ore.1:9' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoRutileBaseVeins' block='NetherOres:tile.netherores.ore.1:9'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D2C7A9</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoRutileSize * _default_' range=':= 1 * 1 * nthoRutileSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoRutileSize * _default_' range=':= 1 * 1 * nthoRutileSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoRutileFreq * _default_'/>
@@ -4252,16 +4774,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Rutile -->
                 <IfCondition condition=':= nthoRutileDist = "hugeVeins"'>
                 
-                    <Veins name='nthoRutileBaseVeins' block='NetherOres:tile.netherores.ore.1:9' inherits='PresetHugeVeins'>
+                    <Veins name='nthoRutileBaseVeins' block='NetherOres:tile.netherores.ore.1:9'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D2C7A9</WireframeColor>
@@ -4282,12 +4814,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoRutileBaseCloud' block='NetherOres:tile.netherores.ore.1:9' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60D2C7A9</WireframeColor>
@@ -4302,10 +4838,16 @@ Saltpeter, Magnesium
                         <!-- Begin Rutile Strategic Cloud Hint Veins -->
                         <Veins name='nthoRutileBaseHintVeins' block='NetherOres:tile.netherores.ore.1:9' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60D2C7A9</WireframeColor>
@@ -4347,14 +4889,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Tungsten -->
                 <IfCondition condition=':= nthoTungstenDist = "layeredVeins"'>
                 
-                    <Veins name='nthoTungstenBaseVeins' block='NetherOres:tile.netherores.ore.1:10' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoTungstenBaseVeins' block='NetherOres:tile.netherores.ore.1:10'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60212121</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoTungstenSize * _default_' range=':= 1 * 1 * nthoTungstenSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoTungstenSize * _default_' range=':= 1 * 1 * nthoTungstenSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTungstenFreq * _default_'/>
@@ -4368,16 +4911,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Tungsten -->
                 <IfCondition condition=':= nthoTungstenDist = "hugeVeins"'>
                 
-                    <Veins name='nthoTungstenBaseVeins' block='NetherOres:tile.netherores.ore.1:10' inherits='PresetHugeVeins'>
+                    <Veins name='nthoTungstenBaseVeins' block='NetherOres:tile.netherores.ore.1:10'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60212121</WireframeColor>
@@ -4398,12 +4951,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoTungstenBaseCloud' block='NetherOres:tile.netherores.ore.1:10' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60212121</WireframeColor>
@@ -4418,10 +4975,16 @@ Saltpeter, Magnesium
                         <!-- Begin Tungsten Strategic Cloud Hint Veins -->
                         <Veins name='nthoTungstenBaseHintVeins' block='NetherOres:tile.netherores.ore.1:10' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60212121</WireframeColor>
@@ -4463,14 +5026,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Amber -->
                 <IfCondition condition=':= nthoAmberDist = "layeredVeins"'>
                 
-                    <Veins name='nthoAmberBaseVeins' block='NetherOres:tile.netherores.ore.1:11' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoAmberBaseVeins' block='NetherOres:tile.netherores.ore.1:11'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FEA219</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoAmberSize * _default_' range=':= 1 * 1 * nthoAmberSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoAmberSize * _default_' range=':= 1 * 1 * nthoAmberSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoAmberFreq * _default_'/>
@@ -4484,16 +5048,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Amber -->
                 <IfCondition condition=':= nthoAmberDist = "hugeVeins"'>
                 
-                    <Veins name='nthoAmberBaseVeins' block='NetherOres:tile.netherores.ore.1:11' inherits='PresetHugeVeins'>
+                    <Veins name='nthoAmberBaseVeins' block='NetherOres:tile.netherores.ore.1:11'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FEA219</WireframeColor>
@@ -4514,12 +5088,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoAmberBaseCloud' block='NetherOres:tile.netherores.ore.1:11' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FEA219</WireframeColor>
@@ -4534,10 +5112,16 @@ Saltpeter, Magnesium
                         <!-- Begin Amber Strategic Cloud Hint Veins -->
                         <Veins name='nthoAmberBaseHintVeins' block='NetherOres:tile.netherores.ore.1:11' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FEA219</WireframeColor>
@@ -4579,14 +5163,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Tennantite -->
                 <IfCondition condition=':= nthoTennantiteDist = "layeredVeins"'>
                 
-                    <Veins name='nthoTennantiteBaseVeins' block='NetherOres:tile.netherores.ore.1:12' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoTennantiteBaseVeins' block='NetherOres:tile.netherores.ore.1:12'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609EE2B1</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoTennantiteSize * _default_' range=':= 1 * 1 * nthoTennantiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoTennantiteSize * _default_' range=':= 1 * 1 * nthoTennantiteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTennantiteFreq * _default_'/>
@@ -4600,16 +5185,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Tennantite -->
                 <IfCondition condition=':= nthoTennantiteDist = "hugeVeins"'>
                 
-                    <Veins name='nthoTennantiteBaseVeins' block='NetherOres:tile.netherores.ore.1:12' inherits='PresetHugeVeins'>
+                    <Veins name='nthoTennantiteBaseVeins' block='NetherOres:tile.netherores.ore.1:12'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609EE2B1</WireframeColor>
@@ -4630,12 +5225,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoTennantiteBaseCloud' block='NetherOres:tile.netherores.ore.1:12' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x609EE2B1</WireframeColor>
@@ -4650,10 +5249,16 @@ Saltpeter, Magnesium
                         <!-- Begin Tennantite Strategic Cloud Hint Veins -->
                         <Veins name='nthoTennantiteBaseHintVeins' block='NetherOres:tile.netherores.ore.1:12' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x609EE2B1</WireframeColor>
@@ -4695,14 +5300,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Salt -->
                 <IfCondition condition=':= nthoSaltDist = "layeredVeins"'>
                 
-                    <Veins name='nthoSaltBaseVeins' block='NetherOres:tile.netherores.ore.1:13' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoSaltBaseVeins' block='NetherOres:tile.netherores.ore.1:13'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFFFFF</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSaltSize * _default_' range=':= 1 * 1 * nthoSaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSaltSize * _default_' range=':= 1 * 1 * nthoSaltSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSaltFreq * _default_'/>
@@ -4716,16 +5322,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Salt -->
                 <IfCondition condition=':= nthoSaltDist = "hugeVeins"'>
                 
-                    <Veins name='nthoSaltBaseVeins' block='NetherOres:tile.netherores.ore.1:13' inherits='PresetHugeVeins'>
+                    <Veins name='nthoSaltBaseVeins' block='NetherOres:tile.netherores.ore.1:13'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFFFFF</WireframeColor>
@@ -4746,12 +5362,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoSaltBaseCloud' block='NetherOres:tile.netherores.ore.1:13' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFFFFF</WireframeColor>
@@ -4766,10 +5386,16 @@ Saltpeter, Magnesium
                         <!-- Begin Salt Strategic Cloud Hint Veins -->
                         <Veins name='nthoSaltBaseHintVeins' block='NetherOres:tile.netherores.ore.1:13' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FFFFFF</WireframeColor>
@@ -4811,14 +5437,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Saltpeter -->
                 <IfCondition condition=':= nthoSaltpeterDist = "layeredVeins"'>
                 
-                    <Veins name='nthoSaltpeterBaseVeins' block='NetherOres:tile.netherores.ore.1:14' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoSaltpeterBaseVeins' block='NetherOres:tile.netherores.ore.1:14'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60F4F6F9</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSaltpeterSize * _default_' range=':= 1 * 1 * nthoSaltpeterSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSaltpeterSize * _default_' range=':= 1 * 1 * nthoSaltpeterSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSaltpeterFreq * _default_'/>
@@ -4832,16 +5459,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Saltpeter -->
                 <IfCondition condition=':= nthoSaltpeterDist = "hugeVeins"'>
                 
-                    <Veins name='nthoSaltpeterBaseVeins' block='NetherOres:tile.netherores.ore.1:14' inherits='PresetHugeVeins'>
+                    <Veins name='nthoSaltpeterBaseVeins' block='NetherOres:tile.netherores.ore.1:14'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60F4F6F9</WireframeColor>
@@ -4862,12 +5499,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoSaltpeterBaseCloud' block='NetherOres:tile.netherores.ore.1:14' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60F4F6F9</WireframeColor>
@@ -4882,10 +5523,16 @@ Saltpeter, Magnesium
                         <!-- Begin Saltpeter Strategic Cloud Hint Veins -->
                         <Veins name='nthoSaltpeterBaseHintVeins' block='NetherOres:tile.netherores.ore.1:14' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60F4F6F9</WireframeColor>
@@ -4927,14 +5574,15 @@ Saltpeter, Magnesium
                 <!-- Begin LayeredVeins distribution of Magnesium -->
                 <IfCondition condition=':= nthoMagnesiumDist = "layeredVeins"'>
                 
-                    <Veins name='nthoMagnesiumBaseVeins' block='NetherOres:tile.netherores.ore.1:15' inherits='PresetLayeredVeins'>
+                    <Veins name='nthoMagnesiumBaseVeins' block='NetherOres:tile.netherores.ore.1:15'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60827066</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoMagnesiumSize * _default_' range=':= 1 * 1 * nthoMagnesiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoMagnesiumSize * _default_' range=':= 1 * 1 * nthoMagnesiumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoMagnesiumFreq * _default_'/>
@@ -4948,16 +5596,26 @@ Saltpeter, Magnesium
                 <!-- Begin  Huge Veins distribution of Magnesium -->
                 <IfCondition condition=':= nthoMagnesiumDist = "hugeVeins"'>
                 
-                    <Veins name='nthoMagnesiumBaseVeins' block='NetherOres:tile.netherores.ore.1:15' inherits='PresetHugeVeins'>
+                    <Veins name='nthoMagnesiumBaseVeins' block='NetherOres:tile.netherores.ore.1:15'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60827066</WireframeColor>
@@ -4978,12 +5636,16 @@ Saltpeter, Magnesium
                 
                     <Cloud name='nthoMagnesiumBaseCloud' block='NetherOres:tile.netherores.ore.1:15' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60827066</WireframeColor>
@@ -4998,10 +5660,16 @@ Saltpeter, Magnesium
                         <!-- Begin Magnesium Strategic Cloud Hint Veins -->
                         <Veins name='nthoMagnesiumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:15' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60827066</WireframeColor>

--- a/src/main/resources/config/modules/Netherrocks.xml
+++ b/src/main/resources/config/modules/Netherrocks.xml
@@ -1,12 +1,9 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Netherrocks Module
-
-Generates: 
-Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Netherrocks" Module: This configuration
+      covers malachite, dragonstone, illumenite, fyrite, ashtone, and
+      argonite.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="netherrocks">
@@ -271,12 +268,12 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='netherrocks:malachite_ore:0' />
-                    <Replaces block='netherrocks:dragonstone_ore:0' />
-                    <Replaces block='netherrocks:illumenite_ore:0' />
-                    <Replaces block='netherrocks:fyrite_ore:0' />
-                    <Replaces block='netherrocks:ashstone_ore:0' />
-                    <Replaces block='netherrocks:argonite_ore:0' />
+                    <Replaces block='netherrocks:malachite_ore' />
+                    <Replaces block='netherrocks:dragonstone_ore' />
+                    <Replaces block='netherrocks:illumenite_ore' />
+                    <Replaces block='netherrocks:fyrite_ore' />
+                    <Replaces block='netherrocks:ashstone_ore' />
+                    <Replaces block='netherrocks:argonite_ore' />
                 </Substitute>
                 <!-- Original Nether Ore Removal Complete -->
                 
@@ -287,14 +284,15 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin Layered Veins distribution of Malachite -->
                 <IfCondition condition=':= nthrMalachiteDist = "layeredVeins"'>
                 
-                    <Veins name='nthrMalachiteBaseVeins' block='netherrocks:malachite_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='nthrMalachiteBaseVeins' block='netherrocks:malachite_ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60046652</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrMalachiteSize * _default_' range=':= 3 * 1 * nthrMalachiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrMalachiteSize * _default_' range=':= 3 * 1 * nthrMalachiteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrMalachiteFreq * _default_'/>
@@ -308,16 +306,26 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin  Huge Veins distribution of Malachite -->
                 <IfCondition condition=':= nthrMalachiteDist = "hugeVeins"'>
                 
-                    <Veins name='nthrMalachiteBaseVeins' block='netherrocks:malachite_ore' inherits='PresetHugeVeins'>
+                    <Veins name='nthrMalachiteBaseVeins' block='netherrocks:malachite_ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60046652</WireframeColor>
@@ -338,12 +346,16 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 
                     <Cloud name='nthrMalachiteBaseCloud' block='netherrocks:malachite_ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60046652</WireframeColor>
@@ -358,10 +370,16 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                         <!-- Begin Malachite Strategic Cloud Hint Veins -->
                         <Veins name='nthrMalachiteBaseHintVeins' block='netherrocks:malachite_ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60046652</WireframeColor>
@@ -403,14 +421,15 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin Layered Veins distribution of Dragonstone -->
                 <IfCondition condition=':= nthrDragonstoneDist = "layeredVeins"'>
                 
-                    <Veins name='nthrDragonstoneBaseVeins' block='netherrocks:dragonstone_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='nthrDragonstoneBaseVeins' block='netherrocks:dragonstone_ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602F0E0F</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrDragonstoneSize * _default_' range=':= 3 * 1 * nthrDragonstoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrDragonstoneSize * _default_' range=':= 3 * 1 * nthrDragonstoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrDragonstoneFreq * _default_'/>
@@ -424,16 +443,26 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin  Huge Veins distribution of Dragonstone -->
                 <IfCondition condition=':= nthrDragonstoneDist = "hugeVeins"'>
                 
-                    <Veins name='nthrDragonstoneBaseVeins' block='netherrocks:dragonstone_ore' inherits='PresetHugeVeins'>
+                    <Veins name='nthrDragonstoneBaseVeins' block='netherrocks:dragonstone_ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602F0E0F</WireframeColor>
@@ -454,12 +483,16 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 
                     <Cloud name='nthrDragonstoneBaseCloud' block='netherrocks:dragonstone_ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602F0E0F</WireframeColor>
@@ -474,10 +507,16 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                         <!-- Begin Dragonstone Strategic Cloud Hint Veins -->
                         <Veins name='nthrDragonstoneBaseHintVeins' block='netherrocks:dragonstone_ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x602F0E0F</WireframeColor>
@@ -519,14 +558,15 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin Layered Veins distribution of Illumenite -->
                 <IfCondition condition=':= nthrIllumeniteDist = "layeredVeins"'>
                 
-                    <Veins name='nthrIllumeniteBaseVeins' block='netherrocks:illumenite_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='nthrIllumeniteBaseVeins' block='netherrocks:illumenite_ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FCFEB0</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrIllumeniteSize * _default_' range=':= 3 * 1 * nthrIllumeniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrIllumeniteSize * _default_' range=':= 3 * 1 * nthrIllumeniteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrIllumeniteFreq * _default_'/>
@@ -540,16 +580,26 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin  Huge Veins distribution of Illumenite -->
                 <IfCondition condition=':= nthrIllumeniteDist = "hugeVeins"'>
                 
-                    <Veins name='nthrIllumeniteBaseVeins' block='netherrocks:illumenite_ore' inherits='PresetHugeVeins'>
+                    <Veins name='nthrIllumeniteBaseVeins' block='netherrocks:illumenite_ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FCFEB0</WireframeColor>
@@ -570,12 +620,16 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 
                     <Cloud name='nthrIllumeniteBaseCloud' block='netherrocks:illumenite_ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FCFEB0</WireframeColor>
@@ -590,10 +644,16 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                         <!-- Begin Illumenite Strategic Cloud Hint Veins -->
                         <Veins name='nthrIllumeniteBaseHintVeins' block='netherrocks:illumenite_ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FCFEB0</WireframeColor>
@@ -635,14 +695,15 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin Layered Veins distribution of Fyrite -->
                 <IfCondition condition=':= nthrFyriteDist = "layeredVeins"'>
                 
-                    <Veins name='nthrFyriteBaseVeins' block='netherrocks:fyrite_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='nthrFyriteBaseVeins' block='netherrocks:fyrite_ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BF0000</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrFyriteSize * _default_' range=':= 3 * 1 * nthrFyriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrFyriteSize * _default_' range=':= 3 * 1 * nthrFyriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrFyriteFreq * _default_'/>
@@ -656,16 +717,26 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin  Huge Veins distribution of Fyrite -->
                 <IfCondition condition=':= nthrFyriteDist = "hugeVeins"'>
                 
-                    <Veins name='nthrFyriteBaseVeins' block='netherrocks:fyrite_ore' inherits='PresetHugeVeins'>
+                    <Veins name='nthrFyriteBaseVeins' block='netherrocks:fyrite_ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BF0000</WireframeColor>
@@ -686,12 +757,16 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 
                     <Cloud name='nthrFyriteBaseCloud' block='netherrocks:fyrite_ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BF0000</WireframeColor>
@@ -706,10 +781,16 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                         <!-- Begin Fyrite Strategic Cloud Hint Veins -->
                         <Veins name='nthrFyriteBaseHintVeins' block='netherrocks:fyrite_ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60BF0000</WireframeColor>
@@ -751,14 +832,15 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin Layered Veins distribution of Ashtone -->
                 <IfCondition condition=':= nthrAshtoneDist = "layeredVeins"'>
                 
-                    <Veins name='nthrAshtoneBaseVeins' block='netherrocks:ashstone_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='nthrAshtoneBaseVeins' block='netherrocks:ashstone_ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x603F3F60</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrAshtoneSize * _default_' range=':= 3 * 1 * nthrAshtoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrAshtoneSize * _default_' range=':= 3 * 1 * nthrAshtoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrAshtoneFreq * _default_'/>
@@ -772,16 +854,26 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin  Huge Veins distribution of Ashtone -->
                 <IfCondition condition=':= nthrAshtoneDist = "hugeVeins"'>
                 
-                    <Veins name='nthrAshtoneBaseVeins' block='netherrocks:ashstone_ore' inherits='PresetHugeVeins'>
+                    <Veins name='nthrAshtoneBaseVeins' block='netherrocks:ashstone_ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x603F3F60</WireframeColor>
@@ -802,12 +894,16 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 
                     <Cloud name='nthrAshtoneBaseCloud' block='netherrocks:ashstone_ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x603F3F60</WireframeColor>
@@ -822,10 +918,16 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                         <!-- Begin Ashtone Strategic Cloud Hint Veins -->
                         <Veins name='nthrAshtoneBaseHintVeins' block='netherrocks:ashstone_ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x603F3F60</WireframeColor>
@@ -867,14 +969,15 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin Layered Veins distribution of Argonite -->
                 <IfCondition condition=':= nthrArgoniteDist = "layeredVeins"'>
                 
-                    <Veins name='nthrArgoniteBaseVeins' block='netherrocks:argonite_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='nthrArgoniteBaseVeins' block='netherrocks:argonite_ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x600F0035</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrArgoniteSize * _default_' range=':= 3 * 1 * nthrArgoniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrArgoniteSize * _default_' range=':= 3 * 1 * nthrArgoniteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrArgoniteFreq * _default_'/>
@@ -888,16 +991,26 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 <!-- Begin  Huge Veins distribution of Argonite -->
                 <IfCondition condition=':= nthrArgoniteDist = "hugeVeins"'>
                 
-                    <Veins name='nthrArgoniteBaseVeins' block='netherrocks:argonite_ore' inherits='PresetHugeVeins'>
+                    <Veins name='nthrArgoniteBaseVeins' block='netherrocks:argonite_ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x600F0035</WireframeColor>
@@ -918,12 +1031,16 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                 
                     <Cloud name='nthrArgoniteBaseCloud' block='netherrocks:argonite_ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x600F0035</WireframeColor>
@@ -938,10 +1055,16 @@ Malachite, Dragonstone, Illumenite, Fyrite, Ashtone, Argonite
                         <!-- Begin Argonite Strategic Cloud Hint Veins -->
                         <Veins name='nthrArgoniteBaseHintVeins' block='netherrocks:argonite_ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x600F0035</WireframeColor>

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -1,12 +1,8 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Pams HarvestCraft Module
-
-Generates: 
-Salt
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Pams HarvestCraft" Module: This
+      configuration covers salt.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="harvestcraft">
@@ -76,7 +72,7 @@ Salt
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='harvestcraft:salt:0' />
+                    <Replaces block='harvestcraft:salt' />
                 </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
                 
@@ -87,17 +83,21 @@ Salt
                 <!-- Begin SparseVeins distribution of Salt -->
                 <IfCondition condition=':= hvstSaltDist = "sparseVeins"'>
                 
-                    <Veins name='hvstSaltBaseVeins' block='harvestcraft:salt' inherits='PresetSparseVeins'>
+                    <Veins name='hvstSaltBaseVeins' block='harvestcraft:salt'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6090927C</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * hvstSaltSize * _default_' range=':= 1 * 1 * hvstSaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 4' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * hvstSaltSize * _default_' range=':= 1 * 1 * hvstSaltSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * hvstSaltFreq * _default_'/>
@@ -107,7 +107,7 @@ Salt
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Salt Sparse Veins) Settings -->
-                    <Veins name='hvstSaltPrefersVeins' block='harvestcraft:salt' inherits='hvstSaltBaseVeins'>
+                    <Veins name='hvstSaltPrefersVeins' block='harvestcraft:salt'  inherits='hvstSaltBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -127,22 +127,25 @@ Salt
                 <!-- Begin  Small Deposits distribution of Salt -->
                 <IfCondition condition=':= hvstSaltDist = "smallDeposits"'>
                 
-                    <Veins name='hvstSaltBaseVeins' block='harvestcraft:salt' inherits='PresetSmallDeposits'>
+                    <Veins name='hvstSaltBaseVeins' block='harvestcraft:salt'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6090927C</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * hvstSaltSize * _default_' range=':= 1 * 1 * hvstSaltSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * hvstSaltSize * _default_' range=':= 1 * 1 * hvstSaltSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * hvstSaltFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 1.2 * _default_' range=':= 1 * _default_'/>
+                        <Setting name='BranchInclination' avg=':= -_default_' range=':= 0'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Salt Small Deposits) Settings -->
-                    <Veins name='hvstSaltPrefersVeins' block='harvestcraft:salt' inherits='hvstSaltBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Salt Deposit Veins) Settings -->
+                    <Veins name='hvstSaltPrefersVeins' block='harvestcraft:salt'  inherits='hvstSaltBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -153,7 +156,7 @@ Salt
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mountain'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Salt Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Salt Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Salt -->
@@ -164,12 +167,16 @@ Salt
                 
                     <Cloud name='hvstSaltBaseCloud' block='harvestcraft:salt' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6090927C</WireframeColor>
@@ -184,10 +191,16 @@ Salt
                         <!-- Begin Salt Strategic Cloud Hint Veins -->
                         <Veins name='hvstSaltBaseHintVeins' block='harvestcraft:salt' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6090927C</WireframeColor>

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -1,13 +1,9 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Project Red Module
-
-Generates: 
-Ruby, Sapphire, Peridot, Copper, Tin, Silver, Electrotine, Marble,
-Basalt
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Project Red" Module: This configuration
+      covers ruby, sapphire, peridot, copper, tin, silver,
+      electrotine, marble, and  basalt.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="ProjRed|Exploration">
@@ -359,14 +355,14 @@ Basalt
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='ProjRed|Exploration:projectred.exploration.ore:0' />
+                    <Replaces block='ProjRed|Exploration:projectred.exploration.ore' />
                     <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' />
                     <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' />
                     <Replaces block='ProjRed|Exploration:projectred.exploration.ore:3' />
                     <Replaces block='ProjRed|Exploration:projectred.exploration.ore:4' />
                     <Replaces block='ProjRed|Exploration:projectred.exploration.ore:5' />
                     <Replaces block='ProjRed|Exploration:projectred.exploration.ore:6' />
-                    <Replaces block='ProjRed|Exploration:projectred.exploration.stone:0' />
+                    <Replaces block='ProjRed|Exploration:projectred.exploration.stone' />
                     <Replaces block='ProjRed|Exploration:projectred.exploration.stone:3' />
                 </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
@@ -378,35 +374,32 @@ Basalt
                 <!-- Begin PipeVeins distribution of Ruby -->
                 <IfCondition condition=':= predRubyDist = "pipeVeins"'>
                 
-                    
-                    <!-- Begin Ruby Ore Configuration -->
-                    <Veins name='predRubyBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore' inherits='PresetPipeVeins' seed='0xE23A'>
+                    <Veins name='predRubyBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore'  inherits='PresetPipeVeins' seed='0xE23A'>
                         <Description>
-                            Short sparsely filled veins sloping up from near the bottom of the map.
+                            Short sparsely filled veins sloping up
+                            from near the bottom of the map.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60900113</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * predRubySize * _default_' range=':= 1 * 1 * predRubySize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * predRubySize * _default_' range=':= 1 * 1 * predRubySize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * predRubyFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
-                    <!-- End Ruby Ore Configuration -->
                     
-                    
-                    <!-- Begin Ruby Pipe Configuration -->
-                    <Veins name= 'predRubyBasePipe' block='minecraft:stone' inherits='predRubyBaseVeins' seed='0xE23A'>
+                    <!-- Begin Pipe Filling (Ruby Pipe Veins) Settings -->
+                    <Veins name='predRubyPipeVeins' block='minecraft:stone'  inherits='predRubyBaseVeins' seed='0xE23A'>
                         <Description>
-                            Fills center of each tube with Pipe material.
+                            Fills the vein with an additional material
+                            (minecraft:stone).
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60900113</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 1 * predRubySize * _default_' range=':= 0.5 * 1 * 1 * predRubySize * _default_'/>
                         <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 1 * predRubySize * _default_' range=':= 0.5 * 1 * 1 * predRubySize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
                         <Replaces block='minecraft:stone'/>
                         <Replaces block='ProjRed|Exploration:projectred.exploration.ore'/>
                         <Replaces block='minecraft:dirt'/>
@@ -414,10 +407,8 @@ Basalt
                         <Replaces block='minecraft:gravel'/>
                         <Replaces block='minecraft:netherrack'/>
                         <Replaces block='minecraft:end_stone'/>
-                        <BiomeType name='Mountain'/>
                     </Veins>
-                    <!-- End Ruby Pipe Configuration -->
-                    
+                    <!-- End Pipe Filling (Ruby Pipe Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End PipeVeins distribution of Ruby -->
@@ -426,19 +417,20 @@ Basalt
                 <!-- Begin  Small Deposits distribution of Ruby -->
                 <IfCondition condition=':= predRubyDist = "smallDeposits"'>
                 
-                    <Veins name='predRubyBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore' inherits='PresetSmallDeposits'>
+                    <Veins name='predRubyBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60900113</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * predRubySize * _default_' range=':= 1 * 1 * predRubySize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predRubySize * _default_' range=':= 1 * 1 * predRubySize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * predRubyFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -450,12 +442,16 @@ Basalt
                 
                     <Cloud name='predRubyBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60900113</WireframeColor>
@@ -471,10 +467,16 @@ Basalt
                         <!-- Begin Ruby Strategic Cloud Hint Veins -->
                         <Veins name='predRubyBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60900113</WireframeColor>
@@ -518,35 +520,32 @@ Basalt
                 <!-- Begin PipeVeins distribution of Sapphire -->
                 <IfCondition condition=':= predSapphireDist = "pipeVeins"'>
                 
-                    
-                    <!-- Begin Sapphire Ore Configuration -->
-                    <Veins name='predSapphireBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:1' inherits='PresetPipeVeins' seed='0x5196'>
+                    <Veins name='predSapphireBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:1'  inherits='PresetPipeVeins' seed='0x5196'>
                         <Description>
-                            Short sparsely filled veins sloping up from near the bottom of the map.
+                            Short sparsely filled veins sloping up
+                            from near the bottom of the map.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x600011C8</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * predSapphireSize * _default_' range=':= 1 * 1 * predSapphireSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * predSapphireSize * _default_' range=':= 1 * 1 * predSapphireSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * predSapphireFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
-                    <!-- End Sapphire Ore Configuration -->
                     
-                    
-                    <!-- Begin Sapphire Pipe Configuration -->
-                    <Veins name= 'predSapphireBasePipe' block='minecraft:stone' inherits='predSapphireBaseVeins' seed='0x5196'>
+                    <!-- Begin Pipe Filling (Sapphire Pipe Veins) Settings -->
+                    <Veins name='predSapphirePipeVeins' block='minecraft:stone'  inherits='predSapphireBaseVeins' seed='0x5196'>
                         <Description>
-                            Fills center of each tube with Pipe material.
+                            Fills the vein with an additional material
+                            (minecraft:stone).
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x600011C8</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 1 * predSapphireSize * _default_' range=':= 0.5 * 1 * 1 * predSapphireSize * _default_'/>
                         <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 1 * predSapphireSize * _default_' range=':= 0.5 * 1 * 1 * predSapphireSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
                         <Replaces block='minecraft:stone'/>
                         <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1'/>
                         <Replaces block='minecraft:dirt'/>
@@ -554,10 +553,8 @@ Basalt
                         <Replaces block='minecraft:gravel'/>
                         <Replaces block='minecraft:netherrack'/>
                         <Replaces block='minecraft:end_stone'/>
-                        <BiomeType name='Mountain'/>
                     </Veins>
-                    <!-- End Sapphire Pipe Configuration -->
-                    
+                    <!-- End Pipe Filling (Sapphire Pipe Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End PipeVeins distribution of Sapphire -->
@@ -566,19 +563,20 @@ Basalt
                 <!-- Begin  Small Deposits distribution of Sapphire -->
                 <IfCondition condition=':= predSapphireDist = "smallDeposits"'>
                 
-                    <Veins name='predSapphireBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:1' inherits='PresetSmallDeposits'>
+                    <Veins name='predSapphireBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:1'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x600011C8</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * predSapphireSize * _default_' range=':= 1 * 1 * predSapphireSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predSapphireSize * _default_' range=':= 1 * 1 * predSapphireSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * predSapphireFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -590,12 +588,16 @@ Basalt
                 
                     <Cloud name='predSapphireBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x600011C8</WireframeColor>
@@ -611,10 +613,16 @@ Basalt
                         <!-- Begin Sapphire Strategic Cloud Hint Veins -->
                         <Veins name='predSapphireBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x600011C8</WireframeColor>
@@ -658,35 +666,32 @@ Basalt
                 <!-- Begin PipeVeins distribution of Peridot -->
                 <IfCondition condition=':= predPeridotDist = "pipeVeins"'>
                 
-                    
-                    <!-- Begin Peridot Ore Configuration -->
-                    <Veins name='predPeridotBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:2' inherits='PresetPipeVeins' seed='0x8759'>
+                    <Veins name='predPeridotBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:2'  inherits='PresetPipeVeins' seed='0x8759'>
                         <Description>
-                            Short sparsely filled veins sloping up from near the bottom of the map.
+                            Short sparsely filled veins sloping up
+                            from near the bottom of the map.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60057529</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * predPeridotSize * _default_' range=':= 1 * 1 * predPeridotSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * predPeridotSize * _default_' range=':= 1 * 1 * predPeridotSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * predPeridotFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
-                    <!-- End Peridot Ore Configuration -->
                     
-                    
-                    <!-- Begin Peridot Pipe Configuration -->
-                    <Veins name= 'predPeridotBasePipe' block='minecraft:stone' inherits='predPeridotBaseVeins' seed='0x8759'>
+                    <!-- Begin Pipe Filling (Peridot Pipe Veins) Settings -->
+                    <Veins name='predPeridotPipeVeins' block='minecraft:stone'  inherits='predPeridotBaseVeins' seed='0x8759'>
                         <Description>
-                            Fills center of each tube with Pipe material.
+                            Fills the vein with an additional material
+                            (minecraft:stone).
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60057529</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 1 * predPeridotSize * _default_' range=':= 0.5 * 1 * 1 * predPeridotSize * _default_'/>
                         <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 1 * predPeridotSize * _default_' range=':= 0.5 * 1 * 1 * predPeridotSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
                         <Replaces block='minecraft:stone'/>
                         <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2'/>
                         <Replaces block='minecraft:dirt'/>
@@ -694,10 +699,8 @@ Basalt
                         <Replaces block='minecraft:gravel'/>
                         <Replaces block='minecraft:netherrack'/>
                         <Replaces block='minecraft:end_stone'/>
-                        <BiomeType name='Mountain'/>
                     </Veins>
-                    <!-- End Peridot Pipe Configuration -->
-                    
+                    <!-- End Pipe Filling (Peridot Pipe Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End PipeVeins distribution of Peridot -->
@@ -706,19 +709,20 @@ Basalt
                 <!-- Begin  Small Deposits distribution of Peridot -->
                 <IfCondition condition=':= predPeridotDist = "smallDeposits"'>
                 
-                    <Veins name='predPeridotBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:2' inherits='PresetSmallDeposits'>
+                    <Veins name='predPeridotBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:2'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60057529</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * predPeridotSize * _default_' range=':= 1 * 1 * predPeridotSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predPeridotSize * _default_' range=':= 1 * 1 * predPeridotSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * predPeridotFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -730,12 +734,16 @@ Basalt
                 
                     <Cloud name='predPeridotBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60057529</WireframeColor>
@@ -751,10 +759,16 @@ Basalt
                         <!-- Begin Peridot Strategic Cloud Hint Veins -->
                         <Veins name='predPeridotBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60057529</WireframeColor>
@@ -798,14 +812,15 @@ Basalt
                 <!-- Begin Layered Veins distribution of Copper -->
                 <IfCondition condition=':= predCopperDist = "layeredVeins"'>
                 
-                    <Veins name='predCopperBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='PresetLayeredVeins'>
+                    <Veins name='predCopperBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:3'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.9 * predCopperSize * _default_' range=':= 1 * 0.9 * predCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 45' range=':= 10' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 45' range=':= 10' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.9 * predCopperSize * _default_' range=':= 1 * 0.9 * predCopperSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * predCopperFreq * _default_'/>
@@ -816,7 +831,7 @@ Basalt
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='predCopperPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='predCopperBaseVeins'>
+                    <Veins name='predCopperPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:3'  inherits='predCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -834,16 +849,26 @@ Basalt
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= predCopperDist = "hugeVeins"'>
                 
-                    <Veins name='predCopperBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='PresetHugeVeins'>
+                    <Veins name='predCopperBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:3'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -859,7 +884,7 @@ Basalt
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                    <Veins name='predCopperPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='predCopperBaseVeins'>
+                    <Veins name='predCopperPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:3'  inherits='predCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -879,12 +904,16 @@ Basalt
                 
                     <Cloud name='predCopperBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -899,10 +928,16 @@ Basalt
                         <!-- Begin Copper Strategic Cloud Hint Veins -->
                         <Veins name='predCopperBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -946,14 +981,15 @@ Basalt
                 <!-- Begin Layered Veins distribution of Tin -->
                 <IfCondition condition=':= predTinDist = "layeredVeins"'>
                 
-                    <Veins name='predTinBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='PresetLayeredVeins'>
+                    <Veins name='predTinBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:4'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * predTinSize * _default_' range=':= 1 * 0.85 * predTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.85 * predTinSize * _default_' range=':= 1 * 0.85 * predTinSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * predTinFreq * _default_'/>
@@ -964,7 +1000,7 @@ Basalt
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='predTinPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='predTinBaseVeins'>
+                    <Veins name='predTinPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:4'  inherits='predTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -982,16 +1018,26 @@ Basalt
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= predTinDist = "hugeVeins"'>
                 
-                    <Veins name='predTinBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='PresetHugeVeins'>
+                    <Veins name='predTinBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:4'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -1007,7 +1053,7 @@ Basalt
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                    <Veins name='predTinPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='predTinBaseVeins'>
+                    <Veins name='predTinPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:4'  inherits='predTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1027,12 +1073,16 @@ Basalt
                 
                     <Cloud name='predTinBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -1047,10 +1097,16 @@ Basalt
                         <!-- Begin Tin Strategic Cloud Hint Veins -->
                         <Veins name='predTinBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -1094,14 +1150,15 @@ Basalt
                 <!-- Begin Layered Veins distribution of Silver -->
                 <IfCondition condition=':= predSilverDist = "layeredVeins"'>
                 
-                    <Veins name='predSilverBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='predSilverBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:5'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3F2F7</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * predSilverSize * _default_' range=':= 1 * 0.85 * predSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.85 * predSilverSize * _default_' range=':= 1 * 0.85 * predSilverSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * predSilverFreq * _default_'/>
@@ -1112,7 +1169,7 @@ Basalt
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                    <Veins name='predSilverPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='predSilverBaseVeins'>
+                    <Veins name='predSilverPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:5'  inherits='predSilverBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1130,16 +1187,26 @@ Basalt
                 <!-- Begin  Huge Veins distribution of Silver -->
                 <IfCondition condition=':= predSilverDist = "hugeVeins"'>
                 
-                    <Veins name='predSilverBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='PresetHugeVeins'>
+                    <Veins name='predSilverBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:5'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3F2F7</WireframeColor>
@@ -1155,7 +1222,7 @@ Basalt
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Huge Veins) Settings -->
-                    <Veins name='predSilverPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='predSilverBaseVeins'>
+                    <Veins name='predSilverPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:5'  inherits='predSilverBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1175,12 +1242,16 @@ Basalt
                 
                     <Cloud name='predSilverBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3F2F7</WireframeColor>
@@ -1195,10 +1266,16 @@ Basalt
                         <!-- Begin Silver Strategic Cloud Hint Veins -->
                         <Veins name='predSilverBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E3F2F7</WireframeColor>
@@ -1242,33 +1319,23 @@ Basalt
                 <!-- Begin VerticalVeins distribution of Electrotine -->
                 <IfCondition condition=':= predElectrotineDist = "verticalVeins"'>
                 
-                    <Veins name='predElectrotineBaseParentVeins' block='ProjRed|Exploration:projectred.exploration.ore:6' inherits='PresetVerticalVeins'>
+                    <Veins name='predElectrotineBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:6'  inherits='PresetVerticalVeins' >
                         <Description>
-                            Single vertical veins that occur with no motherlodes.
+                            Single vertical veins that occur with no
+                            motherlodes.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6001FFFC</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * predElectrotineSize * _default_' range=':= 1 * 1 * predElectrotineSize * _default_'/>
                         <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * predElectrotineSize * _default_' range=':= 1 * 1 * predElectrotineSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':=  1 * 1.3 * predElectrotineFreq * _default_'/>
+                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.3 * predElectrotineFreq * _default_'/>
                         <Replaces block='minecraft:stone'/>
-                        <Veins name='predElectrotineBaseChildVeins' block='ProjRed|Exploration:projectred.exploration.ore:6' inherits='PresetVerticalVeins'>
-                            <Description>
-                                Single vertical veins that occur with no motherlodes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6001FFFC</WireframeColor>
-                            <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
-                            <Setting name='SegmentRadius' avg=':= 1 * 1 * predElectrotineSize * _default_' range=':= 1 * 1 * predElectrotineSize * _default_'/>
-                            <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                            <Setting name='MotherlodeFrequency' avg=':= 1 * 1.3 * predElectrotineFreq * 3 * _default_'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Electrotine Vertical Veins) Settings -->
-                    <Veins name='predElectrotinePrefersParentVeins' block='ProjRed|Exploration:projectred.exploration.ore:6' inherits='predElectrotineBaseParentVeins'>
+                    <Veins name='predElectrotinePrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:6'  inherits='predElectrotineBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1276,15 +1343,6 @@ Basalt
                         <WireframeColor>0x6001FFFC</WireframeColor>
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Desert'/>
-                        <Veins name='predElectrotinePrefersChildVeins' block='ProjRed|Exploration:projectred.exploration.ore:6' inherits='predElectrotineBaseChildVeins'>
-                            <Description>
-                                Spawns 2 more times in preferred biomes.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6001FFFC</WireframeColor>
-                            <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                            <BiomeType name='Desert'/>
-                        </Veins>
                     </Veins>
                     <!-- End Preferred Biome Distribution (Electrotine Vertical Veins) Settings -->
                 
@@ -1295,22 +1353,23 @@ Basalt
                 <!-- Begin  Small Deposits distribution of Electrotine -->
                 <IfCondition condition=':= predElectrotineDist = "smallDeposits"'>
                 
-                    <Veins name='predElectrotineBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:6' inherits='PresetSmallDeposits'>
+                    <Veins name='predElectrotineBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:6'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6001FFFC</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * predElectrotineSize * _default_' range=':= 1 * 1 * predElectrotineSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predElectrotineSize * _default_' range=':= 1 * 1 * predElectrotineSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.3 * predElectrotineFreq * _default_'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Electrotine Small Deposits) Settings -->
-                    <Veins name='predElectrotinePrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:6' inherits='predElectrotineBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Electrotine Deposit Veins) Settings -->
+                    <Veins name='predElectrotinePrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:6'  inherits='predElectrotineBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1319,7 +1378,7 @@ Basalt
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Desert'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Electrotine Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Electrotine Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Electrotine -->
@@ -1330,12 +1389,16 @@ Basalt
                 
                     <Cloud name='predElectrotineBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore:6' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6001FFFC</WireframeColor>
@@ -1350,10 +1413,16 @@ Basalt
                         <!-- Begin Electrotine Strategic Cloud Hint Veins -->
                         <Veins name='predElectrotineBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:6' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6001FFFC</WireframeColor>
@@ -1397,14 +1466,15 @@ Basalt
                 <!-- Begin Layered Veins distribution of Marble -->
                 <IfCondition condition=':= predMarbleDist = "layeredVeins"'>
                 
-                    <Veins name='predMarbleBaseVeins' block='ProjRed|Exploration:projectred.exploration.stone' inherits='PresetLayeredVeins'>
+                    <Veins name='predMarbleBaseVeins' block='ProjRed|Exploration:projectred.exploration.stone'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFFFFF</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * predMarbleSize * _default_' range=':= 1 * 1 * predMarbleSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * predMarbleSize * _default_' range=':= 1 * 1 * predMarbleSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * predMarbleFreq * _default_'/>
@@ -1412,7 +1482,7 @@ Basalt
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Marble Layered Veins) Settings -->
-                    <Veins name='predMarblePrefersVeins' block='ProjRed|Exploration:projectred.exploration.stone' inherits='predMarbleBaseVeins'>
+                    <Veins name='predMarblePrefersVeins' block='ProjRed|Exploration:projectred.exploration.stone'  inherits='predMarbleBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1434,14 +1504,15 @@ Basalt
                 <!-- Begin Layered Veins distribution of Basalt -->
                 <IfCondition condition=':= predBasaltDist = "layeredVeins"'>
                 
-                    <Veins name='predBasaltBaseVeins' block='ProjRed|Exploration:projectred.exploration.stone:3' inherits='PresetLayeredVeins'>
+                    <Veins name='predBasaltBaseVeins' block='ProjRed|Exploration:projectred.exploration.stone:3'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60111111</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * predBasaltSize * _default_' range=':= 1 * 1 * predBasaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * predBasaltSize * _default_' range=':= 1 * 1 * predBasaltSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * predBasaltFreq * _default_'/>
@@ -1449,7 +1520,7 @@ Basalt
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Basalt Layered Veins) Settings -->
-                    <Veins name='predBasaltPrefersVeins' block='ProjRed|Exploration:projectred.exploration.stone:3' inherits='predBasaltBaseVeins'>
+                    <Veins name='predBasaltPrefersVeins' block='ProjRed|Exploration:projectred.exploration.stone:3'  inherits='predBasaltBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -1,13 +1,9 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   RailCraft Module
-
-Generates: 
-Quarry Stone, Sulfur, Poor Iron, Poor Gold, Poor Copper, Poor Tin,
-Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "RailCraft" Module: This configuration
+      covers quarry stone, sulfur, poor iron, poor gold, poor copper,
+      poor tin,  poor lead, saltpeter, abyssal ores, and firestone.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="Railcraft">
@@ -316,30 +312,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Saltpeter Configuration UI Complete -->
                 
                 
-                <!-- Remove Abyssal Stone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='rlcrRemoveAbyssalStoneDist'  displayState='shown' displayGroup='groupRailCraft'> 
-                        <Description> Controls how Remove Abyssal Stone is generated </Description> 
-                        <DisplayName>RailCraft Remove Abyssal Stone</DisplayName>
-                        <Choice value='substituteGen' displayValue='Substitute'>
-                            <Description>
-                                Simple substitution.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Remove Abyssal Stone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='rlcrRemoveAbyssalStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Frequency multiplier for RailCraft Remove Abyssal Stone distributions </Description>
-                        <DisplayName>RailCraft Remove Abyssal Stone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='rlcrRemoveAbyssalStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Size multiplier for RailCraft Remove Abyssal Stone distributions </Description>
-                        <DisplayName>RailCraft Remove Abyssal Stone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Remove Abyssal Stone Configuration UI Complete -->
-                
-                
                 <!-- Abyssal Ores Configuration UI Starting -->
                 <ConfigSection>
                     <OptionChoice name='rlcrAbyssalOresDist'  displayState='shown' displayGroup='groupRailCraft'> 
@@ -410,16 +382,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
             <IfCondition condition=':= ?COGActive'>
                 
                 <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='rlcrOverworldOreSubstitute0' block='Railcraft:cube:6'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='minecraft:stone:0' />
-                </Substitute>
-                <Substitute name='rlcrOverworldOreSubstitute1' block='minecraft:stone'>
+                <Substitute name='rlcrOverworldOreSubstitute0' block='minecraft:stone'>
                     <Description>
                         Replace vanilla-generated ore clusters.
                     </Description>
@@ -427,15 +390,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
                     <Replaces block='Railcraft:cube:7' />
-                    <Replaces block='Railcraft:ore:0' />
+                    <Replaces block='Railcraft:ore' />
                     <Replaces block='Railcraft:ore:7' />
                     <Replaces block='Railcraft:ore:8' />
                     <Replaces block='Railcraft:ore:9' />
                     <Replaces block='Railcraft:ore:10' />
                     <Replaces block='Railcraft:ore:11' />
                     <Replaces block='Railcraft:ore:2' />
+                    <Replaces block='Railcraft:cube:6' />
                 </Substitute>
-                <Substitute name='rlcrOverworldOreSubstitute2' block='minecraft:sandstone'>
+                <Substitute name='rlcrOverworldOreSubstitute1' block='minecraft:stone'>
                     <Description>
                         Replace vanilla-generated ore clusters.
                     </Description>
@@ -453,14 +417,15 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin Layered Veins distribution of Quarry Stone -->
                 <IfCondition condition=':= rlcrQuarryStoneDist = "layeredVeins"'>
                 
-                    <Veins name='rlcrQuarryStoneBaseVeins' block='Railcraft:cube:7' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrQuarryStoneBaseVeins' block='Railcraft:cube:7'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFFFFF</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * rlcrQuarryStoneSize * _default_' range=':= 1 * 1 * rlcrQuarryStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * rlcrQuarryStoneSize * _default_' range=':= 1 * 1 * rlcrQuarryStoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * rlcrQuarryStoneFreq * _default_'/>
@@ -468,7 +433,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Quarry Stone Layered Veins) Settings -->
-                    <Veins name='rlcrQuarryStonePrefersVeins' block='Railcraft:cube:7' inherits='rlcrQuarryStoneBaseVeins'>
+                    <Veins name='rlcrQuarryStonePrefersVeins' block='Railcraft:cube:7'  inherits='rlcrQuarryStoneBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -490,64 +455,10 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin PipeVeins distribution of Sulfur -->
                 <IfCondition condition=':= rlcrSulfurDist = "pipeVeins"'>
                 
-                    
-                    <!-- Begin Sulfur Ore Configuration -->
-                    <Veins name='rlcrSulfurBaseVeins' block='Railcraft:ore' inherits='PresetPipeVeins' seed='0x68D1'>
+                    <Veins name='rlcrSulfurBaseVeins' block='Railcraft:ore'  inherits='PresetPipeVeins' seed='0x68D1'>
                         <Description>
-                            Short sparsely filled veins sloping up from near the bottom of the map.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFE25C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * rlcrSulfurSize * _default_' range=':= 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= _default_' type='normal' scaleTo='SeaLevel' />
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * rlcrSulfurSize * _default_' range=':= 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * rlcrSulfurFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Sulfur Ore Configuration -->
-                    
-                    
-                    <!-- Begin Sulfur Pipe Configuration -->
-                    <Veins name= 'rlcrSulfurBasePipe' block='Railcraft:cube:6' inherits='rlcrSulfurBaseVeins' seed='0x68D1'>
-                        <Description>
-                            Fills center of each tube with Pipe material.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFE25C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 1 * rlcrSulfurSize * _default_' range=':= 0.5 * 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 1 * rlcrSulfurSize * _default_' range=':= 0.5 * 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='Railcraft:ore'/>
-                        <Replaces block='minecraft:dirt'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:gravel'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        <Replaces block='minecraft:end_stone'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Sulfur Pipe Configuration -->
-                    
-                
-                </IfCondition>
-                <!-- End PipeVeins distribution of Sulfur -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Sulfur -->
-                <IfCondition condition=':= rlcrSulfurDist = "hugeVeins"'>
-                
-                    <Veins name='rlcrSulfurBaseVeins' block='Railcraft:ore' inherits='PresetHugeVeins'>
-                        <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Short sparsely filled veins sloping up
+                            from near the bottom of the map.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFE25C</WireframeColor>
@@ -556,8 +467,67 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * rlcrSulfurSize * _default_' range=':= 1 * 1 * rlcrSulfurSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * rlcrSulfurFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
+                        <Replaces block='minecraft:stone'/>
+                    </Veins>
+                    
+                    <!-- Begin Pipe Filling (Sulfur Pipe Veins) Settings -->
+                    <Veins name='rlcrSulfurPipeVeins' block='Railcraft:cube:6'  inherits='rlcrSulfurBaseVeins' seed='0x68D1'>
+                        <Description>
+                            Fills the vein with an additional material
+                            (Railcraft:cube:6).
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x60FFE25C</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 1 * rlcrSulfurSize * _default_' range=':= 0.5 * 1 * 1 * rlcrSulfurSize * _default_'/>
+                        <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 1 * rlcrSulfurSize * _default_' range=':= 0.5 * 1 * 1 * rlcrSulfurSize * _default_'/>
+                        <Replaces block='minecraft:stone'/>
+                        <Replaces block='Railcraft:ore'/>
+                        <Replaces block='minecraft:dirt'/>
+                        <Replaces block='minecraft:stone'/>
+                        <Replaces block='minecraft:gravel'/>
+                        <Replaces block='minecraft:netherrack'/>
+                        <Replaces block='minecraft:end_stone'/>
+                    </Veins>
+                    <!-- End Pipe Filling (Sulfur Pipe Veins) Settings -->
+                
+                </IfCondition>
+                <!-- End PipeVeins distribution of Sulfur -->
+                
+                
+                <!-- Begin  Huge Veins distribution of Sulfur -->
+                <IfCondition condition=':= rlcrSulfurDist = "hugeVeins"'>
+                
+                    <Veins name='rlcrSulfurBaseVeins' block='Railcraft:ore'  inherits='PresetHugeVeins' >
+                        <Description>
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x60FFE25C</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * rlcrSulfurSize * _default_' range=':= 1 * 1 * rlcrSulfurSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * rlcrSulfurSize * _default_' range=':= 1 * 1 * rlcrSulfurSize * _default_'/>
+                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
+                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * rlcrSulfurFreq * _default_'/>
+                        <BiomeType name='Mountain'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                 
                 </IfCondition>
@@ -569,12 +539,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 
                     <Cloud name='rlcrSulfurBaseCloud' block='Railcraft:ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFE25C</WireframeColor>
@@ -590,10 +564,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <!-- Begin Sulfur Strategic Cloud Hint Veins -->
                         <Veins name='rlcrSulfurBaseHintVeins' block='Railcraft:ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FFE25C</WireframeColor>
@@ -637,14 +617,15 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin LayeredVeins distribution of Poor Iron -->
                 <IfCondition condition=':= rlcrPoorIronDist = "layeredVeins"'>
                 
-                    <Veins name='rlcrPoorIronBaseVeins' block='Railcraft:ore:7' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrPoorIronBaseVeins' block='Railcraft:ore:7'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrPoorIronSize * _default_' range=':= 3 * 1 * rlcrPoorIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrPoorIronSize * _default_' range=':= 3 * 1 * rlcrPoorIronSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorIronFreq * _default_'/>
@@ -653,7 +634,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Iron Layered Veins) Settings -->
-                    <Veins name='rlcrPoorIronPrefersVeins' block='Railcraft:ore:7' inherits='rlcrPoorIronBaseVeins'>
+                    <Veins name='rlcrPoorIronPrefersVeins' block='Railcraft:ore:7'  inherits='rlcrPoorIronBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -672,16 +653,26 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Poor Iron -->
                 <IfCondition condition=':= rlcrPoorIronDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrPoorIronBaseVeins' block='Railcraft:ore:7' inherits='PresetHugeVeins'>
+                    <Veins name='rlcrPoorIronBaseVeins' block='Railcraft:ore:7'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -695,7 +686,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Iron Huge Veins) Settings -->
-                    <Veins name='rlcrPoorIronPrefersVeins' block='Railcraft:ore:7' inherits='rlcrPoorIronBaseVeins'>
+                    <Veins name='rlcrPoorIronPrefersVeins' block='Railcraft:ore:7'  inherits='rlcrPoorIronBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -716,12 +707,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 
                     <Cloud name='rlcrPoorIronBaseCloud' block='Railcraft:ore:7' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -736,10 +731,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <!-- Begin Poor Iron Strategic Cloud Hint Veins -->
                         <Veins name='rlcrPoorIronBaseHintVeins' block='Railcraft:ore:7' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -783,14 +784,15 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin LayeredVeins distribution of Poor Gold -->
                 <IfCondition condition=':= rlcrPoorGoldDist = "layeredVeins"'>
                 
-                    <Veins name='rlcrPoorGoldBaseVeins' block='Railcraft:ore:8' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrPoorGoldBaseVeins' block='Railcraft:ore:8'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 3 * 0.8 * rlcrPoorGoldSize * _default_' range=':= 3 * 0.8 * rlcrPoorGoldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 3 * 0.8 * rlcrPoorGoldSize * _default_' range=':= 3 * 0.8 * rlcrPoorGoldSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * rlcrPoorGoldFreq * _default_'/>
@@ -801,7 +803,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Gold Layered Veins) Settings -->
-                    <Veins name='rlcrPoorGoldPrefersVeins' block='Railcraft:ore:8' inherits='rlcrPoorGoldBaseVeins'>
+                    <Veins name='rlcrPoorGoldPrefersVeins' block='Railcraft:ore:8'  inherits='rlcrPoorGoldBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -819,16 +821,26 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Poor Gold -->
                 <IfCondition condition=':= rlcrPoorGoldDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrPoorGoldBaseVeins' block='Railcraft:ore:8' inherits='PresetHugeVeins'>
+                    <Veins name='rlcrPoorGoldBaseVeins' block='Railcraft:ore:8'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
@@ -844,7 +856,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Gold Huge Veins) Settings -->
-                    <Veins name='rlcrPoorGoldPrefersVeins' block='Railcraft:ore:8' inherits='rlcrPoorGoldBaseVeins'>
+                    <Veins name='rlcrPoorGoldPrefersVeins' block='Railcraft:ore:8'  inherits='rlcrPoorGoldBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -864,12 +876,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 
                     <Cloud name='rlcrPoorGoldBaseCloud' block='Railcraft:ore:8' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
@@ -884,10 +900,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <!-- Begin Poor Gold Strategic Cloud Hint Veins -->
                         <Veins name='rlcrPoorGoldBaseHintVeins' block='Railcraft:ore:8' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60EAEF57</WireframeColor>
@@ -931,14 +953,15 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin LayeredVeins distribution of Poor Copper -->
                 <IfCondition condition=':= rlcrPoorCopperDist = "layeredVeins"'>
                 
-                    <Veins name='rlcrPoorCopperBaseVeins' block='Railcraft:ore:9' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrPoorCopperBaseVeins' block='Railcraft:ore:9'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrPoorCopperSize * _default_' range=':= 3 * 1 * rlcrPoorCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrPoorCopperSize * _default_' range=':= 3 * 1 * rlcrPoorCopperSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorCopperFreq * _default_'/>
@@ -947,7 +970,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Copper Layered Veins) Settings -->
-                    <Veins name='rlcrPoorCopperPrefersVeins' block='Railcraft:ore:9' inherits='rlcrPoorCopperBaseVeins'>
+                    <Veins name='rlcrPoorCopperPrefersVeins' block='Railcraft:ore:9'  inherits='rlcrPoorCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -966,16 +989,26 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Poor Copper -->
                 <IfCondition condition=':= rlcrPoorCopperDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrPoorCopperBaseVeins' block='Railcraft:ore:9' inherits='PresetHugeVeins'>
+                    <Veins name='rlcrPoorCopperBaseVeins' block='Railcraft:ore:9'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -989,7 +1022,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Copper Huge Veins) Settings -->
-                    <Veins name='rlcrPoorCopperPrefersVeins' block='Railcraft:ore:9' inherits='rlcrPoorCopperBaseVeins'>
+                    <Veins name='rlcrPoorCopperPrefersVeins' block='Railcraft:ore:9'  inherits='rlcrPoorCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1010,12 +1043,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 
                     <Cloud name='rlcrPoorCopperBaseCloud' block='Railcraft:ore:9' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -1030,10 +1067,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <!-- Begin Poor Copper Strategic Cloud Hint Veins -->
                         <Veins name='rlcrPoorCopperBaseHintVeins' block='Railcraft:ore:9' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -1077,14 +1120,15 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin LayeredVeins distribution of Poor Tin -->
                 <IfCondition condition=':= rlcrPoorTinDist = "layeredVeins"'>
                 
-                    <Veins name='rlcrPoorTinBaseVeins' block='Railcraft:ore:10' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrPoorTinBaseVeins' block='Railcraft:ore:10'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrPoorTinSize * _default_' range=':= 3 * 1 * rlcrPoorTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrPoorTinSize * _default_' range=':= 3 * 1 * rlcrPoorTinSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorTinFreq * _default_'/>
@@ -1093,7 +1137,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Tin Layered Veins) Settings -->
-                    <Veins name='rlcrPoorTinPrefersVeins' block='Railcraft:ore:10' inherits='rlcrPoorTinBaseVeins'>
+                    <Veins name='rlcrPoorTinPrefersVeins' block='Railcraft:ore:10'  inherits='rlcrPoorTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1112,16 +1156,26 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Poor Tin -->
                 <IfCondition condition=':= rlcrPoorTinDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrPoorTinBaseVeins' block='Railcraft:ore:10' inherits='PresetHugeVeins'>
+                    <Veins name='rlcrPoorTinBaseVeins' block='Railcraft:ore:10'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -1135,7 +1189,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Tin Huge Veins) Settings -->
-                    <Veins name='rlcrPoorTinPrefersVeins' block='Railcraft:ore:10' inherits='rlcrPoorTinBaseVeins'>
+                    <Veins name='rlcrPoorTinPrefersVeins' block='Railcraft:ore:10'  inherits='rlcrPoorTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1156,12 +1210,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 
                     <Cloud name='rlcrPoorTinBaseCloud' block='Railcraft:ore:10' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -1176,10 +1234,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <!-- Begin Poor Tin Strategic Cloud Hint Veins -->
                         <Veins name='rlcrPoorTinBaseHintVeins' block='Railcraft:ore:10' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -1223,14 +1287,15 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin LayeredVeins distribution of Poor Lead -->
                 <IfCondition condition=':= rlcrPoorLeadDist = "layeredVeins"'>
                 
-                    <Veins name='rlcrPoorLeadBaseVeins' block='Railcraft:ore:11' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrPoorLeadBaseVeins' block='Railcraft:ore:11'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60818EBE</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrPoorLeadSize * _default_' range=':= 3 * 1 * rlcrPoorLeadSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrPoorLeadSize * _default_' range=':= 3 * 1 * rlcrPoorLeadSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorLeadFreq * _default_'/>
@@ -1239,7 +1304,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Lead Layered Veins) Settings -->
-                    <Veins name='rlcrPoorLeadPrefersVeins' block='Railcraft:ore:11' inherits='rlcrPoorLeadBaseVeins'>
+                    <Veins name='rlcrPoorLeadPrefersVeins' block='Railcraft:ore:11'  inherits='rlcrPoorLeadBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1258,16 +1323,26 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Poor Lead -->
                 <IfCondition condition=':= rlcrPoorLeadDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrPoorLeadBaseVeins' block='Railcraft:ore:11' inherits='PresetHugeVeins'>
+                    <Veins name='rlcrPoorLeadBaseVeins' block='Railcraft:ore:11'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60818EBE</WireframeColor>
@@ -1281,7 +1356,7 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Poor Lead Huge Veins) Settings -->
-                    <Veins name='rlcrPoorLeadPrefersVeins' block='Railcraft:ore:11' inherits='rlcrPoorLeadBaseVeins'>
+                    <Veins name='rlcrPoorLeadPrefersVeins' block='Railcraft:ore:11'  inherits='rlcrPoorLeadBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1302,12 +1377,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 
                     <Cloud name='rlcrPoorLeadBaseCloud' block='Railcraft:ore:11' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60818EBE</WireframeColor>
@@ -1322,10 +1401,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <!-- Begin Poor Lead Strategic Cloud Hint Veins -->
                         <Veins name='rlcrPoorLeadBaseHintVeins' block='Railcraft:ore:11' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60818EBE</WireframeColor>
@@ -1369,43 +1454,10 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin LayeredVeins distribution of Saltpeter -->
                 <IfCondition condition=':= rlcrSaltpeterDist = "layeredVeins"'>
                 
-                    <Veins name='rlcrSaltpeterBaseVeins' block='Railcraft:ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrSaltpeterBaseVeins' block='Railcraft:ore:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CED0BA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 2.3 * rlcrSaltpeterSize * _default_' range=':= 1 * 2.3 * rlcrSaltpeterSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 5' type='normal' scaleTo='SeaLevel'/> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 2.3 * rlcrSaltpeterSize * _default_' range=':= 1 * 2.3 * rlcrSaltpeterSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.04 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.03 * rlcrSaltpeterFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.03 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 180/_default_ * _default_' range=':= 90/_default_ * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 1000'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.75'/>
-                        <Replaces block='minecraft:sandstone'/>
-                        <Replaces block='minecraft:sand'/>
-                        <BiomeType name='Desert'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Saltpeter -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Saltpeter -->
-                <IfCondition condition=':= rlcrSaltpeterDist = "hugeVeins"'>
-                
-                    <Veins name='rlcrSaltpeterBaseVeins' block='Railcraft:ore:1' inherits='PresetHugeVeins'>
-                        <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60CED0BA</WireframeColor>
@@ -1418,9 +1470,53 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <Setting name='BranchLength' avg=':= 180/_default_ * _default_' range=':= 90/_default_ * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 1000'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.75'/>
+                        <BiomeType name='Desert'/>
                         <Replaces block='minecraft:sandstone'/>
                         <Replaces block='minecraft:sand'/>
+                    </Veins>
+                
+                </IfCondition>
+                <!-- End LayeredVeins distribution of Saltpeter -->
+                
+                
+                <!-- Begin  Huge Veins distribution of Saltpeter -->
+                <IfCondition condition=':= rlcrSaltpeterDist = "hugeVeins"'>
+                
+                    <Veins name='rlcrSaltpeterBaseVeins' block='Railcraft:ore:1'  inherits='PresetHugeVeins' >
+                        <Description>
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x60CED0BA</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 1 * 2.3 * rlcrSaltpeterSize * _default_' range=':= 1 * 2.3 * rlcrSaltpeterSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 5' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 2.3 * rlcrSaltpeterSize * _default_' range=':= 1 * 2.3 * rlcrSaltpeterSize * _default_'/>
+                        <Setting name='OreDensity' avg=':= 1 * 0.04 * _default_' range=':= _default_'/>
+                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.03 * rlcrSaltpeterFreq * _default_'/>
+                        <Setting name='BranchFrequency' avg=':= 0.03 * _default_'/>
+                        <Setting name='BranchLength' avg=':= 180/_default_ * _default_' range=':= 90/_default_ * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 1000'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.75'/>
                         <BiomeType name='Desert'/>
+                        <Replaces block='minecraft:sandstone'/>
+                        <Replaces block='minecraft:sand'/>
                     </Veins>
                 
                 </IfCondition>
@@ -1450,22 +1546,6 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- End Saltpeter Generation --> 
 
                 
-                <!-- Begin Remove Abyssal Stone Generation --> 
-                
-                <!-- Begin Substitute distribution of Remove Abyssal Stone -->
-                <IfCondition condition=':= rlcrRemoveAbyssalStoneDist = "substituteGen"'>
-                
-                    <Substitute name='rlcrRemoveAbyssalStoneBaseSubstitute' block='minecraft:stone'>
-                        <Description> This is a straight-up replacement of one block with another. </Description>
-                        <Replaces block='Railcraft:cube:6'/>
-                    </Substitute>
-                
-                </IfCondition>
-                <!-- End Substitute distribution of Remove Abyssal Stone -->
-                
-                <!-- End Remove Abyssal Stone Generation --> 
-
-                
                 <!-- Begin Abyssal Ores Generation --> 
                 
                 <!-- Begin Geodes distribution of Abyssal Ores -->
@@ -1475,7 +1555,8 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     <!-- Begin Abyssal Ores Geode Crust -->
                     <Veins name='rlcrAbyssalOresBaseShell' block='Railcraft:cube:6' inherits='PresetSmallDeposits' seed='0x9668'>
                         <Description>
-                            The geode's outer shell, composed of the Pipe material.
+                            The geode's outer shell, composed of the
+                            Pipe material.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60000000</WireframeColor>
@@ -1494,7 +1575,8 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     <!-- Begin Abyssal Ores Geode Crystals -->
                     <Veins name='rlcrAbyssalOresBaseCrystal' block='Railcraft:ore:2' inherits='PresetSmallDeposits' seed='0x9668'>
                         <Description>
-                            The geode's inner material, usually some form of crystal.
+                            The geode's inner material, usually some
+                            form of crystal.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60000000</WireframeColor>
@@ -1511,7 +1593,8 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     <!-- Begin Abyssal Ores Geode Crystals (Railcraft:ore:3) -->
                     <Veins name='rlcrAbyssalOresBase1Crystal' block='Railcraft:ore:3' inherits='PresetSmallDeposits' seed='0x9668'>
                         <Description>
-                            The geode's inner material, usually some form of crystal.
+                            The geode's inner material, usually some
+                            form of crystal.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60000000</WireframeColor>
@@ -1528,7 +1611,8 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     <!-- Begin Abyssal Ores Geode Crystals (Railcraft:ore:4) -->
                     <Veins name='rlcrAbyssalOresBase2Crystal' block='Railcraft:ore:4' inherits='PresetSmallDeposits' seed='0x9668'>
                         <Description>
-                            The geode's inner material, usually some form of crystal.
+                            The geode's inner material, usually some
+                            form of crystal.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60000000</WireframeColor>
@@ -1545,7 +1629,8 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                     <!-- Begin Abyssal Ores Geode Air Pocket -->
                     <Veins name='rlcrAbyssalOresBaseAirBubble' block='minecraft:air' inherits='PresetSmallDeposits' seed='0x9668'>
                         <Description>
-                            The air pocket within the center of a geode.
+                            The air pocket within the center of a
+                            geode.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60000000</WireframeColor>
@@ -1592,14 +1677,15 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin LayeredVeins distribution of Firestone -->
                 <IfCondition condition=':= rlcrFirestoneDist = "layeredVeins"'>
                 
-                    <Veins name='rlcrFirestoneBaseVeins' block='Railcraft:ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='rlcrFirestoneBaseVeins' block='Railcraft:ore:5'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C64E0D</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * rlcrFirestoneSize * _default_' range=':= 0.5 * 1 * rlcrFirestoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 31' range=':= 2' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 31' range=':= 2' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 0.5 * 1 * rlcrFirestoneSize * _default_' range=':= 0.5 * 1 * rlcrFirestoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 0.5 * 1 * rlcrFirestoneFreq * _default_'/>
@@ -1613,16 +1699,26 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 <!-- Begin  Huge Veins distribution of Firestone -->
                 <IfCondition condition=':= rlcrFirestoneDist = "hugeVeins"'>
                 
-                    <Veins name='rlcrFirestoneBaseVeins' block='Railcraft:ore:5' inherits='PresetHugeVeins'>
+                    <Veins name='rlcrFirestoneBaseVeins' block='Railcraft:ore:5'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C64E0D</WireframeColor>
@@ -1643,12 +1739,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                 
                     <Cloud name='rlcrFirestoneBaseCloud' block='Railcraft:ore:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60C64E0D</WireframeColor>
@@ -1663,10 +1763,16 @@ Poor Lead, Saltpeter, Remove Abyssal Stone, Abyssal Ores, Firestone
                         <!-- Begin Firestone Strategic Cloud Hint Veins -->
                         <Veins name='rlcrFirestoneBaseHintVeins' block='Railcraft:ore:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60C64E0D</WireframeColor>

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -1,15 +1,11 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   ReactorCraft Module
-
-Generates: 
-Pitchblende, Cadmium, Indium, Silver, End Pitchblende, Ammonium
-Chloride, Calcite, Magnetite, Thorite, Blue Fluorite, Pink Fluorite,
-Orange Fluorite, Magenta Fluorite, Green Fluorite, Red Fluorite, White
-Fluorite, Yellow Fluorite
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "ReactorCraft" Module: This configuration
+      covers pitchblende, cadmium, indium, silver, end pitchblende,
+      ammonium  chloride, calcite, magnetite, thorite, blue fluorite,
+      pink fluorite,  orange fluorite, magenta fluorite, green
+      fluorite, red fluorite, white  fluorite, and yellow fluorite.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="ReactorCraft">
@@ -589,14 +585,14 @@ Fluorite, Yellow Fluorite
                     <Replaces block='ReactorCraft:reactorcraft_block_ore:4' />
                     <Replaces block='ReactorCraft:reactorcraft_block_ore:7' />
                     <Replaces block='ReactorCraft:reactorcraft_block_ore:8' />
-                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:0' />
-                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:0' />
-                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:0' />
-                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:0' />
-                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:0' />
-                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:0' />
-                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:0' />
-                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:0' />
+                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore' />
+                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore' />
+                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore' />
+                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore' />
+                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore' />
+                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore' />
+                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore' />
+                    <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore' />
                 </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
                 
@@ -607,14 +603,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin LayeredVeins distribution of Pitchblende -->
                 <IfCondition condition=':= recrPitchblendeDist = "layeredVeins"'>
                 
-                    <Veins name='recrPitchblendeBaseVeins' block='ReactorCraft:reactorcraft_block_ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='recrPitchblendeBaseVeins' block='ReactorCraft:reactorcraft_block_ore:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60454454</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * recrPitchblendeSize * _default_' range=':= 1 * 0.8 * recrPitchblendeSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 16' range=':= 8' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 16' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * recrPitchblendeSize * _default_' range=':= 1 * 0.8 * recrPitchblendeSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.55 * recrPitchblendeFreq * _default_'/>
@@ -625,7 +622,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Pitchblende Layered Veins) Settings -->
-                    <Veins name='recrPitchblendePrefersVeins' block='ReactorCraft:reactorcraft_block_ore:1' inherits='recrPitchblendeBaseVeins'>
+                    <Veins name='recrPitchblendePrefersVeins' block='ReactorCraft:reactorcraft_block_ore:1'  inherits='recrPitchblendeBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -643,16 +640,26 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Pitchblende -->
                 <IfCondition condition=':= recrPitchblendeDist = "hugeVeins"'>
                 
-                    <Veins name='recrPitchblendeBaseVeins' block='ReactorCraft:reactorcraft_block_ore:1' inherits='PresetHugeVeins'>
+                    <Veins name='recrPitchblendeBaseVeins' block='ReactorCraft:reactorcraft_block_ore:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60454454</WireframeColor>
@@ -668,7 +675,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Pitchblende Huge Veins) Settings -->
-                    <Veins name='recrPitchblendePrefersVeins' block='ReactorCraft:reactorcraft_block_ore:1' inherits='recrPitchblendeBaseVeins'>
+                    <Veins name='recrPitchblendePrefersVeins' block='ReactorCraft:reactorcraft_block_ore:1'  inherits='recrPitchblendeBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -688,12 +695,16 @@ Fluorite, Yellow Fluorite
                 
                     <Cloud name='recrPitchblendeBaseCloud' block='ReactorCraft:reactorcraft_block_ore:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60454454</WireframeColor>
@@ -708,10 +719,16 @@ Fluorite, Yellow Fluorite
                         <!-- Begin Pitchblende Strategic Cloud Hint Veins -->
                         <Veins name='recrPitchblendeBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60454454</WireframeColor>
@@ -755,14 +772,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin LayeredVeins distribution of Cadmium -->
                 <IfCondition condition=':= recrCadmiumDist = "layeredVeins"'>
                 
-                    <Veins name='recrCadmiumBaseVeins' block='ReactorCraft:reactorcraft_block_ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='recrCadmiumBaseVeins' block='ReactorCraft:reactorcraft_block_ore:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607184A4</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * recrCadmiumSize * _default_' range=':= 1 * 0.8 * recrCadmiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 22' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 22' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * recrCadmiumSize * _default_' range=':= 1 * 0.8 * recrCadmiumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * recrCadmiumFreq * _default_'/>
@@ -773,7 +791,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Cadmium Layered Veins) Settings -->
-                    <Veins name='recrCadmiumPrefersVeins' block='ReactorCraft:reactorcraft_block_ore:2' inherits='recrCadmiumBaseVeins'>
+                    <Veins name='recrCadmiumPrefersVeins' block='ReactorCraft:reactorcraft_block_ore:2'  inherits='recrCadmiumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -791,16 +809,26 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Cadmium -->
                 <IfCondition condition=':= recrCadmiumDist = "hugeVeins"'>
                 
-                    <Veins name='recrCadmiumBaseVeins' block='ReactorCraft:reactorcraft_block_ore:2' inherits='PresetHugeVeins'>
+                    <Veins name='recrCadmiumBaseVeins' block='ReactorCraft:reactorcraft_block_ore:2'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607184A4</WireframeColor>
@@ -816,7 +844,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Cadmium Huge Veins) Settings -->
-                    <Veins name='recrCadmiumPrefersVeins' block='ReactorCraft:reactorcraft_block_ore:2' inherits='recrCadmiumBaseVeins'>
+                    <Veins name='recrCadmiumPrefersVeins' block='ReactorCraft:reactorcraft_block_ore:2'  inherits='recrCadmiumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -836,12 +864,16 @@ Fluorite, Yellow Fluorite
                 
                     <Cloud name='recrCadmiumBaseCloud' block='ReactorCraft:reactorcraft_block_ore:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607184A4</WireframeColor>
@@ -856,10 +888,16 @@ Fluorite, Yellow Fluorite
                         <!-- Begin Cadmium Strategic Cloud Hint Veins -->
                         <Veins name='recrCadmiumBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x607184A4</WireframeColor>
@@ -903,14 +941,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin LayeredVeins distribution of Indium -->
                 <IfCondition condition=':= recrIndiumDist = "layeredVeins"'>
                 
-                    <Veins name='recrIndiumBaseVeins' block='ReactorCraft:reactorcraft_block_ore:3' inherits='PresetLayeredVeins'>
+                    <Veins name='recrIndiumBaseVeins' block='ReactorCraft:reactorcraft_block_ore:3'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607A7C89</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * recrIndiumSize * _default_' range=':= 1 * 0.8 * recrIndiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 8' range=':= 8' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 8' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * recrIndiumSize * _default_' range=':= 1 * 0.8 * recrIndiumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.5 * recrIndiumFreq * _default_'/>
@@ -927,16 +966,26 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Indium -->
                 <IfCondition condition=':= recrIndiumDist = "hugeVeins"'>
                 
-                    <Veins name='recrIndiumBaseVeins' block='ReactorCraft:reactorcraft_block_ore:3' inherits='PresetHugeVeins'>
+                    <Veins name='recrIndiumBaseVeins' block='ReactorCraft:reactorcraft_block_ore:3'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607A7C89</WireframeColor>
@@ -960,12 +1009,16 @@ Fluorite, Yellow Fluorite
                 
                     <Cloud name='recrIndiumBaseCloud' block='ReactorCraft:reactorcraft_block_ore:3' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607A7C89</WireframeColor>
@@ -980,10 +1033,16 @@ Fluorite, Yellow Fluorite
                         <!-- Begin Indium Strategic Cloud Hint Veins -->
                         <Veins name='recrIndiumBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:3' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x607A7C89</WireframeColor>
@@ -1025,14 +1084,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin LayeredVeins distribution of Silver -->
                 <IfCondition condition=':= recrSilverDist = "layeredVeins"'>
                 
-                    <Veins name='recrSilverBaseVeins' block='ReactorCraft:reactorcraft_block_ore:4' inherits='PresetLayeredVeins'>
+                    <Veins name='recrSilverBaseVeins' block='ReactorCraft:reactorcraft_block_ore:4'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3F2F7</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * recrSilverSize * _default_' range=':= 1 * 0.85 * recrSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.85 * recrSilverSize * _default_' range=':= 1 * 0.85 * recrSilverSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * recrSilverFreq * _default_'/>
@@ -1049,16 +1109,26 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Silver -->
                 <IfCondition condition=':= recrSilverDist = "hugeVeins"'>
                 
-                    <Veins name='recrSilverBaseVeins' block='ReactorCraft:reactorcraft_block_ore:4' inherits='PresetHugeVeins'>
+                    <Veins name='recrSilverBaseVeins' block='ReactorCraft:reactorcraft_block_ore:4'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3F2F7</WireframeColor>
@@ -1082,12 +1152,16 @@ Fluorite, Yellow Fluorite
                 
                     <Cloud name='recrSilverBaseCloud' block='ReactorCraft:reactorcraft_block_ore:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3F2F7</WireframeColor>
@@ -1102,10 +1176,16 @@ Fluorite, Yellow Fluorite
                         <!-- Begin Silver Strategic Cloud Hint Veins -->
                         <Veins name='recrSilverBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E3F2F7</WireframeColor>
@@ -1147,17 +1227,21 @@ Fluorite, Yellow Fluorite
                 <!-- Begin Sparse Veins distribution of Calcite -->
                 <IfCondition condition=':= recrCalciteDist = "sparseVeins"'>
                 
-                    <Veins name='recrCalciteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:7' inherits='PresetSparseVeins'>
+                    <Veins name='recrCalciteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:7'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FEA219</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * recrCalciteSize * _default_' range=':= 1 * 1 * recrCalciteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * recrCalciteSize * _default_' range=':= 1 * 1 * recrCalciteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * recrCalciteFreq * _default_'/>
@@ -1168,7 +1252,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Calcite Sparse Veins) Settings -->
-                    <Veins name='recrCalcitePrefersVeins' block='ReactorCraft:reactorcraft_block_ore:7' inherits='recrCalciteBaseVeins'>
+                    <Veins name='recrCalcitePrefersVeins' block='ReactorCraft:reactorcraft_block_ore:7'  inherits='recrCalciteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1187,16 +1271,26 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Calcite -->
                 <IfCondition condition=':= recrCalciteDist = "hugeVeins"'>
                 
-                    <Veins name='recrCalciteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:7' inherits='PresetHugeVeins'>
+                    <Veins name='recrCalciteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:7'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FEA219</WireframeColor>
@@ -1212,7 +1306,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Calcite Huge Veins) Settings -->
-                    <Veins name='recrCalcitePrefersVeins' block='ReactorCraft:reactorcraft_block_ore:7' inherits='recrCalciteBaseVeins'>
+                    <Veins name='recrCalcitePrefersVeins' block='ReactorCraft:reactorcraft_block_ore:7'  inherits='recrCalciteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1233,12 +1327,16 @@ Fluorite, Yellow Fluorite
                 
                     <Cloud name='recrCalciteBaseCloud' block='ReactorCraft:reactorcraft_block_ore:7' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FEA219</WireframeColor>
@@ -1253,10 +1351,16 @@ Fluorite, Yellow Fluorite
                         <!-- Begin Calcite Strategic Cloud Hint Veins -->
                         <Veins name='recrCalciteBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:7' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FEA219</WireframeColor>
@@ -1300,14 +1404,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin LayeredVeins distribution of Magnetite -->
                 <IfCondition condition=':= recrMagnetiteDist = "layeredVeins"'>
                 
-                    <Veins name='recrMagnetiteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:8' inherits='PresetLayeredVeins'>
+                    <Veins name='recrMagnetiteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:8'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60212121</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * recrMagnetiteSize * _default_' range=':= 1 * 1 * recrMagnetiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 94' range=':= 34' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 94' range=':= 34' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * recrMagnetiteSize * _default_' range=':= 1 * 1 * recrMagnetiteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 2 * recrMagnetiteFreq * _default_'/>
@@ -1322,16 +1427,26 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Magnetite -->
                 <IfCondition condition=':= recrMagnetiteDist = "hugeVeins"'>
                 
-                    <Veins name='recrMagnetiteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:8' inherits='PresetHugeVeins'>
+                    <Veins name='recrMagnetiteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:8'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60212121</WireframeColor>
@@ -1353,12 +1468,16 @@ Fluorite, Yellow Fluorite
                 
                     <Cloud name='recrMagnetiteBaseCloud' block='ReactorCraft:reactorcraft_block_ore:8' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60212121</WireframeColor>
@@ -1373,10 +1492,16 @@ Fluorite, Yellow Fluorite
                         <!-- Begin Magnetite Strategic Cloud Hint Veins -->
                         <Veins name='recrMagnetiteBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:8' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60212121</WireframeColor>
@@ -1418,14 +1543,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin Layered Veins distribution of Blue Fluorite -->
                 <IfCondition condition=':= recrBlueFluoriteDist = "layeredVeins"'>
                 
-                    <Veins name='recrBlueFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='PresetLayeredVeins'>
+                    <Veins name='recrBlueFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60283270</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * recrBlueFluoriteSize * _default_' range=':= 1 * 1 * recrBlueFluoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * recrBlueFluoriteSize * _default_' range=':= 1 * 1 * recrBlueFluoriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1/8 * 1 * recrBlueFluoriteFreq * _default_'/>
@@ -1433,7 +1559,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Blue Fluorite Layered Veins) Settings -->
-                    <Veins name='recrBlueFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='recrBlueFluoriteBaseVeins'>
+                    <Veins name='recrBlueFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='recrBlueFluoriteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1455,14 +1581,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin Layered Veins distribution of Pink Fluorite -->
                 <IfCondition condition=':= recrPinkFluoriteDist = "layeredVeins"'>
                 
-                    <Veins name='recrPinkFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='PresetLayeredVeins'>
+                    <Veins name='recrPinkFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607A5970</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * recrPinkFluoriteSize * _default_' range=':= 1 * 1 * recrPinkFluoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * recrPinkFluoriteSize * _default_' range=':= 1 * 1 * recrPinkFluoriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1/8 * 1 * recrPinkFluoriteFreq * _default_'/>
@@ -1470,7 +1597,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Pink Fluorite Layered Veins) Settings -->
-                    <Veins name='recrPinkFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='recrPinkFluoriteBaseVeins'>
+                    <Veins name='recrPinkFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='recrPinkFluoriteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1492,14 +1619,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin Layered Veins distribution of Orange Fluorite -->
                 <IfCondition condition=':= recrOrangeFluoriteDist = "layeredVeins"'>
                 
-                    <Veins name='recrOrangeFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='PresetLayeredVeins'>
+                    <Veins name='recrOrangeFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x607A5927</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * recrOrangeFluoriteSize * _default_' range=':= 1 * 1 * recrOrangeFluoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * recrOrangeFluoriteSize * _default_' range=':= 1 * 1 * recrOrangeFluoriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1/8 * 1 * recrOrangeFluoriteFreq * _default_'/>
@@ -1507,7 +1635,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Orange Fluorite Layered Veins) Settings -->
-                    <Veins name='recrOrangeFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='recrOrangeFluoriteBaseVeins'>
+                    <Veins name='recrOrangeFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='recrOrangeFluoriteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1529,14 +1657,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin Layered Veins distribution of Magenta Fluorite -->
                 <IfCondition condition=':= recrMagentaFluoriteDist = "layeredVeins"'>
                 
-                    <Veins name='recrMagentaFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='PresetLayeredVeins'>
+                    <Veins name='recrMagentaFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60602774</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * recrMagentaFluoriteSize * _default_' range=':= 1 * 1 * recrMagentaFluoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * recrMagentaFluoriteSize * _default_' range=':= 1 * 1 * recrMagentaFluoriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * recrMagentaFluoriteFreq * _default_'/>
@@ -1544,7 +1673,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Magenta Fluorite Layered Veins) Settings -->
-                    <Veins name='recrMagentaFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='recrMagentaFluoriteBaseVeins'>
+                    <Veins name='recrMagentaFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='recrMagentaFluoriteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1566,14 +1695,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin Layered Veins distribution of Green Fluorite -->
                 <IfCondition condition=':= recrGreenFluoriteDist = "layeredVeins"'>
                 
-                    <Veins name='recrGreenFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='PresetLayeredVeins'>
+                    <Veins name='recrGreenFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60347D3B</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * recrGreenFluoriteSize * _default_' range=':= 1 * 1 * recrGreenFluoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * recrGreenFluoriteSize * _default_' range=':= 1 * 1 * recrGreenFluoriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1/8 * 1 * recrGreenFluoriteFreq * _default_'/>
@@ -1581,7 +1711,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Green Fluorite Layered Veins) Settings -->
-                    <Veins name='recrGreenFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='recrGreenFluoriteBaseVeins'>
+                    <Veins name='recrGreenFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='recrGreenFluoriteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1603,14 +1733,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin Layered Veins distribution of Red Fluorite -->
                 <IfCondition condition=':= recrRedFluoriteDist = "layeredVeins"'>
                 
-                    <Veins name='recrRedFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='PresetLayeredVeins'>
+                    <Veins name='recrRedFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60974747</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * recrRedFluoriteSize * _default_' range=':= 1 * 1 * recrRedFluoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * recrRedFluoriteSize * _default_' range=':= 1 * 1 * recrRedFluoriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1/8 * 1 * recrRedFluoriteFreq * _default_'/>
@@ -1618,7 +1749,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Red Fluorite Layered Veins) Settings -->
-                    <Veins name='recrRedFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='recrRedFluoriteBaseVeins'>
+                    <Veins name='recrRedFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='recrRedFluoriteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1640,14 +1771,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin Layered Veins distribution of White Fluorite -->
                 <IfCondition condition=':= recrWhiteFluoriteDist = "layeredVeins"'>
                 
-                    <Veins name='recrWhiteFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='PresetLayeredVeins'>
+                    <Veins name='recrWhiteFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60969696</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * recrWhiteFluoriteSize * _default_' range=':= 1 * 1 * recrWhiteFluoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * recrWhiteFluoriteSize * _default_' range=':= 1 * 1 * recrWhiteFluoriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1/8 * 1 * recrWhiteFluoriteFreq * _default_'/>
@@ -1655,7 +1787,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (White Fluorite Layered Veins) Settings -->
-                    <Veins name='recrWhiteFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='recrWhiteFluoriteBaseVeins'>
+                    <Veins name='recrWhiteFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='recrWhiteFluoriteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1677,14 +1809,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin Layered Veins distribution of Yellow Fluorite -->
                 <IfCondition condition=':= recrYellowFluoriteDist = "layeredVeins"'>
                 
-                    <Veins name='recrYellowFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='PresetLayeredVeins'>
+                    <Veins name='recrYellowFluoriteBaseVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60978834</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * recrYellowFluoriteSize * _default_' range=':= 1 * 1 * recrYellowFluoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 46' range=':= 14' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * recrYellowFluoriteSize * _default_' range=':= 1 * 1 * recrYellowFluoriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1/8 * 1 * recrYellowFluoriteFreq * _default_'/>
@@ -1692,7 +1825,7 @@ Fluorite, Yellow Fluorite
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Yellow Fluorite Layered Veins) Settings -->
-                    <Veins name='recrYellowFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore' inherits='recrYellowFluoriteBaseVeins'>
+                    <Veins name='recrYellowFluoritePrefersVeins' block='ReactorCraft:reactorcraft_block_fluoriteore'  inherits='recrYellowFluoriteBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1736,14 +1869,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin LayeredVeins distribution of Ammonium Chloride -->
                 <IfCondition condition=':= recrAmmoniumChlorideDist = "layeredVeins"'>
                 
-                    <Veins name='recrAmmoniumChlorideBaseVeins' block='ReactorCraft:reactorcraft_block_ore:6' inherits='PresetLayeredVeins'>
+                    <Veins name='recrAmmoniumChlorideBaseVeins' block='ReactorCraft:reactorcraft_block_ore:6'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFFFFF</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * recrAmmoniumChlorideSize * _default_' range=':= 1 * 0.8 * recrAmmoniumChlorideSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 2' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 2' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * recrAmmoniumChlorideSize * _default_' range=':= 1 * 0.8 * recrAmmoniumChlorideSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * recrAmmoniumChlorideFreq * _default_'/>
@@ -1760,16 +1894,26 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Ammonium Chloride -->
                 <IfCondition condition=':= recrAmmoniumChlorideDist = "hugeVeins"'>
                 
-                    <Veins name='recrAmmoniumChlorideBaseVeins' block='ReactorCraft:reactorcraft_block_ore:6' inherits='PresetHugeVeins'>
+                    <Veins name='recrAmmoniumChlorideBaseVeins' block='ReactorCraft:reactorcraft_block_ore:6'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFFFFF</WireframeColor>
@@ -1793,12 +1937,16 @@ Fluorite, Yellow Fluorite
                 
                     <Cloud name='recrAmmoniumChlorideBaseCloud' block='ReactorCraft:reactorcraft_block_ore:6' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FFFFFF</WireframeColor>
@@ -1813,10 +1961,16 @@ Fluorite, Yellow Fluorite
                         <!-- Begin Ammonium Chloride Strategic Cloud Hint Veins -->
                         <Veins name='recrAmmoniumChlorideBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:6' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FFFFFF</WireframeColor>
@@ -1858,14 +2012,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin LayeredVeins distribution of Thorite -->
                 <IfCondition condition=':= recrThoriteDist = "layeredVeins"'>
                 
-                    <Veins name='recrThoriteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:9' inherits='PresetLayeredVeins'>
+                    <Veins name='recrThoriteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:9'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6054A228</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 3 * recrThoriteSize * _default_' range=':= 1 * 3 * recrThoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 15' range=':= 15' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 15' range=':= 15' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 3 * recrThoriteSize * _default_' range=':= 1 * 3 * recrThoriteSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * recrThoriteFreq * _default_'/>
@@ -1882,16 +2037,26 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of Thorite -->
                 <IfCondition condition=':= recrThoriteDist = "hugeVeins"'>
                 
-                    <Veins name='recrThoriteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:9' inherits='PresetHugeVeins'>
+                    <Veins name='recrThoriteBaseVeins' block='ReactorCraft:reactorcraft_block_ore:9'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6054A228</WireframeColor>
@@ -1915,12 +2080,16 @@ Fluorite, Yellow Fluorite
                 
                     <Cloud name='recrThoriteBaseCloud' block='ReactorCraft:reactorcraft_block_ore:9' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6054A228</WireframeColor>
@@ -1935,10 +2104,16 @@ Fluorite, Yellow Fluorite
                         <!-- Begin Thorite Strategic Cloud Hint Veins -->
                         <Veins name='recrThoriteBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:9' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6054A228</WireframeColor>
@@ -2001,14 +2176,15 @@ Fluorite, Yellow Fluorite
                 <!-- Begin LayeredVeins distribution of End Pitchblende -->
                 <IfCondition condition=':= recrEndPitchblendeDist = "layeredVeins"'>
                 
-                    <Veins name='recrEndPitchblendeBaseVeins' block='ReactorCraft:reactorcraft_block_ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='recrEndPitchblendeBaseVeins' block='ReactorCraft:reactorcraft_block_ore:5'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60454454</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * recrEndPitchblendeSize * _default_' range=':= 1 * 1 * recrEndPitchblendeSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='normal' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * recrEndPitchblendeSize * _default_' range=':= 1 * 1 * recrEndPitchblendeSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * recrEndPitchblendeFreq * _default_'/>
@@ -2022,16 +2198,26 @@ Fluorite, Yellow Fluorite
                 <!-- Begin  Huge Veins distribution of End Pitchblende -->
                 <IfCondition condition=':= recrEndPitchblendeDist = "hugeVeins"'>
                 
-                    <Veins name='recrEndPitchblendeBaseVeins' block='ReactorCraft:reactorcraft_block_ore:5' inherits='PresetHugeVeins'>
+                    <Veins name='recrEndPitchblendeBaseVeins' block='ReactorCraft:reactorcraft_block_ore:5'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60454454</WireframeColor>
@@ -2052,12 +2238,16 @@ Fluorite, Yellow Fluorite
                 
                     <Cloud name='recrEndPitchblendeBaseCloud' block='ReactorCraft:reactorcraft_block_ore:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60454454</WireframeColor>
@@ -2072,10 +2262,16 @@ Fluorite, Yellow Fluorite
                         <!-- Begin End Pitchblende Strategic Cloud Hint Veins -->
                         <Veins name='recrEndPitchblendeBaseHintVeins' block='ReactorCraft:reactorcraft_block_ore:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60454454</WireframeColor>

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -1,12 +1,8 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Simple Ores Module
-
-Generates: 
-Copper, Tin, Mythril, Adamantium, Onyx
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Simple Ores" Module: This configuration
+      covers copper, tin, mythril, adamantium, and onyx.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="simpleores">
@@ -232,11 +228,10 @@ Copper, Tin, Mythril, Adamantium, Onyx
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='simpleores:copper_ore:0' />
-                    <Replaces block='simpleores:tin_ore:0' />
-                    <Replaces block='simpleores:mythril_ore:0' />
-                    <Replaces block='simpleores:adamantium_ore:0' />
-                    <Replaces block='simpleores:onyx_ore:0' />
+                    <Replaces block='simpleores:copper_ore' />
+                    <Replaces block='simpleores:tin_ore' />
+                    <Replaces block='simpleores:mythril_ore' />
+                    <Replaces block='simpleores:adamantium_ore' />
                 </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
                 
@@ -247,14 +242,15 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin Layered Veins distribution of Copper -->
                 <IfCondition condition=':= smpoCopperDist = "layeredVeins"'>
                 
-                    <Veins name='smpoCopperBaseVeins' block='simpleores:copper_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='smpoCopperBaseVeins' block='simpleores:copper_ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * smpoCopperSize * _default_' range=':= 1 * 1 * smpoCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 40' type='uniform' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 40' type='uniform' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * smpoCopperSize * _default_' range=':= 1 * 1 * smpoCopperSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.15 * smpoCopperFreq * _default_'/>
@@ -265,7 +261,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='smpoCopperPrefersVeins' block='simpleores:copper_ore' inherits='smpoCopperBaseVeins'>
+                    <Veins name='smpoCopperPrefersVeins' block='simpleores:copper_ore'  inherits='smpoCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -283,16 +279,26 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= smpoCopperDist = "hugeVeins"'>
                 
-                    <Veins name='smpoCopperBaseVeins' block='simpleores:copper_ore' inherits='PresetHugeVeins'>
+                    <Veins name='smpoCopperBaseVeins' block='simpleores:copper_ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -308,7 +314,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                    <Veins name='smpoCopperPrefersVeins' block='simpleores:copper_ore' inherits='smpoCopperBaseVeins'>
+                    <Veins name='smpoCopperPrefersVeins' block='simpleores:copper_ore'  inherits='smpoCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -328,12 +334,16 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 
                     <Cloud name='smpoCopperBaseCloud' block='simpleores:copper_ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -348,10 +358,16 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <!-- Begin Copper Strategic Cloud Hint Veins -->
                         <Veins name='smpoCopperBaseHintVeins' block='simpleores:copper_ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -395,14 +411,15 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin Layered Veins distribution of Tin -->
                 <IfCondition condition=':= smpoTinDist = "layeredVeins"'>
                 
-                    <Veins name='smpoTinBaseVeins' block='simpleores:tin_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='smpoTinBaseVeins' block='simpleores:tin_ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * smpoTinSize * _default_' range=':= 1 * 1 * smpoTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 40' type='uniform' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 40' type='uniform' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * smpoTinSize * _default_' range=':= 1 * 1 * smpoTinSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * smpoTinFreq * _default_'/>
@@ -412,7 +429,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='smpoTinPrefersVeins' block='simpleores:tin_ore' inherits='smpoTinBaseVeins'>
+                    <Veins name='smpoTinPrefersVeins' block='simpleores:tin_ore'  inherits='smpoTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -430,16 +447,26 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= smpoTinDist = "hugeVeins"'>
                 
-                    <Veins name='smpoTinBaseVeins' block='simpleores:tin_ore' inherits='PresetHugeVeins'>
+                    <Veins name='smpoTinBaseVeins' block='simpleores:tin_ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -454,7 +481,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                    <Veins name='smpoTinPrefersVeins' block='simpleores:tin_ore' inherits='smpoTinBaseVeins'>
+                    <Veins name='smpoTinPrefersVeins' block='simpleores:tin_ore'  inherits='smpoTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -474,12 +501,16 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 
                     <Cloud name='smpoTinBaseCloud' block='simpleores:tin_ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -494,10 +525,16 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <!-- Begin Tin Strategic Cloud Hint Veins -->
                         <Veins name='smpoTinBaseHintVeins' block='simpleores:tin_ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -541,14 +578,15 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin Layered Veins distribution of Mythril -->
                 <IfCondition condition=':= smpoMythrilDist = "layeredVeins"'>
                 
-                    <Veins name='smpoMythrilBaseVeins' block='simpleores:mythril_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='smpoMythrilBaseVeins' block='simpleores:mythril_ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6079AFD2</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * smpoMythrilSize * _default_' range=':= 1 * 0.5 * smpoMythrilSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 19' range=':= 15' type='uniform' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 19' range=':= 15' type='uniform' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.5 * smpoMythrilSize * _default_' range=':= 1 * 0.5 * smpoMythrilSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 6 * smpoMythrilFreq * _default_'/>
@@ -558,7 +596,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Mythril Layered Veins) Settings -->
-                    <Veins name='smpoMythrilPrefersVeins' block='simpleores:mythril_ore' inherits='smpoMythrilBaseVeins'>
+                    <Veins name='smpoMythrilPrefersVeins' block='simpleores:mythril_ore'  inherits='smpoMythrilBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -576,16 +614,26 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin  Huge Veins distribution of Mythril -->
                 <IfCondition condition=':= smpoMythrilDist = "hugeVeins"'>
                 
-                    <Veins name='smpoMythrilBaseVeins' block='simpleores:mythril_ore' inherits='PresetHugeVeins'>
+                    <Veins name='smpoMythrilBaseVeins' block='simpleores:mythril_ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6079AFD2</WireframeColor>
@@ -600,7 +648,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Mythril Huge Veins) Settings -->
-                    <Veins name='smpoMythrilPrefersVeins' block='simpleores:mythril_ore' inherits='smpoMythrilBaseVeins'>
+                    <Veins name='smpoMythrilPrefersVeins' block='simpleores:mythril_ore'  inherits='smpoMythrilBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -620,12 +668,16 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 
                     <Cloud name='smpoMythrilBaseCloud' block='simpleores:mythril_ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6079AFD2</WireframeColor>
@@ -640,10 +692,16 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <!-- Begin Mythril Strategic Cloud Hint Veins -->
                         <Veins name='smpoMythrilBaseHintVeins' block='simpleores:mythril_ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6079AFD2</WireframeColor>
@@ -687,14 +745,15 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin Layered Veins distribution of Adamantium -->
                 <IfCondition condition=':= smpoAdamantiumDist = "layeredVeins"'>
                 
-                    <Veins name='smpoAdamantiumBaseVeins' block='simpleores:adamantium_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='smpoAdamantiumBaseVeins' block='simpleores:adamantium_ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60159800</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.2 * smpoAdamantiumSize * _default_' range=':= 1 * 0.2 * smpoAdamantiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 11' range=':= 9' type='uniform' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 11' range=':= 9' type='uniform' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.2 * smpoAdamantiumSize * _default_' range=':= 1 * 0.2 * smpoAdamantiumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * smpoAdamantiumFreq * _default_'/>
@@ -704,7 +763,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Adamantium Layered Veins) Settings -->
-                    <Veins name='smpoAdamantiumPrefersVeins' block='simpleores:adamantium_ore' inherits='smpoAdamantiumBaseVeins'>
+                    <Veins name='smpoAdamantiumPrefersVeins' block='simpleores:adamantium_ore'  inherits='smpoAdamantiumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -722,16 +781,26 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin  Huge Veins distribution of Adamantium -->
                 <IfCondition condition=':= smpoAdamantiumDist = "hugeVeins"'>
                 
-                    <Veins name='smpoAdamantiumBaseVeins' block='simpleores:adamantium_ore' inherits='PresetHugeVeins'>
+                    <Veins name='smpoAdamantiumBaseVeins' block='simpleores:adamantium_ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60159800</WireframeColor>
@@ -746,7 +815,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Adamantium Huge Veins) Settings -->
-                    <Veins name='smpoAdamantiumPrefersVeins' block='simpleores:adamantium_ore' inherits='smpoAdamantiumBaseVeins'>
+                    <Veins name='smpoAdamantiumPrefersVeins' block='simpleores:adamantium_ore'  inherits='smpoAdamantiumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -766,12 +835,16 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 
                     <Cloud name='smpoAdamantiumBaseCloud' block='simpleores:adamantium_ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60159800</WireframeColor>
@@ -786,10 +859,16 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <!-- Begin Adamantium Strategic Cloud Hint Veins -->
                         <Veins name='smpoAdamantiumBaseHintVeins' block='simpleores:adamantium_ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60159800</WireframeColor>
@@ -843,11 +922,7 @@ Copper, Tin, Mythril, Adamantium, Onyx
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='simpleores:copper_ore:0' />
-                    <Replaces block='simpleores:tin_ore:0' />
-                    <Replaces block='simpleores:mythril_ore:0' />
-                    <Replaces block='simpleores:adamantium_ore:0' />
-                    <Replaces block='simpleores:onyx_ore:0' />
+                    <Replaces block='simpleores:onyx_ore' />
                 </Substitute>
                 <!-- Original Nether Ore Removal Complete -->
                 
@@ -858,14 +933,15 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin Layered Veins distribution of Onyx -->
                 <IfCondition condition=':= smpoOnyxDist = "layeredVeins"'>
                 
-                    <Veins name='smpoOnyxBaseVeins' block='simpleores:onyx_ore' inherits='PresetLayeredVeins'>
+                    <Veins name='smpoOnyxBaseVeins' block='simpleores:onyx_ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60232323</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * smpoOnyxSize * _default_' range=':= 1 * 1 * smpoOnyxSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * smpoOnyxSize * _default_' range=':= 1 * 1 * smpoOnyxSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * smpoOnyxFreq * _default_'/>
@@ -879,16 +955,26 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 <!-- Begin  Huge Veins distribution of Onyx -->
                 <IfCondition condition=':= smpoOnyxDist = "hugeVeins"'>
                 
-                    <Veins name='smpoOnyxBaseVeins' block='simpleores:onyx_ore' inherits='PresetHugeVeins'>
+                    <Veins name='smpoOnyxBaseVeins' block='simpleores:onyx_ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60232323</WireframeColor>
@@ -909,12 +995,16 @@ Copper, Tin, Mythril, Adamantium, Onyx
                 
                     <Cloud name='smpoOnyxBaseCloud' block='simpleores:onyx_ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60232323</WireframeColor>
@@ -929,10 +1019,16 @@ Copper, Tin, Mythril, Adamantium, Onyx
                         <!-- Begin Onyx Strategic Cloud Hint Veins -->
                         <Veins name='smpoOnyxBaseHintVeins' block='simpleores:onyx_ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60232323</WireframeColor>

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -1,13 +1,10 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Thaumcraft 4 Module
-
-Generates: 
-Amber, Cinnabar, Air Infused Stone, Fire Infused Stone, Water Infused
-Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Thaumcraft 4" Module: This configuration
+      covers amber, cinnabar, air infused stone, fire infused stone,
+      water infused  stone, earth infused stone, order infused stone,
+      and entropy infused  stone.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="Thaumcraft">
@@ -391,7 +388,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
                     <Replaces block='Thaumcraft:blockCustomOre:7' />
-                    <Replaces block='Thaumcraft:blockCustomOre:0' />
+                    <Replaces block='Thaumcraft:blockCustomOre' />
                     <Replaces block='Thaumcraft:blockCustomOre:1' />
                     <Replaces block='Thaumcraft:blockCustomOre:2' />
                     <Replaces block='Thaumcraft:blockCustomOre:3' />
@@ -408,17 +405,21 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin SparseVeins distribution of Amber -->
                 <IfCondition condition=':= thm4AmberDist = "sparseVeins"'>
                 
-                    <Veins name='thm4AmberBaseVeins' block='Thaumcraft:blockCustomOre:7' inherits='PresetSparseVeins'>
+                    <Veins name='thm4AmberBaseVeins' block='Thaumcraft:blockCustomOre:7'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FE9D1B</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * thm4AmberSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 80' range=':= 20' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 80' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * thm4AmberSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 3 * thm4AmberFreq * _default_'/>
@@ -426,7 +427,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Amber Sparse Veins) Settings -->
-                    <Veins name='thm4AmberPrefersVeins' block='Thaumcraft:blockCustomOre:7' inherits='thm4AmberBaseVeins'>
+                    <Veins name='thm4AmberPrefersVeins' block='Thaumcraft:blockCustomOre:7'  inherits='thm4AmberBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -444,22 +445,23 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Small Deposits distribution of Amber -->
                 <IfCondition condition=':= thm4AmberDist = "smallDeposits"'>
                 
-                    <Veins name='thm4AmberBaseVeins' block='Thaumcraft:blockCustomOre:7' inherits='PresetSmallDeposits'>
+                    <Veins name='thm4AmberBaseVeins' block='Thaumcraft:blockCustomOre:7'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FE9D1B</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 80' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * thm4AmberSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 80' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * thm4AmberSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 3 * thm4AmberFreq * _default_'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Amber Small Deposits) Settings -->
-                    <Veins name='thm4AmberPrefersVeins' block='Thaumcraft:blockCustomOre:7' inherits='thm4AmberBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Amber Deposit Veins) Settings -->
+                    <Veins name='thm4AmberPrefersVeins' block='Thaumcraft:blockCustomOre:7'  inherits='thm4AmberBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -468,7 +470,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Mountain'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Amber Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Amber Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Amber -->
@@ -477,16 +479,26 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Huge Veins distribution of Amber -->
                 <IfCondition condition=':= thm4AmberDist = "hugeVeins"'>
                 
-                    <Veins name='thm4AmberBaseVeins' block='Thaumcraft:blockCustomOre:7' inherits='PresetHugeVeins'>
+                    <Veins name='thm4AmberBaseVeins' block='Thaumcraft:blockCustomOre:7'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FE9D1B</WireframeColor>
@@ -499,7 +511,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Amber Huge Veins) Settings -->
-                    <Veins name='thm4AmberPrefersVeins' block='Thaumcraft:blockCustomOre:7' inherits='thm4AmberBaseVeins'>
+                    <Veins name='thm4AmberPrefersVeins' block='Thaumcraft:blockCustomOre:7'  inherits='thm4AmberBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -519,12 +531,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 
                     <Cloud name='thm4AmberBaseCloud' block='Thaumcraft:blockCustomOre:7' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FE9D1B</WireframeColor>
@@ -539,10 +555,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <!-- Begin Amber Strategic Cloud Hint Veins -->
                         <Veins name='thm4AmberBaseHintVeins' block='Thaumcraft:blockCustomOre:7' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FE9D1B</WireframeColor>
@@ -586,17 +608,21 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin SparseVeins distribution of Cinnabar -->
                 <IfCondition condition=':= thm4CinnabarDist = "sparseVeins"'>
                 
-                    <Veins name='thm4CinnabarBaseVeins' block='Thaumcraft:blockCustomOre' inherits='PresetSparseVeins'>
+                    <Veins name='thm4CinnabarBaseVeins' block='Thaumcraft:blockCustomOre'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60831C20</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * thm4CinnabarSize * _default_' range=':= 1 * 0.8 * thm4CinnabarSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 10' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * thm4CinnabarSize * _default_' range=':= 1 * 0.8 * thm4CinnabarSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 3 * thm4CinnabarFreq * _default_'/>
@@ -607,7 +633,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Cinnabar Sparse Veins) Settings -->
-                    <Veins name='thm4CinnabarPrefersVeins' block='Thaumcraft:blockCustomOre' inherits='thm4CinnabarBaseVeins'>
+                    <Veins name='thm4CinnabarPrefersVeins' block='Thaumcraft:blockCustomOre'  inherits='thm4CinnabarBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -625,22 +651,26 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Small Deposits distribution of Cinnabar -->
                 <IfCondition condition=':= thm4CinnabarDist = "smallDeposits"'>
                 
-                    <Veins name='thm4CinnabarBaseVeins' block='Thaumcraft:blockCustomOre' inherits='PresetSmallDeposits'>
+                    <Veins name='thm4CinnabarBaseVeins' block='Thaumcraft:blockCustomOre'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60831C20</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * thm4CinnabarSize * _default_' range=':= 1 * 0.8 * thm4CinnabarSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * thm4CinnabarSize * _default_' range=':= 1 * 0.8 * thm4CinnabarSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 3 * thm4CinnabarFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 12'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Cinnabar Small Deposits) Settings -->
-                    <Veins name='thm4CinnabarPrefersVeins' block='Thaumcraft:blockCustomOre' inherits='thm4CinnabarBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Cinnabar Deposit Veins) Settings -->
+                    <Veins name='thm4CinnabarPrefersVeins' block='Thaumcraft:blockCustomOre'  inherits='thm4CinnabarBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -649,7 +679,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                         <BiomeType name='Ocean'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Cinnabar Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Cinnabar Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Cinnabar -->
@@ -658,16 +688,26 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Huge Veins distribution of Cinnabar -->
                 <IfCondition condition=':= thm4CinnabarDist = "hugeVeins"'>
                 
-                    <Veins name='thm4CinnabarBaseVeins' block='Thaumcraft:blockCustomOre' inherits='PresetHugeVeins'>
+                    <Veins name='thm4CinnabarBaseVeins' block='Thaumcraft:blockCustomOre'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60831C20</WireframeColor>
@@ -683,7 +723,7 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Cinnabar Huge Veins) Settings -->
-                    <Veins name='thm4CinnabarPrefersVeins' block='Thaumcraft:blockCustomOre' inherits='thm4CinnabarBaseVeins'>
+                    <Veins name='thm4CinnabarPrefersVeins' block='Thaumcraft:blockCustomOre'  inherits='thm4CinnabarBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -703,12 +743,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 
                     <Cloud name='thm4CinnabarBaseCloud' block='Thaumcraft:blockCustomOre' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60831C20</WireframeColor>
@@ -723,10 +767,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <!-- Begin Cinnabar Strategic Cloud Hint Veins -->
                         <Veins name='thm4CinnabarBaseHintVeins' block='Thaumcraft:blockCustomOre' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60831C20</WireframeColor>
@@ -770,24 +820,27 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin SparseVeins distribution of Air Infused Stone -->
                 <IfCondition condition=':= thm4AirInfusedStoneDist = "sparseVeins"'>
                 
-                    <Veins name='thm4AirInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:1' inherits='PresetSparseVeins'>
+                    <Veins name='thm4AirInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:1'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FEFEAB</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4AirInfusedStoneFreq * _default_'/>
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Forest'/>
                         <BiomeType name='Plains'/>
                         <BiomeType name='Hills'/>
@@ -795,10 +848,11 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Air Infused Stone Sparse Veins) Settings -->
-                    <Veins name='thm4AirInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:1' inherits='thm4AirInfusedStoneBaseVeins'>
+                    <Veins name='thm4AirInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:1'  inherits='thm4AirInfusedStoneBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -817,57 +871,10 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Small Deposits distribution of Air Infused Stone -->
                 <IfCondition condition=':= thm4AirInfusedStoneDist = "smallDeposits"'>
                 
-                    <Veins name='thm4AirInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:1' inherits='PresetSmallDeposits'>
+                    <Veins name='thm4AirInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:1'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFEAB</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4AirInfusedStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Air Infused Stone Small Deposits) Settings -->
-                    <Veins name='thm4AirInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:1' inherits='thm4AirInfusedStoneBaseVeins'>
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFEAB</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Air Infused Stone Small Deposits) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Air Infused Stone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Air Infused Stone -->
-                <IfCondition condition=':= thm4AirInfusedStoneDist = "hugeVeins"'>
-                
-                    <Veins name='thm4AirInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:1' inherits='PresetHugeVeins'>
-                        <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FEFEAB</WireframeColor>
@@ -879,7 +886,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Forest'/>
                         <BiomeType name='Plains'/>
                         <BiomeType name='Hills'/>
@@ -887,10 +893,72 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
+                    </Veins>
+                    
+                    <!-- Begin Preferred Biome Distribution (Air Infused Stone Deposit Veins) Settings -->
+                    <Veins name='thm4AirInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:1'  inherits='thm4AirInfusedStoneBaseVeins' >
+                        <Description>
+                            Spawns 4 more times in preferred biomes.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x60FEFEAB</WireframeColor>
+                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
+                        <BiomeType name='Plains'/>
+                        <BiomeType name='Magical'/>
+                    </Veins>
+                    <!-- End Preferred Biome Distribution (Air Infused Stone Deposit Veins) Settings -->
+                
+                </IfCondition>
+                <!-- End  Small Deposits distribution of Air Infused Stone -->
+                
+                
+                <!-- Begin  Huge Veins distribution of Air Infused Stone -->
+                <IfCondition condition=':= thm4AirInfusedStoneDist = "hugeVeins"'>
+                
+                    <Veins name='thm4AirInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:1'  inherits='PresetHugeVeins' >
+                        <Description>
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x60FEFEAB</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_'/>
+                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
+                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4AirInfusedStoneFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 12'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
+                        <BiomeType name='Forest'/>
+                        <BiomeType name='Plains'/>
+                        <BiomeType name='Hills'/>
+                        <BiomeType name='Jungle'/>
+                        <BiomeType name='Beach'/>
+                        <BiomeType name='Mushroom'/>
+                        <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Air Infused Stone Huge Veins) Settings -->
-                    <Veins name='thm4AirInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:1' inherits='thm4AirInfusedStoneBaseVeins'>
+                    <Veins name='thm4AirInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:1'  inherits='thm4AirInfusedStoneBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -911,12 +979,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 
                     <Cloud name='thm4AirInfusedStoneBaseCloud' block='Thaumcraft:blockCustomOre:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FEFEAB</WireframeColor>
@@ -938,10 +1010,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <!-- Begin Air Infused Stone Strategic Cloud Hint Veins -->
                         <Veins name='thm4AirInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FEFEAB</WireframeColor>
@@ -999,33 +1077,37 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin SparseVeins distribution of Fire Infused Stone -->
                 <IfCondition condition=':= thm4FireInfusedStoneDist = "sparseVeins"'>
                 
-                    <Veins name='thm4FireInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:2' inherits='PresetSparseVeins'>
+                    <Veins name='thm4FireInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:2'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FC5100</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4FireInfusedStoneFreq * _default_'/>
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
                         <BiomeType name='Desert'/>
                         <BiomeType name='Wasteland'/>
                         <BiomeType name='Beach'/>
                         <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Fire Infused Stone Sparse Veins) Settings -->
-                    <Veins name='thm4FireInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:2' inherits='thm4FireInfusedStoneBaseVeins'>
+                    <Veins name='thm4FireInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:2'  inherits='thm4FireInfusedStoneBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -1044,55 +1126,10 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Small Deposits distribution of Fire Infused Stone -->
                 <IfCondition condition=':= thm4FireInfusedStoneDist = "smallDeposits"'>
                 
-                    <Veins name='thm4FireInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:2' inherits='PresetSmallDeposits'>
+                    <Veins name='thm4FireInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:2'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FC5100</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4FireInfusedStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Fire Infused Stone Small Deposits) Settings -->
-                    <Veins name='thm4FireInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:2' inherits='thm4FireInfusedStoneBaseVeins'>
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FC5100</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Fire Infused Stone Small Deposits) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Fire Infused Stone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Fire Infused Stone -->
-                <IfCondition condition=':= thm4FireInfusedStoneDist = "hugeVeins"'>
-                
-                    <Veins name='thm4FireInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:2' inherits='PresetHugeVeins'>
-                        <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FC5100</WireframeColor>
@@ -1104,16 +1141,75 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
                         <BiomeType name='Desert'/>
                         <BiomeType name='Wasteland'/>
                         <BiomeType name='Beach'/>
                         <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
+                    </Veins>
+                    
+                    <!-- Begin Preferred Biome Distribution (Fire Infused Stone Deposit Veins) Settings -->
+                    <Veins name='thm4FireInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:2'  inherits='thm4FireInfusedStoneBaseVeins' >
+                        <Description>
+                            Spawns 4 more times in preferred biomes.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x60FC5100</WireframeColor>
+                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
+                        <BiomeType name='Desert'/>
+                        <BiomeType name='Magical'/>
+                    </Veins>
+                    <!-- End Preferred Biome Distribution (Fire Infused Stone Deposit Veins) Settings -->
+                
+                </IfCondition>
+                <!-- End  Small Deposits distribution of Fire Infused Stone -->
+                
+                
+                <!-- Begin  Huge Veins distribution of Fire Infused Stone -->
+                <IfCondition condition=':= thm4FireInfusedStoneDist = "hugeVeins"'>
+                
+                    <Veins name='thm4FireInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:2'  inherits='PresetHugeVeins' >
+                        <Description>
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x60FC5100</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_'/>
+                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
+                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4FireInfusedStoneFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 12'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
+                        <BiomeType name='Mountain'/>
+                        <BiomeType name='Desert'/>
+                        <BiomeType name='Wasteland'/>
+                        <BiomeType name='Beach'/>
+                        <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Fire Infused Stone Huge Veins) Settings -->
-                    <Veins name='thm4FireInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:2' inherits='thm4FireInfusedStoneBaseVeins'>
+                    <Veins name='thm4FireInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:2'  inherits='thm4FireInfusedStoneBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -1134,12 +1230,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 
                     <Cloud name='thm4FireInfusedStoneBaseCloud' block='Thaumcraft:blockCustomOre:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FC5100</WireframeColor>
@@ -1159,10 +1259,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <!-- Begin Fire Infused Stone Strategic Cloud Hint Veins -->
                         <Veins name='thm4FireInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FC5100</WireframeColor>
@@ -1216,24 +1322,27 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin SparseVeins distribution of Water Infused Stone -->
                 <IfCondition condition=':= thm4WaterInfusedStoneDist = "sparseVeins"'>
                 
-                    <Veins name='thm4WaterInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:3' inherits='PresetSparseVeins'>
+                    <Veins name='thm4WaterInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:3'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6000C0FA</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4WaterInfusedStoneFreq * _default_'/>
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Forest'/>
                         <BiomeType name='Swamp'/>
                         <BiomeType name='Water'/>
@@ -1242,10 +1351,11 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Water Infused Stone Sparse Veins) Settings -->
-                    <Veins name='thm4WaterInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:3' inherits='thm4WaterInfusedStoneBaseVeins'>
+                    <Veins name='thm4WaterInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:3'  inherits='thm4WaterInfusedStoneBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1265,59 +1375,10 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Small Deposits distribution of Water Infused Stone -->
                 <IfCondition condition=':= thm4WaterInfusedStoneDist = "smallDeposits"'>
                 
-                    <Veins name='thm4WaterInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:3' inherits='PresetSmallDeposits'>
+                    <Veins name='thm4WaterInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:3'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000C0FA</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4WaterInfusedStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Water'/>
-                        <BiomeType name='Frozen'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Water Infused Stone Small Deposits) Settings -->
-                    <Veins name='thm4WaterInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:3' inherits='thm4WaterInfusedStoneBaseVeins'>
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000C0FA</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Water'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Water Infused Stone Small Deposits) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Water Infused Stone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Water Infused Stone -->
-                <IfCondition condition=':= thm4WaterInfusedStoneDist = "hugeVeins"'>
-                
-                    <Veins name='thm4WaterInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:3' inherits='PresetHugeVeins'>
-                        <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6000C0FA</WireframeColor>
@@ -1329,7 +1390,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Forest'/>
                         <BiomeType name='Swamp'/>
                         <BiomeType name='Water'/>
@@ -1338,10 +1398,74 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
+                    </Veins>
+                    
+                    <!-- Begin Preferred Biome Distribution (Water Infused Stone Deposit Veins) Settings -->
+                    <Veins name='thm4WaterInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:3'  inherits='thm4WaterInfusedStoneBaseVeins' >
+                        <Description>
+                            Spawns 2 more times in preferred biomes.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x6000C0FA</WireframeColor>
+                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
+                        <BiomeType name='Swamp'/>
+                        <BiomeType name='Water'/>
+                        <BiomeType name='Magical'/>
+                    </Veins>
+                    <!-- End Preferred Biome Distribution (Water Infused Stone Deposit Veins) Settings -->
+                
+                </IfCondition>
+                <!-- End  Small Deposits distribution of Water Infused Stone -->
+                
+                
+                <!-- Begin  Huge Veins distribution of Water Infused Stone -->
+                <IfCondition condition=':= thm4WaterInfusedStoneDist = "hugeVeins"'>
+                
+                    <Veins name='thm4WaterInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:3'  inherits='PresetHugeVeins' >
+                        <Description>
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x6000C0FA</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_'/>
+                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
+                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4WaterInfusedStoneFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 12'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
+                        <BiomeType name='Forest'/>
+                        <BiomeType name='Swamp'/>
+                        <BiomeType name='Water'/>
+                        <BiomeType name='Frozen'/>
+                        <BiomeType name='Jungle'/>
+                        <BiomeType name='Beach'/>
+                        <BiomeType name='Mushroom'/>
+                        <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Water Infused Stone Huge Veins) Settings -->
-                    <Veins name='thm4WaterInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:3' inherits='thm4WaterInfusedStoneBaseVeins'>
+                    <Veins name='thm4WaterInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:3'  inherits='thm4WaterInfusedStoneBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1363,12 +1487,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 
                     <Cloud name='thm4WaterInfusedStoneBaseCloud' block='Thaumcraft:blockCustomOre:3' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6000C0FA</WireframeColor>
@@ -1391,10 +1519,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <!-- Begin Water Infused Stone Strategic Cloud Hint Veins -->
                         <Veins name='thm4WaterInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:3' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6000C0FA</WireframeColor>
@@ -1454,24 +1588,27 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin SparseVeins distribution of Earth Infused Stone -->
                 <IfCondition condition=':= thm4EarthInfusedStoneDist = "sparseVeins"'>
                 
-                    <Veins name='thm4EarthInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:4' inherits='PresetSparseVeins'>
+                    <Veins name='thm4EarthInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:4'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6000D900</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4EarthInfusedStoneFreq * _default_'/>
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
                         <BiomeType name='Hills'/>
                         <BiomeType name='Desert'/>
@@ -1480,10 +1617,11 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Earth Infused Stone Sparse Veins) Settings -->
-                    <Veins name='thm4EarthInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:4' inherits='thm4EarthInfusedStoneBaseVeins'>
+                    <Veins name='thm4EarthInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:4'  inherits='thm4EarthInfusedStoneBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -1503,59 +1641,10 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Small Deposits distribution of Earth Infused Stone -->
                 <IfCondition condition=':= thm4EarthInfusedStoneDist = "smallDeposits"'>
                 
-                    <Veins name='thm4EarthInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:4' inherits='PresetSmallDeposits'>
+                    <Veins name='thm4EarthInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:4'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000D900</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4EarthInfusedStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Earth Infused Stone Small Deposits) Settings -->
-                    <Veins name='thm4EarthInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:4' inherits='thm4EarthInfusedStoneBaseVeins'>
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000D900</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Earth Infused Stone Small Deposits) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Earth Infused Stone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Earth Infused Stone -->
-                <IfCondition condition=':= thm4EarthInfusedStoneDist = "hugeVeins"'>
-                
-                    <Veins name='thm4EarthInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:4' inherits='PresetHugeVeins'>
-                        <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6000D900</WireframeColor>
@@ -1567,7 +1656,6 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Mountain'/>
                         <BiomeType name='Hills'/>
                         <BiomeType name='Desert'/>
@@ -1576,10 +1664,74 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
+                    </Veins>
+                    
+                    <!-- Begin Preferred Biome Distribution (Earth Infused Stone Deposit Veins) Settings -->
+                    <Veins name='thm4EarthInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:4'  inherits='thm4EarthInfusedStoneBaseVeins' >
+                        <Description>
+                            Spawns 4 more times in preferred biomes.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x6000D900</WireframeColor>
+                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
+                        <BiomeType name='Mountain'/>
+                        <BiomeType name='Hills'/>
+                        <BiomeType name='Magical'/>
+                    </Veins>
+                    <!-- End Preferred Biome Distribution (Earth Infused Stone Deposit Veins) Settings -->
+                
+                </IfCondition>
+                <!-- End  Small Deposits distribution of Earth Infused Stone -->
+                
+                
+                <!-- Begin  Huge Veins distribution of Earth Infused Stone -->
+                <IfCondition condition=':= thm4EarthInfusedStoneDist = "hugeVeins"'>
+                
+                    <Veins name='thm4EarthInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:4'  inherits='PresetHugeVeins' >
+                        <Description>
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x6000D900</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_'/>
+                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
+                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4EarthInfusedStoneFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 12'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
+                        <BiomeType name='Mountain'/>
+                        <BiomeType name='Hills'/>
+                        <BiomeType name='Desert'/>
+                        <BiomeType name='Jungle'/>
+                        <BiomeType name='Wasteland'/>
+                        <BiomeType name='Beach'/>
+                        <BiomeType name='Mushroom'/>
+                        <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Earth Infused Stone Huge Veins) Settings -->
-                    <Veins name='thm4EarthInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:4' inherits='thm4EarthInfusedStoneBaseVeins'>
+                    <Veins name='thm4EarthInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:4'  inherits='thm4EarthInfusedStoneBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -1601,12 +1753,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 
                     <Cloud name='thm4EarthInfusedStoneBaseCloud' block='Thaumcraft:blockCustomOre:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x6000D900</WireframeColor>
@@ -1629,10 +1785,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <!-- Begin Earth Infused Stone Strategic Cloud Hint Veins -->
                         <Veins name='thm4EarthInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x6000D900</WireframeColor>
@@ -1692,34 +1854,38 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin SparseVeins distribution of Order Infused Stone -->
                 <IfCondition condition=':= thm4OrderInfusedStoneDist = "sparseVeins"'>
                 
-                    <Veins name='thm4OrderInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:5' inherits='PresetSparseVeins'>
+                    <Veins name='thm4OrderInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:5'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EBEBF9</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4OrderInfusedStoneFreq * _default_'/>
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Forest'/>
                         <BiomeType name='Plains'/>
                         <BiomeType name='Mountain'/>
                         <BiomeType name='Hills'/>
                         <BiomeType name='Jungle'/>
                         <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Order Infused Stone Sparse Veins) Settings -->
-                    <Veins name='thm4OrderInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:5' inherits='thm4OrderInfusedStoneBaseVeins'>
+                    <Veins name='thm4OrderInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:5'  inherits='thm4OrderInfusedStoneBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -1739,57 +1905,10 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Small Deposits distribution of Order Infused Stone -->
                 <IfCondition condition=':= thm4OrderInfusedStoneDist = "smallDeposits"'>
                 
-                    <Veins name='thm4OrderInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:5' inherits='PresetSmallDeposits'>
+                    <Veins name='thm4OrderInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:5'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EBEBF9</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4OrderInfusedStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Order Infused Stone Small Deposits) Settings -->
-                    <Veins name='thm4OrderInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:5' inherits='thm4OrderInfusedStoneBaseVeins'>
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EBEBF9</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Order Infused Stone Small Deposits) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Order Infused Stone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Order Infused Stone -->
-                <IfCondition condition=':= thm4OrderInfusedStoneDist = "hugeVeins"'>
-                
-                    <Veins name='thm4OrderInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:5' inherits='PresetHugeVeins'>
-                        <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EBEBF9</WireframeColor>
@@ -1801,17 +1920,78 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Forest'/>
                         <BiomeType name='Plains'/>
                         <BiomeType name='Mountain'/>
                         <BiomeType name='Hills'/>
                         <BiomeType name='Jungle'/>
                         <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
+                    </Veins>
+                    
+                    <!-- Begin Preferred Biome Distribution (Order Infused Stone Deposit Veins) Settings -->
+                    <Veins name='thm4OrderInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:5'  inherits='thm4OrderInfusedStoneBaseVeins' >
+                        <Description>
+                            Spawns 4 more times in preferred biomes.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x60EBEBF9</WireframeColor>
+                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
+                        <BiomeType name='Forest'/>
+                        <BiomeType name='Jungle'/>
+                        <BiomeType name='Magical'/>
+                    </Veins>
+                    <!-- End Preferred Biome Distribution (Order Infused Stone Deposit Veins) Settings -->
+                
+                </IfCondition>
+                <!-- End  Small Deposits distribution of Order Infused Stone -->
+                
+                
+                <!-- Begin  Huge Veins distribution of Order Infused Stone -->
+                <IfCondition condition=':= thm4OrderInfusedStoneDist = "hugeVeins"'>
+                
+                    <Veins name='thm4OrderInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:5'  inherits='PresetHugeVeins' >
+                        <Description>
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x60EBEBF9</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_'/>
+                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
+                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4OrderInfusedStoneFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 12'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
+                        <BiomeType name='Forest'/>
+                        <BiomeType name='Plains'/>
+                        <BiomeType name='Mountain'/>
+                        <BiomeType name='Hills'/>
+                        <BiomeType name='Jungle'/>
+                        <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Order Infused Stone Huge Veins) Settings -->
-                    <Veins name='thm4OrderInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:5' inherits='thm4OrderInfusedStoneBaseVeins'>
+                    <Veins name='thm4OrderInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:5'  inherits='thm4OrderInfusedStoneBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -1833,12 +2013,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 
                     <Cloud name='thm4OrderInfusedStoneBaseCloud' block='Thaumcraft:blockCustomOre:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EBEBF9</WireframeColor>
@@ -1859,10 +2043,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <!-- Begin Order Infused Stone Strategic Cloud Hint Veins -->
                         <Veins name='thm4OrderInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60EBEBF9</WireframeColor>
@@ -1918,34 +2108,38 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin SparseVeins distribution of Entropy Infused Stone -->
                 <IfCondition condition=':= thm4EntropyInfusedStoneDist = "sparseVeins"'>
                 
-                    <Veins name='thm4EntropyInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:6' inherits='PresetSparseVeins'>
+                    <Veins name='thm4EntropyInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:6'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60260920</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' />
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4EntropyInfusedStoneFreq * _default_'/>
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Swamp'/>
                         <BiomeType name='Desert'/>
                         <BiomeType name='Wasteland'/>
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Entropy Infused Stone Sparse Veins) Settings -->
-                    <Veins name='thm4EntropyInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:6' inherits='thm4EntropyInfusedStoneBaseVeins'>
+                    <Veins name='thm4EntropyInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:6'  inherits='thm4EntropyInfusedStoneBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -1965,57 +2159,10 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 <!-- Begin  Small Deposits distribution of Entropy Infused Stone -->
                 <IfCondition condition=':= thm4EntropyInfusedStoneDist = "smallDeposits"'>
                 
-                    <Veins name='thm4EntropyInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:6' inherits='PresetSmallDeposits'>
+                    <Veins name='thm4EntropyInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:6'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60260920</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4EntropyInfusedStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Entropy Infused Stone Small Deposits) Settings -->
-                    <Veins name='thm4EntropyInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:6' inherits='thm4EntropyInfusedStoneBaseVeins'>
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60260920</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Entropy Infused Stone Small Deposits) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Entropy Infused Stone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Entropy Infused Stone -->
-                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "hugeVeins"'>
-                
-                    <Veins name='thm4EntropyInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:6' inherits='PresetHugeVeins'>
-                        <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60260920</WireframeColor>
@@ -2027,17 +2174,78 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
                         <Setting name='BranchHeightLimit' avg=':= 12'/>
                         <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
                         <BiomeType name='Swamp'/>
                         <BiomeType name='Desert'/>
                         <BiomeType name='Wasteland'/>
                         <BiomeType name='Beach'/>
                         <BiomeType name='Mushroom'/>
                         <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
+                    </Veins>
+                    
+                    <!-- Begin Preferred Biome Distribution (Entropy Infused Stone Deposit Veins) Settings -->
+                    <Veins name='thm4EntropyInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:6'  inherits='thm4EntropyInfusedStoneBaseVeins' >
+                        <Description>
+                            Spawns 4 more times in preferred biomes.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x60260920</WireframeColor>
+                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
+                        <BiomeType name='Wasteland'/>
+                        <BiomeType name='Mushroom'/>
+                        <BiomeType name='Magical'/>
+                    </Veins>
+                    <!-- End Preferred Biome Distribution (Entropy Infused Stone Deposit Veins) Settings -->
+                
+                </IfCondition>
+                <!-- End  Small Deposits distribution of Entropy Infused Stone -->
+                
+                
+                <!-- Begin  Huge Veins distribution of Entropy Infused Stone -->
+                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "hugeVeins"'>
+                
+                    <Veins name='thm4EntropyInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:6'  inherits='PresetHugeVeins' >
+                        <Description>
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
+                        </Description>
+                        <DrawWireframe>:=drawWireframes</DrawWireframe>
+                        <WireframeColor>0x60260920</WireframeColor>
+                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_'/>
+                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
+                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4EntropyInfusedStoneFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 12'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
+                        <BiomeType name='Swamp'/>
+                        <BiomeType name='Desert'/>
+                        <BiomeType name='Wasteland'/>
+                        <BiomeType name='Beach'/>
+                        <BiomeType name='Mushroom'/>
+                        <BiomeType name='Magical'/>
+                        <Replaces block='minecraft:stone'/>
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Entropy Infused Stone Huge Veins) Settings -->
-                    <Veins name='thm4EntropyInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:6' inherits='thm4EntropyInfusedStoneBaseVeins'>
+                    <Veins name='thm4EntropyInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:6'  inherits='thm4EntropyInfusedStoneBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -2059,12 +2267,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                 
                     <Cloud name='thm4EntropyInfusedStoneBaseCloud' block='Thaumcraft:blockCustomOre:6' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60260920</WireframeColor>
@@ -2085,10 +2297,16 @@ Stone, Earth Infused Stone, Order Infused Stone, Entropy Infused Stone
                         <!-- Begin Entropy Infused Stone Strategic Cloud Hint Veins -->
                         <Veins name='thm4EntropyInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:6' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60260920</WireframeColor>

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -1,12 +1,9 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Thermal Foundation Module
-
-Generates: 
-Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Thermal Foundation" Module: This
+      configuration covers copper, tin, silver, lead, ferrous, shiny,
+      and mana infused.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="ThermalFoundation">
@@ -315,7 +312,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     <Comment>
                         The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                     </Comment>
-                    <Replaces block='ThermalFoundation:Ore:0' />
+                    <Replaces block='ThermalFoundation:Ore' />
                     <Replaces block='ThermalFoundation:Ore:1' />
                     <Replaces block='ThermalFoundation:Ore:2' />
                     <Replaces block='ThermalFoundation:Ore:3' />
@@ -332,14 +329,15 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin LayeredVeins distribution of Copper -->
                 <IfCondition condition=':= thfoCopperDist = "layeredVeins"'>
                 
-                    <Veins name='thfoCopperBaseVeins' block='ThermalFoundation:Ore' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoCopperBaseVeins' block='ThermalFoundation:Ore'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.9 * thfoCopperSize * _default_' range=':= 1 * 0.9 * thfoCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 45' range=':= 10' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 45' range=':= 10' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.9 * thfoCopperSize * _default_' range=':= 1 * 0.9 * thfoCopperSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * thfoCopperFreq * _default_'/>
@@ -350,7 +348,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='thfoCopperPrefersVeins' block='ThermalFoundation:Ore' inherits='thfoCopperBaseVeins'>
+                    <Veins name='thfoCopperPrefersVeins' block='ThermalFoundation:Ore'  inherits='thfoCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -368,16 +366,26 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= thfoCopperDist = "hugeVeins"'>
                 
-                    <Veins name='thfoCopperBaseVeins' block='ThermalFoundation:Ore' inherits='PresetHugeVeins'>
+                    <Veins name='thfoCopperBaseVeins' block='ThermalFoundation:Ore'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -393,7 +401,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                    <Veins name='thfoCopperPrefersVeins' block='ThermalFoundation:Ore' inherits='thfoCopperBaseVeins'>
+                    <Veins name='thfoCopperPrefersVeins' block='ThermalFoundation:Ore'  inherits='thfoCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -413,12 +421,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 
                     <Cloud name='thfoCopperBaseCloud' block='ThermalFoundation:Ore' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -433,10 +445,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <!-- Begin Copper Strategic Cloud Hint Veins -->
                         <Veins name='thfoCopperBaseHintVeins' block='ThermalFoundation:Ore' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -480,14 +498,15 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin LayeredVeins distribution of Tin -->
                 <IfCondition condition=':= thfoTinDist = "layeredVeins"'>
                 
-                    <Veins name='thfoTinBaseVeins' block='ThermalFoundation:Ore:1' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoTinBaseVeins' block='ThermalFoundation:Ore:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * thfoTinSize * _default_' range=':= 1 * 0.85 * thfoTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.85 * thfoTinSize * _default_' range=':= 1 * 0.85 * thfoTinSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * thfoTinFreq * _default_'/>
@@ -498,7 +517,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='thfoTinPrefersVeins' block='ThermalFoundation:Ore:1' inherits='thfoTinBaseVeins'>
+                    <Veins name='thfoTinPrefersVeins' block='ThermalFoundation:Ore:1'  inherits='thfoTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -516,16 +535,26 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= thfoTinDist = "hugeVeins"'>
                 
-                    <Veins name='thfoTinBaseVeins' block='ThermalFoundation:Ore:1' inherits='PresetHugeVeins'>
+                    <Veins name='thfoTinBaseVeins' block='ThermalFoundation:Ore:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -541,7 +570,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                    <Veins name='thfoTinPrefersVeins' block='ThermalFoundation:Ore:1' inherits='thfoTinBaseVeins'>
+                    <Veins name='thfoTinPrefersVeins' block='ThermalFoundation:Ore:1'  inherits='thfoTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -561,12 +590,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 
                     <Cloud name='thfoTinBaseCloud' block='ThermalFoundation:Ore:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -581,10 +614,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <!-- Begin Tin Strategic Cloud Hint Veins -->
                         <Veins name='thfoTinBaseHintVeins' block='ThermalFoundation:Ore:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -628,14 +667,15 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin LayeredVeins distribution of Silver -->
                 <IfCondition condition=':= thfoSilverDist = "layeredVeins"'>
                 
-                    <Veins name='thfoSilverBaseVeins' block='ThermalFoundation:Ore:2' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoSilverBaseVeins' block='ThermalFoundation:Ore:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3F2F7</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * thfoSilverSize * _default_' range=':= 1 * 0.85 * thfoSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.85 * thfoSilverSize * _default_' range=':= 1 * 0.85 * thfoSilverSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * thfoSilverFreq * _default_'/>
@@ -646,7 +686,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                    <Veins name='thfoSilverPrefersVeins' block='ThermalFoundation:Ore:2' inherits='thfoSilverBaseVeins'>
+                    <Veins name='thfoSilverPrefersVeins' block='ThermalFoundation:Ore:2'  inherits='thfoSilverBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -664,16 +704,26 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Silver -->
                 <IfCondition condition=':= thfoSilverDist = "hugeVeins"'>
                 
-                    <Veins name='thfoSilverBaseVeins' block='ThermalFoundation:Ore:2' inherits='PresetHugeVeins'>
+                    <Veins name='thfoSilverBaseVeins' block='ThermalFoundation:Ore:2'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3F2F7</WireframeColor>
@@ -689,7 +739,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Silver Huge Veins) Settings -->
-                    <Veins name='thfoSilverPrefersVeins' block='ThermalFoundation:Ore:2' inherits='thfoSilverBaseVeins'>
+                    <Veins name='thfoSilverPrefersVeins' block='ThermalFoundation:Ore:2'  inherits='thfoSilverBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -709,12 +759,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 
                     <Cloud name='thfoSilverBaseCloud' block='ThermalFoundation:Ore:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E3F2F7</WireframeColor>
@@ -729,10 +783,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <!-- Begin Silver Strategic Cloud Hint Veins -->
                         <Veins name='thfoSilverBaseHintVeins' block='ThermalFoundation:Ore:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E3F2F7</WireframeColor>
@@ -776,14 +836,15 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin LayeredVeins distribution of Lead -->
                 <IfCondition condition=':= thfoLeadDist = "layeredVeins"'>
                 
-                    <Veins name='thfoLeadBaseVeins' block='ThermalFoundation:Ore:3' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoLeadBaseVeins' block='ThermalFoundation:Ore:3'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60818EBE</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * thfoLeadSize * _default_' range=':= 1 * 1 * thfoLeadSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * thfoLeadSize * _default_' range=':= 1 * 1 * thfoLeadSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * thfoLeadFreq * _default_'/>
@@ -793,7 +854,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Lead Layered Veins) Settings -->
-                    <Veins name='thfoLeadPrefersVeins' block='ThermalFoundation:Ore:3' inherits='thfoLeadBaseVeins'>
+                    <Veins name='thfoLeadPrefersVeins' block='ThermalFoundation:Ore:3'  inherits='thfoLeadBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -811,16 +872,26 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Lead -->
                 <IfCondition condition=':= thfoLeadDist = "hugeVeins"'>
                 
-                    <Veins name='thfoLeadBaseVeins' block='ThermalFoundation:Ore:3' inherits='PresetHugeVeins'>
+                    <Veins name='thfoLeadBaseVeins' block='ThermalFoundation:Ore:3'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60818EBE</WireframeColor>
@@ -835,7 +906,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Lead Huge Veins) Settings -->
-                    <Veins name='thfoLeadPrefersVeins' block='ThermalFoundation:Ore:3' inherits='thfoLeadBaseVeins'>
+                    <Veins name='thfoLeadPrefersVeins' block='ThermalFoundation:Ore:3'  inherits='thfoLeadBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -855,12 +926,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 
                     <Cloud name='thfoLeadBaseCloud' block='ThermalFoundation:Ore:3' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60818EBE</WireframeColor>
@@ -875,10 +950,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <!-- Begin Lead Strategic Cloud Hint Veins -->
                         <Veins name='thfoLeadBaseHintVeins' block='ThermalFoundation:Ore:3' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60818EBE</WireframeColor>
@@ -922,14 +1003,15 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin LayeredVeins distribution of Ferrous -->
                 <IfCondition condition=':= thfoFerrousDist = "layeredVeins"'>
                 
-                    <Veins name='thfoFerrousBaseVeins' block='ThermalFoundation:Ore:4' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoFerrousBaseVeins' block='ThermalFoundation:Ore:4'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BCBDAB</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * thfoFerrousSize * _default_' range=':= 1 * 0.85 * thfoFerrousSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.85 * thfoFerrousSize * _default_' range=':= 1 * 0.85 * thfoFerrousSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * thfoFerrousFreq * _default_'/>
@@ -940,7 +1022,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Ferrous Layered Veins) Settings -->
-                    <Veins name='thfoFerrousPrefersVeins' block='ThermalFoundation:Ore:4' inherits='thfoFerrousBaseVeins'>
+                    <Veins name='thfoFerrousPrefersVeins' block='ThermalFoundation:Ore:4'  inherits='thfoFerrousBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -958,16 +1040,26 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Ferrous -->
                 <IfCondition condition=':= thfoFerrousDist = "hugeVeins"'>
                 
-                    <Veins name='thfoFerrousBaseVeins' block='ThermalFoundation:Ore:4' inherits='PresetHugeVeins'>
+                    <Veins name='thfoFerrousBaseVeins' block='ThermalFoundation:Ore:4'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BCBDAB</WireframeColor>
@@ -983,7 +1075,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Ferrous Huge Veins) Settings -->
-                    <Veins name='thfoFerrousPrefersVeins' block='ThermalFoundation:Ore:4' inherits='thfoFerrousBaseVeins'>
+                    <Veins name='thfoFerrousPrefersVeins' block='ThermalFoundation:Ore:4'  inherits='thfoFerrousBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1003,12 +1095,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 
                     <Cloud name='thfoFerrousBaseCloud' block='ThermalFoundation:Ore:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60BCBDAB</WireframeColor>
@@ -1023,10 +1119,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <!-- Begin Ferrous Strategic Cloud Hint Veins -->
                         <Veins name='thfoFerrousBaseHintVeins' block='ThermalFoundation:Ore:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60BCBDAB</WireframeColor>
@@ -1070,14 +1172,15 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin LayeredVeins distribution of Shiny -->
                 <IfCondition condition=':= thfoShinyDist = "layeredVeins"'>
                 
-                    <Veins name='thfoShinyBaseVeins' block='ThermalFoundation:Ore:5' inherits='PresetLayeredVeins'>
+                    <Veins name='thfoShinyBaseVeins' block='ThermalFoundation:Ore:5'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x606FE5F3</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.80 * thfoShinySize * _default_' range=':= 1 * 0.80 * thfoShinySize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 16' range=':= 8' type='normal' scaleTo='Biome'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 16' range=':= 8' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.80 * thfoShinySize * _default_' range=':= 1 * 0.80 * thfoShinySize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * thfoShinyFreq * _default_'/>
@@ -1088,7 +1191,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Shiny Layered Veins) Settings -->
-                    <Veins name='thfoShinyPrefersVeins' block='ThermalFoundation:Ore:5' inherits='thfoShinyBaseVeins'>
+                    <Veins name='thfoShinyPrefersVeins' block='ThermalFoundation:Ore:5'  inherits='thfoShinyBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1106,16 +1209,26 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Shiny -->
                 <IfCondition condition=':= thfoShinyDist = "hugeVeins"'>
                 
-                    <Veins name='thfoShinyBaseVeins' block='ThermalFoundation:Ore:5' inherits='PresetHugeVeins'>
+                    <Veins name='thfoShinyBaseVeins' block='ThermalFoundation:Ore:5'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x606FE5F3</WireframeColor>
@@ -1131,7 +1244,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Shiny Huge Veins) Settings -->
-                    <Veins name='thfoShinyPrefersVeins' block='ThermalFoundation:Ore:5' inherits='thfoShinyBaseVeins'>
+                    <Veins name='thfoShinyPrefersVeins' block='ThermalFoundation:Ore:5'  inherits='thfoShinyBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1151,12 +1264,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 
                     <Cloud name='thfoShinyBaseCloud' block='ThermalFoundation:Ore:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x606FE5F3</WireframeColor>
@@ -1171,10 +1288,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <!-- Begin Shiny Strategic Cloud Hint Veins -->
                         <Veins name='thfoShinyBaseHintVeins' block='ThermalFoundation:Ore:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x606FE5F3</WireframeColor>
@@ -1218,17 +1341,21 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin SparseVeins distribution of Mana Infused -->
                 <IfCondition condition=':= thfoManaInfusedDist = "sparseVeins"'>
                 
-                    <Veins name='thfoManaInfusedBaseVeins' block='ThermalFoundation:Ore:5' inherits='PresetSparseVeins'>
+                    <Veins name='thfoManaInfusedBaseVeins' block='ThermalFoundation:Ore:5'  inherits='PresetSparseVeins' >
                         <Description>
-                            Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                            these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                            compared to solid ore veins.  They are also more difficult to follow, since it is 
-                            harder to get an idea of their direction while mining.
+                            Large veins filled very lightly with ore.
+                            Because they contain less ore per volume,
+                            these veins are relatively wide and long.
+                            Mining the ore from them is time consuming
+                            compared to solid ore veins.  They are
+                            also more difficult to follow, since it is
+                            harder to get an idea of their direction
+                            while mining.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E2E273</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thfoManaInfusedSize * _default_' range=':= 1 * 0.75 * thfoManaInfusedSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='Biome' />
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='Biome' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thfoManaInfusedSize * _default_' range=':= 1 * 0.75 * thfoManaInfusedSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thfoManaInfusedFreq * _default_'/>
@@ -1239,7 +1366,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Mana Infused Sparse Veins) Settings -->
-                    <Veins name='thfoManaInfusedPrefersVeins' block='ThermalFoundation:Ore:5' inherits='thfoManaInfusedBaseVeins'>
+                    <Veins name='thfoManaInfusedPrefersVeins' block='ThermalFoundation:Ore:5'  inherits='thfoManaInfusedBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -1257,22 +1384,26 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Small Deposits distribution of Mana Infused -->
                 <IfCondition condition=':= thfoManaInfusedDist = "smallDeposits"'>
                 
-                    <Veins name='thfoManaInfusedBaseVeins' block='ThermalFoundation:Ore:5' inherits='PresetSmallDeposits'>
+                    <Veins name='thfoManaInfusedBaseVeins' block='ThermalFoundation:Ore:5'  inherits='PresetSmallDeposits' >
                         <Description>
-                            Small motherlodes without any branches.
-                            Similar to the deposits produced by StandardGen distributions.
+                            Small motherlodes with no veins; similar
+                            to vanilla clusters.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E2E273</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='Biome' /> 
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thfoManaInfusedSize * _default_' range=':= 1 * 0.75 * thfoManaInfusedSize * _default_'/>
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='Biome' /> 
+                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thfoManaInfusedSize * _default_' range=':= 1 * 0.75 * thfoManaInfusedSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thfoManaInfusedFreq * _default_'/>
+                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
+                        <Setting name='BranchHeightLimit' avg=':= 12'/>
+                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                         <Replaces block='minecraft:stone'/>
                     </Veins>
                     
-                    <!-- Begin Preferred Biome Distribution (Mana Infused Small Deposits) Settings -->
-                    <Veins name='thfoManaInfusedPrefersVeins' block='ThermalFoundation:Ore:5' inherits='thfoManaInfusedBaseVeins'>
+                    <!-- Begin Preferred Biome Distribution (Mana Infused Deposit Veins) Settings -->
+                    <Veins name='thfoManaInfusedPrefersVeins' block='ThermalFoundation:Ore:5'  inherits='thfoManaInfusedBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -1281,7 +1412,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
                         <BiomeType name='Magical'/>
                     </Veins>
-                    <!-- End Preferred Biome Distribution (Mana Infused Small Deposits) Settings -->
+                    <!-- End Preferred Biome Distribution (Mana Infused Deposit Veins) Settings -->
                 
                 </IfCondition>
                 <!-- End  Small Deposits distribution of Mana Infused -->
@@ -1290,16 +1421,26 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 <!-- Begin  Huge Veins distribution of Mana Infused -->
                 <IfCondition condition=':= thfoManaInfusedDist = "hugeVeins"'>
                 
-                    <Veins name='thfoManaInfusedBaseVeins' block='ThermalFoundation:Ore:5' inherits='PresetHugeVeins'>
+                    <Veins name='thfoManaInfusedBaseVeins' block='ThermalFoundation:Ore:5'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E2E273</WireframeColor>
@@ -1315,7 +1456,7 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Mana Infused Huge Veins) Settings -->
-                    <Veins name='thfoManaInfusedPrefersVeins' block='ThermalFoundation:Ore:5' inherits='thfoManaInfusedBaseVeins'>
+                    <Veins name='thfoManaInfusedPrefersVeins' block='ThermalFoundation:Ore:5'  inherits='thfoManaInfusedBaseVeins' >
                         <Description>
                             Spawns 4 more times in preferred biomes.
                         </Description>
@@ -1335,12 +1476,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                 
                     <Cloud name='thfoManaInfusedBaseCloud' block='ThermalFoundation:Ore:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E2E273</WireframeColor>
@@ -1355,10 +1500,16 @@ Copper, Tin, Silver, Lead, Ferrous, Shiny, Mana Infused
                         <!-- Begin Mana Infused Strategic Cloud Hint Veins -->
                         <Veins name='thfoManaInfusedBaseHintVeins' block='ThermalFoundation:Ore:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E2E273</WireframeColor>

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -1,13 +1,10 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Tinkers Construct Module
-
-Generates: 
-Copper, Tin, Aluminum, Iron Gravel, Gold Gravel, Copper Gravel, Tin
-Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Tinkers Construct" Module: This
+      configuration covers copper, tin, aluminum, iron gravel, gold
+      gravel, copper gravel, tin  gravel, aluminum gravel, cobalt,
+      ardite, and nether cobalt gravel.
+      ================================================================
+      -->
 
     <!-- Mod detection -->
     <IfModInstalled name="TConstruct">
@@ -460,21 +457,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
             <IfCondition condition=':= ?COGActive'>
                 
                 <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='ticoOverworldOreSubstitute0' block='minecraft:gravel'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='TConstruct:GravelOre:0' />
-                    <Replaces block='TConstruct:GravelOre:1' />
-                    <Replaces block='TConstruct:GravelOre:2' />
-                    <Replaces block='TConstruct:GravelOre:3' />
-                    <Replaces block='TConstruct:GravelOre:4' />
-                    <Replaces block='TConstruct:GravelOre:5' />
-                </Substitute>
-                <Substitute name='ticoOverworldOreSubstitute1' block='minecraft:stone'>
+                <Substitute name='ticoOverworldOreSubstitute0' block='minecraft:stone'>
                     <Description>
                         Replace vanilla-generated ore clusters.
                     </Description>
@@ -485,6 +468,19 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     <Replaces block='TConstruct:SearedBrick:4' />
                     <Replaces block='TConstruct:SearedBrick:5' />
                 </Substitute>
+                <Substitute name='ticoOverworldOreSubstitute1' block='minecraft:stone'>
+                    <Description>
+                        Replace vanilla-generated ore clusters.
+                    </Description>
+                    <Comment>
+                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
+                    </Comment>
+                    <Replaces block='TConstruct:GravelOre' />
+                    <Replaces block='TConstruct:GravelOre:1' />
+                    <Replaces block='TConstruct:GravelOre:2' />
+                    <Replaces block='TConstruct:GravelOre:3' />
+                    <Replaces block='TConstruct:GravelOre:4' />
+                </Substitute>
                 <!-- Original Overworld Ore Removal Complete -->
                 
                 <!-- Adding ores --> 
@@ -494,14 +490,15 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin LayeredVeins distribution of Copper -->
                 <IfCondition condition=':= ticoCopperDist = "layeredVeins"'>
                 
-                    <Veins name='ticoCopperBaseVeins' block='TConstruct:SearedBrick:3' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoCopperBaseVeins' block='TConstruct:SearedBrick:3'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * ticoCopperSize * _default_' range=':= 1 * 0.8 * ticoCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 40' range=':= 20' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 40' range=':= 20' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * ticoCopperSize * _default_' range=':= 1 * 0.8 * ticoCopperSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * ticoCopperFreq * _default_'/>
@@ -512,7 +509,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='ticoCopperPrefersVeins' block='TConstruct:SearedBrick:3' inherits='ticoCopperBaseVeins'>
+                    <Veins name='ticoCopperPrefersVeins' block='TConstruct:SearedBrick:3'  inherits='ticoCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -530,16 +527,26 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Copper -->
                 <IfCondition condition=':= ticoCopperDist = "hugeVeins"'>
                 
-                    <Veins name='ticoCopperBaseVeins' block='TConstruct:SearedBrick:3' inherits='PresetHugeVeins'>
+                    <Veins name='ticoCopperBaseVeins' block='TConstruct:SearedBrick:3'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -555,7 +562,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                    <Veins name='ticoCopperPrefersVeins' block='TConstruct:SearedBrick:3' inherits='ticoCopperBaseVeins'>
+                    <Veins name='ticoCopperPrefersVeins' block='TConstruct:SearedBrick:3'  inherits='ticoCopperBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -575,12 +582,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 
                     <Cloud name='ticoCopperBaseCloud' block='TConstruct:SearedBrick:3' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -595,10 +606,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <!-- Begin Copper Strategic Cloud Hint Veins -->
                         <Veins name='ticoCopperBaseHintVeins' block='TConstruct:SearedBrick:3' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -642,14 +659,15 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin LayeredVeins distribution of Tin -->
                 <IfCondition condition=':= ticoTinDist = "layeredVeins"'>
                 
-                    <Veins name='ticoTinBaseVeins' block='TConstruct:SearedBrick:4' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoTinBaseVeins' block='TConstruct:SearedBrick:4'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * ticoTinSize * _default_' range=':= 1 * 0.8 * ticoTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * ticoTinSize * _default_' range=':= 1 * 0.8 * ticoTinSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * ticoTinFreq * _default_'/>
@@ -660,7 +678,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='ticoTinPrefersVeins' block='TConstruct:SearedBrick:4' inherits='ticoTinBaseVeins'>
+                    <Veins name='ticoTinPrefersVeins' block='TConstruct:SearedBrick:4'  inherits='ticoTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -678,16 +696,26 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Tin -->
                 <IfCondition condition=':= ticoTinDist = "hugeVeins"'>
                 
-                    <Veins name='ticoTinBaseVeins' block='TConstruct:SearedBrick:4' inherits='PresetHugeVeins'>
+                    <Veins name='ticoTinBaseVeins' block='TConstruct:SearedBrick:4'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -703,7 +731,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                    <Veins name='ticoTinPrefersVeins' block='TConstruct:SearedBrick:4' inherits='ticoTinBaseVeins'>
+                    <Veins name='ticoTinPrefersVeins' block='TConstruct:SearedBrick:4'  inherits='ticoTinBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -723,12 +751,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 
                     <Cloud name='ticoTinBaseCloud' block='TConstruct:SearedBrick:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -743,10 +775,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <!-- Begin Tin Strategic Cloud Hint Veins -->
                         <Veins name='ticoTinBaseHintVeins' block='TConstruct:SearedBrick:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -790,14 +828,15 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin LayeredVeins distribution of Aluminum -->
                 <IfCondition condition=':= ticoAluminumDist = "layeredVeins"'>
                 
-                    <Veins name='ticoAluminumBaseVeins' block='TConstruct:SearedBrick:5' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoAluminumBaseVeins' block='TConstruct:SearedBrick:5'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EDEDED</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.6 * ticoAluminumSize * _default_' range=':= 1 * 0.6 * ticoAluminumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.6 * ticoAluminumSize * _default_' range=':= 1 * 0.6 * ticoAluminumSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * ticoAluminumFreq * _default_'/>
@@ -808,7 +847,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Aluminum Layered Veins) Settings -->
-                    <Veins name='ticoAluminumPrefersVeins' block='TConstruct:SearedBrick:5' inherits='ticoAluminumBaseVeins'>
+                    <Veins name='ticoAluminumPrefersVeins' block='TConstruct:SearedBrick:5'  inherits='ticoAluminumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -826,16 +865,26 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Aluminum -->
                 <IfCondition condition=':= ticoAluminumDist = "hugeVeins"'>
                 
-                    <Veins name='ticoAluminumBaseVeins' block='TConstruct:SearedBrick:5' inherits='PresetHugeVeins'>
+                    <Veins name='ticoAluminumBaseVeins' block='TConstruct:SearedBrick:5'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EDEDED</WireframeColor>
@@ -851,7 +900,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Aluminum Huge Veins) Settings -->
-                    <Veins name='ticoAluminumPrefersVeins' block='TConstruct:SearedBrick:5' inherits='ticoAluminumBaseVeins'>
+                    <Veins name='ticoAluminumPrefersVeins' block='TConstruct:SearedBrick:5'  inherits='ticoAluminumBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -871,12 +920,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 
                     <Cloud name='ticoAluminumBaseCloud' block='TConstruct:SearedBrick:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EDEDED</WireframeColor>
@@ -891,10 +944,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <!-- Begin Aluminum Strategic Cloud Hint Veins -->
                         <Veins name='ticoAluminumBaseHintVeins' block='TConstruct:SearedBrick:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60EDEDED</WireframeColor>
@@ -938,14 +997,15 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin LayeredVeins distribution of Iron Gravel -->
                 <IfCondition condition=':= ticoIronGravelDist = "layeredVeins"'>
                 
-                    <Veins name='ticoIronGravelBaseVeins' block='TConstruct:GravelOre' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoIronGravelBaseVeins' block='TConstruct:GravelOre'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoIronGravelSize * _default_' range=':= 1 * 1 * ticoIronGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoIronGravelSize * _default_' range=':= 1 * 1 * ticoIronGravelSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoIronGravelFreq * _default_'/>
@@ -953,7 +1013,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Iron Gravel Layered Veins) Settings -->
-                    <Veins name='ticoIronGravelPrefersVeins' block='TConstruct:GravelOre' inherits='ticoIronGravelBaseVeins'>
+                    <Veins name='ticoIronGravelPrefersVeins' block='TConstruct:GravelOre'  inherits='ticoIronGravelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -971,16 +1031,26 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Iron Gravel -->
                 <IfCondition condition=':= ticoIronGravelDist = "hugeVeins"'>
                 
-                    <Veins name='ticoIronGravelBaseVeins' block='TConstruct:GravelOre' inherits='PresetHugeVeins'>
+                    <Veins name='ticoIronGravelBaseVeins' block='TConstruct:GravelOre'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -993,7 +1063,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Iron Gravel Huge Veins) Settings -->
-                    <Veins name='ticoIronGravelPrefersVeins' block='TConstruct:GravelOre' inherits='ticoIronGravelBaseVeins'>
+                    <Veins name='ticoIronGravelPrefersVeins' block='TConstruct:GravelOre'  inherits='ticoIronGravelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1013,12 +1083,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 
                     <Cloud name='ticoIronGravelBaseCloud' block='TConstruct:GravelOre' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -1033,10 +1107,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <!-- Begin Iron Gravel Strategic Cloud Hint Veins -->
                         <Veins name='ticoIronGravelBaseHintVeins' block='TConstruct:GravelOre' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -1080,14 +1160,15 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin LayeredVeins distribution of Gold Gravel -->
                 <IfCondition condition=':= ticoGoldGravelDist = "layeredVeins"'>
                 
-                    <Veins name='ticoGoldGravelBaseVeins' block='TConstruct:GravelOre:1' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoGoldGravelBaseVeins' block='TConstruct:GravelOre:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * ticoGoldGravelSize * _default_' range=':= 1 * 0.8 * ticoGoldGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 0.8 * ticoGoldGravelSize * _default_' range=':= 1 * 0.8 * ticoGoldGravelSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 0.85 * ticoGoldGravelFreq * _default_'/>
@@ -1095,7 +1176,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Gold Gravel Layered Veins) Settings -->
-                    <Veins name='ticoGoldGravelPrefersVeins' block='TConstruct:GravelOre:1' inherits='ticoGoldGravelBaseVeins'>
+                    <Veins name='ticoGoldGravelPrefersVeins' block='TConstruct:GravelOre:1'  inherits='ticoGoldGravelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1113,16 +1194,26 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Gold Gravel -->
                 <IfCondition condition=':= ticoGoldGravelDist = "hugeVeins"'>
                 
-                    <Veins name='ticoGoldGravelBaseVeins' block='TConstruct:GravelOre:1' inherits='PresetHugeVeins'>
+                    <Veins name='ticoGoldGravelBaseVeins' block='TConstruct:GravelOre:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
@@ -1135,7 +1226,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Gold Gravel Huge Veins) Settings -->
-                    <Veins name='ticoGoldGravelPrefersVeins' block='TConstruct:GravelOre:1' inherits='ticoGoldGravelBaseVeins'>
+                    <Veins name='ticoGoldGravelPrefersVeins' block='TConstruct:GravelOre:1'  inherits='ticoGoldGravelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1155,12 +1246,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 
                     <Cloud name='ticoGoldGravelBaseCloud' block='TConstruct:GravelOre:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
@@ -1175,10 +1270,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <!-- Begin Gold Gravel Strategic Cloud Hint Veins -->
                         <Veins name='ticoGoldGravelBaseHintVeins' block='TConstruct:GravelOre:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60EAEF57</WireframeColor>
@@ -1222,14 +1323,15 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin LayeredVeins distribution of Copper Gravel -->
                 <IfCondition condition=':= ticoCopperGravelDist = "layeredVeins"'>
                 
-                    <Veins name='ticoCopperGravelBaseVeins' block='TConstruct:GravelOre:2' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoCopperGravelBaseVeins' block='TConstruct:GravelOre:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoCopperGravelSize * _default_' range=':= 1 * 1 * ticoCopperGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoCopperGravelSize * _default_' range=':= 1 * 1 * ticoCopperGravelSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoCopperGravelFreq * _default_'/>
@@ -1237,7 +1339,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Gravel Layered Veins) Settings -->
-                    <Veins name='ticoCopperGravelPrefersVeins' block='TConstruct:GravelOre:2' inherits='ticoCopperGravelBaseVeins'>
+                    <Veins name='ticoCopperGravelPrefersVeins' block='TConstruct:GravelOre:2'  inherits='ticoCopperGravelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1255,16 +1357,26 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Copper Gravel -->
                 <IfCondition condition=':= ticoCopperGravelDist = "hugeVeins"'>
                 
-                    <Veins name='ticoCopperGravelBaseVeins' block='TConstruct:GravelOre:2' inherits='PresetHugeVeins'>
+                    <Veins name='ticoCopperGravelBaseVeins' block='TConstruct:GravelOre:2'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -1277,7 +1389,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Copper Gravel Huge Veins) Settings -->
-                    <Veins name='ticoCopperGravelPrefersVeins' block='TConstruct:GravelOre:2' inherits='ticoCopperGravelBaseVeins'>
+                    <Veins name='ticoCopperGravelPrefersVeins' block='TConstruct:GravelOre:2'  inherits='ticoCopperGravelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1297,12 +1409,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 
                     <Cloud name='ticoCopperGravelBaseCloud' block='TConstruct:GravelOre:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -1317,10 +1433,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <!-- Begin Copper Gravel Strategic Cloud Hint Veins -->
                         <Veins name='ticoCopperGravelBaseHintVeins' block='TConstruct:GravelOre:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60FF8E2B</WireframeColor>
@@ -1364,14 +1486,15 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin LayeredVeins distribution of Tin Gravel -->
                 <IfCondition condition=':= ticoTinGravelDist = "layeredVeins"'>
                 
-                    <Veins name='ticoTinGravelBaseVeins' block='TConstruct:GravelOre:3' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoTinGravelBaseVeins' block='TConstruct:GravelOre:3'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoTinGravelSize * _default_' range=':= 1 * 1 * ticoTinGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoTinGravelSize * _default_' range=':= 1 * 1 * ticoTinGravelSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoTinGravelFreq * _default_'/>
@@ -1379,7 +1502,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Gravel Layered Veins) Settings -->
-                    <Veins name='ticoTinGravelPrefersVeins' block='TConstruct:GravelOre:3' inherits='ticoTinGravelBaseVeins'>
+                    <Veins name='ticoTinGravelPrefersVeins' block='TConstruct:GravelOre:3'  inherits='ticoTinGravelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1397,16 +1520,26 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Tin Gravel -->
                 <IfCondition condition=':= ticoTinGravelDist = "hugeVeins"'>
                 
-                    <Veins name='ticoTinGravelBaseVeins' block='TConstruct:GravelOre:3' inherits='PresetHugeVeins'>
+                    <Veins name='ticoTinGravelBaseVeins' block='TConstruct:GravelOre:3'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -1419,7 +1552,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Tin Gravel Huge Veins) Settings -->
-                    <Veins name='ticoTinGravelPrefersVeins' block='TConstruct:GravelOre:3' inherits='ticoTinGravelBaseVeins'>
+                    <Veins name='ticoTinGravelPrefersVeins' block='TConstruct:GravelOre:3'  inherits='ticoTinGravelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1439,12 +1572,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 
                     <Cloud name='ticoTinGravelBaseCloud' block='TConstruct:GravelOre:3' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -1459,10 +1596,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <!-- Begin Tin Gravel Strategic Cloud Hint Veins -->
                         <Veins name='ticoTinGravelBaseHintVeins' block='TConstruct:GravelOre:3' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60E8E8E8</WireframeColor>
@@ -1506,14 +1649,15 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin LayeredVeins distribution of Aluminum Gravel -->
                 <IfCondition condition=':= ticoAluminumGravelDist = "layeredVeins"'>
                 
-                    <Veins name='ticoAluminumGravelBaseVeins' block='TConstruct:GravelOre:4' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoAluminumGravelBaseVeins' block='TConstruct:GravelOre:4'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EDEDED</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoAluminumGravelSize * _default_' range=':= 1 * 1 * ticoAluminumGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoAluminumGravelSize * _default_' range=':= 1 * 1 * ticoAluminumGravelSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoAluminumGravelFreq * _default_'/>
@@ -1521,7 +1665,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Aluminum Gravel Layered Veins) Settings -->
-                    <Veins name='ticoAluminumGravelPrefersVeins' block='TConstruct:GravelOre:4' inherits='ticoAluminumGravelBaseVeins'>
+                    <Veins name='ticoAluminumGravelPrefersVeins' block='TConstruct:GravelOre:4'  inherits='ticoAluminumGravelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1539,16 +1683,26 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Aluminum Gravel -->
                 <IfCondition condition=':= ticoAluminumGravelDist = "hugeVeins"'>
                 
-                    <Veins name='ticoAluminumGravelBaseVeins' block='TConstruct:GravelOre:4' inherits='PresetHugeVeins'>
+                    <Veins name='ticoAluminumGravelBaseVeins' block='TConstruct:GravelOre:4'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EDEDED</WireframeColor>
@@ -1561,7 +1715,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Veins>
                     
                     <!-- Begin Preferred Biome Distribution (Aluminum Gravel Huge Veins) Settings -->
-                    <Veins name='ticoAluminumGravelPrefersVeins' block='TConstruct:GravelOre:4' inherits='ticoAluminumGravelBaseVeins'>
+                    <Veins name='ticoAluminumGravelPrefersVeins' block='TConstruct:GravelOre:4'  inherits='ticoAluminumGravelBaseVeins' >
                         <Description>
                             Spawns 2 more times in preferred biomes.
                         </Description>
@@ -1581,12 +1735,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 
                     <Cloud name='ticoAluminumGravelBaseCloud' block='TConstruct:GravelOre:4' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EDEDED</WireframeColor>
@@ -1601,10 +1759,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <!-- Begin Aluminum Gravel Strategic Cloud Hint Veins -->
                         <Veins name='ticoAluminumGravelBaseHintVeins' block='TConstruct:GravelOre:4' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60EDEDED</WireframeColor>
@@ -1651,21 +1815,7 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
             <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
                 
                 <!-- Starting Original Nether Ore Removal -->
-                <Substitute name='ticoNetherOreSubstitute0' block='minecraft:gravel'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='TConstruct:GravelOre:0' />
-                    <Replaces block='TConstruct:GravelOre:1' />
-                    <Replaces block='TConstruct:GravelOre:2' />
-                    <Replaces block='TConstruct:GravelOre:3' />
-                    <Replaces block='TConstruct:GravelOre:4' />
-                    <Replaces block='TConstruct:GravelOre:5' />
-                </Substitute>
-                <Substitute name='ticoNetherOreSubstitute1' block='minecraft:netherrack'>
+                <Substitute name='ticoNetherOreSubstitute0' block='minecraft:netherrack'>
                     <Description>
                         Replace vanilla-generated ore clusters.
                     </Description>
@@ -1674,6 +1824,15 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                     </Comment>
                     <Replaces block='TConstruct:SearedBrick:1' />
                     <Replaces block='TConstruct:SearedBrick:2' />
+                </Substitute>
+                <Substitute name='ticoNetherOreSubstitute1' block='minecraft:netherrack'>
+                    <Description>
+                        Replace vanilla-generated ore clusters.
+                    </Description>
+                    <Comment>
+                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
+                    </Comment>
+                    <Replaces block='TConstruct:GravelOre:5' />
                 </Substitute>
                 <!-- Original Nether Ore Removal Complete -->
                 
@@ -1684,14 +1843,15 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin LayeredVeins distribution of Cobalt -->
                 <IfCondition condition=':= ticoCobaltDist = "layeredVeins"'>
                 
-                    <Veins name='ticoCobaltBaseVeins' block='TConstruct:SearedBrick:1' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoCobaltBaseVeins' block='TConstruct:SearedBrick:1'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x601D62B8</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoCobaltSize * _default_' range=':= 1 * 1 * ticoCobaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoCobaltSize * _default_' range=':= 1 * 1 * ticoCobaltSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 0.5 * 1 * ticoCobaltFreq * _default_'/>
@@ -1705,16 +1865,26 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Cobalt -->
                 <IfCondition condition=':= ticoCobaltDist = "hugeVeins"'>
                 
-                    <Veins name='ticoCobaltBaseVeins' block='TConstruct:SearedBrick:1' inherits='PresetHugeVeins'>
+                    <Veins name='ticoCobaltBaseVeins' block='TConstruct:SearedBrick:1'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x601D62B8</WireframeColor>
@@ -1735,12 +1905,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 
                     <Cloud name='ticoCobaltBaseCloud' block='TConstruct:SearedBrick:1' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x601D62B8</WireframeColor>
@@ -1755,10 +1929,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <!-- Begin Cobalt Strategic Cloud Hint Veins -->
                         <Veins name='ticoCobaltBaseHintVeins' block='TConstruct:SearedBrick:1' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x601D62B8</WireframeColor>
@@ -1800,14 +1980,15 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin LayeredVeins distribution of Ardite -->
                 <IfCondition condition=':= ticoArditeDist = "layeredVeins"'>
                 
-                    <Veins name='ticoArditeBaseVeins' block='TConstruct:SearedBrick:2' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoArditeBaseVeins' block='TConstruct:SearedBrick:2'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60F48A00</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoArditeSize * _default_' range=':= 1 * 1 * ticoArditeSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoArditeSize * _default_' range=':= 1 * 1 * ticoArditeSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 0.5 * 1 * ticoArditeFreq * _default_'/>
@@ -1821,16 +2002,26 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Ardite -->
                 <IfCondition condition=':= ticoArditeDist = "hugeVeins"'>
                 
-                    <Veins name='ticoArditeBaseVeins' block='TConstruct:SearedBrick:2' inherits='PresetHugeVeins'>
+                    <Veins name='ticoArditeBaseVeins' block='TConstruct:SearedBrick:2'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60F48A00</WireframeColor>
@@ -1851,12 +2042,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 
                     <Cloud name='ticoArditeBaseCloud' block='TConstruct:SearedBrick:2' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60F48A00</WireframeColor>
@@ -1871,10 +2066,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <!-- Begin Ardite Strategic Cloud Hint Veins -->
                         <Veins name='ticoArditeBaseHintVeins' block='TConstruct:SearedBrick:2' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x60F48A00</WireframeColor>
@@ -1916,14 +2117,15 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin LayeredVeins distribution of Nether Cobalt Gravel -->
                 <IfCondition condition=':= ticoNetherCobaltGravelDist = "layeredVeins"'>
                 
-                    <Veins name='ticoNetherCobaltGravelBaseVeins' block='TConstruct:GravelOre:5' inherits='PresetLayeredVeins'>
+                    <Veins name='ticoNetherCobaltGravelBaseVeins' block='TConstruct:GravelOre:5'  inherits='PresetLayeredVeins' >
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4
+                            horizontal veins each.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x601D62B8</WireframeColor>
                         <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_' range=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                         <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_' range=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_'/>
                         <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                         <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * ticoNetherCobaltGravelFreq * _default_'/>
@@ -1937,16 +2139,26 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 <!-- Begin  Huge Veins distribution of Nether Cobalt Gravel -->
                 <IfCondition condition=':= ticoNetherCobaltGravelDist = "hugeVeins"'>
                 
-                    <Veins name='ticoNetherCobaltGravelBaseVeins' block='TConstruct:GravelOre:5' inherits='PresetHugeVeins'>
+                    <Veins name='ticoNetherCobaltGravelBaseVeins' block='TConstruct:GravelOre:5'  inherits='PresetHugeVeins' >
                         <Description>
-                            Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                            parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                            branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                            enough ore to keep a player supplied for a very long time.
-                            The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                            could make finding them much easier and the motherlodes are big enough to supply several people without
-                            shortage.  This might be a good way to add challenge to multiplayer worlds.
-                            Credit: based on feedback by dyrewulf from the MC forums.
+                            Very large, extremely rare motherlodes.
+                            Each motherlode has many long slender
+                            branches - so thin that parts of the
+                            branch won't contain any ore at all.
+                            This, combined with the incredible length
+                            of the branches, makes them more
+                            challenging to follow underground.  Once
+                            found, however, a motherlode contains
+                            enough ore to keep a player supplied for a
+                            very long time.  The rarity of these veins
+                            might be too frustrating in a single-
+                            player setting.  In SMP, though, teamwork
+                            could make finding them much easier and
+                            the motherlodes are big enough to supply
+                            several people without shortage.  This
+                            might be a good way to add challenge to
+                            multiplayer worlds.  Credit: based on
+                            feedback by dyrewulf from the MC forums.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x601D62B8</WireframeColor>
@@ -1967,12 +2179,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                 
                     <Cloud name='ticoNetherCobaltGravelBaseCloud' block='TConstruct:GravelOre:5' inherits='PresetStrategicCloud'>
                         <Description>
-                            Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                            adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                            ore, but it takes some time and effort to mine due to low density.
-                            The intent for strategic clouds is that the player will need to actively search for
-                            one and then set up a semi-permanent mining base and spend some time actually mining
-                            the ore.
+                            Large irregular clouds filled lightly with
+                            ore.  These are huge, spanning several
+                            adjacent chunks, and consequently rather
+                            rare.  They contain a sizeable amount of
+                            ore, but it takes some time and effort to
+                            mine due to low density.  The intent for
+                            strategic clouds is that the player will
+                            need to actively search for one and then
+                            set up a semi-permanent mining base and
+                            spend some time actually mining the ore.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x601D62B8</WireframeColor>
@@ -1987,10 +2203,16 @@ Gravel, Aluminum Gravel, Cobalt, Ardite, Nether Cobalt Gravel
                         <!-- Begin Nether Cobalt Gravel Strategic Cloud Hint Veins -->
                         <Veins name='ticoNetherCobaltGravelBaseHintVeins' block='TConstruct:GravelOre:5' inherits='PresetHintVeins'>
                             <Description>
-                                Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                                They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                                to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                                deposits that would otherwise be very difficult to find. 
+                                Single blocks, generously scattered
+                                through all heights (density is about
+                                that of vanilla iron ore).  They will
+                                replace dirt and sandstone (but not
+                                grass or sand), so they can be found
+                                nearer to the surface than most ores.
+                                Intened to be used as a child
+                                distribution for large, rare strategic
+                                deposits that would otherwise be very
+                                difficult to find.
                             </Description>
                             <DrawWireframe>:=drawWireframes</DrawWireframe>
                             <WireframeColor>0x601D62B8</WireframeColor>

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -1,13 +1,9 @@
-
-<!-- ================================================================ 
-
-Custom Ore Generation:   Vanilla Minecraft Module
-
-Generates: 
-Clay, Coal, Iron, Gold, Redstone, Diamond, Lapis Lazuli, Emerald,
-Nether Quartz
-
-================================================================ -->
+ <!-- ================================================================
+      Custom Ore Generation "Vanilla Minecraft" Module: This
+      configuration covers clay, coal, iron, gold, redstone, diamond,
+      lapis lazuli, emerald, and  nether quartz.
+      ================================================================
+      -->
 
     <!-- Starting Configuration for Custom Ore Generation. -->
     <ConfigSection>
@@ -391,7 +387,7 @@ Nether Quartz
                 <Comment>
                     The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                 </Comment>
-                <Replaces block='minecraft:clay:0' />
+                <Replaces block='minecraft:clay' />
             </Substitute>
             <Substitute name='vnlaOverworldOreSubstitute1' block='minecraft:stone'>
                 <Description>
@@ -400,13 +396,13 @@ Nether Quartz
                 <Comment>
                     The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                 </Comment>
-                <Replaces block='minecraft:coal_ore:0' />
-                <Replaces block='minecraft:iron_ore:0' />
-                <Replaces block='minecraft:gold_ore:0' />
-                <Replaces block='minecraft:redstone_ore:0' />
-                <Replaces block='minecraft:diamond_ore:0' />
-                <Replaces block='minecraft:lapis_ore:0' />
-                <Replaces block='minecraft:emerald_ore:0' />
+                <Replaces block='minecraft:coal_ore' />
+                <Replaces block='minecraft:iron_ore' />
+                <Replaces block='minecraft:gold_ore' />
+                <Replaces block='minecraft:redstone_ore' />
+                <Replaces block='minecraft:diamond_ore' />
+                <Replaces block='minecraft:lapis_ore' />
+                <Replaces block='minecraft:emerald_ore' />
             </Substitute>
             <!-- Original Overworld Ore Removal Complete -->
             
@@ -417,27 +413,27 @@ Nether Quartz
             <!-- Begin LayeredVeins distribution of Clay -->
             <IfCondition condition=':= vnlaClayDist = "layeredVeins"'>
             
-                <Veins name='vnlaClayBaseVeins' block='minecraft:clay' inherits='PresetLayeredVeins'>
+                <Veins name='vnlaClayBaseVeins' block='minecraft:clay'  inherits='PresetLayeredVeins' >
                     <Description>
-                        Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        Small, fairly rare motherlodes with 2-4
+                        horizontal veins each.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60A5A9B9</WireframeColor>
                     <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaClaySize * _default_' range=':= 1 * 1 * vnlaClaySize * _default_'/>
-                    <Setting name='MotherlodeHeight' avg=':= 64' range=':= 16' type='normal' scaleTo='SeaLevel'/> 
+                    <Setting name='MotherlodeHeight' avg=':= 64' range=':= 16' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaClaySize * _default_' range=':= 1 * 1 * vnlaClaySize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 2 * 1 * vnlaClayFreq * _default_'/>
+                    <Biome name='.*' />
+                    <BiomeType name='Desert' weight='-1'/>
                     <Replaces block='minecraft:sand'/>
                     <Replaces block='minecraft:gravel'/>
                     <Replaces block='minecraft:dirt'/>
-                    <BiomeType name='desert' weight='-1'/>
-                    <BiomeType name='nether' weight='-1'/>
-                    <BiomeType name='end' weight='-1'/>
                 </Veins>
                 
                 <!-- Begin Preferred Biome Distribution (Clay Layered Veins) Settings -->
-                <Veins name='vnlaClayPrefersVeins' block='minecraft:clay' inherits='vnlaClayBaseVeins'>
+                <Veins name='vnlaClayPrefersVeins' block='minecraft:clay'  inherits='vnlaClayBaseVeins' >
                     <Description>
                         Spawns 4 more times in preferred biomes.
                     </Description>
@@ -458,27 +454,27 @@ Nether Quartz
             <!-- Begin  Small Deposits distribution of Clay -->
             <IfCondition condition=':= vnlaClayDist = "smallDeposits"'>
             
-                <Veins name='vnlaClayBaseVeins' block='minecraft:clay' inherits='PresetSmallDeposits'>
+                <Veins name='vnlaClayBaseVeins' block='minecraft:clay'  inherits='PresetSmallDeposits' >
                     <Description>
-                        Small motherlodes without any branches.
-                        Similar to the deposits produced by StandardGen distributions.
+                        Small motherlodes with no veins; similar to
+                        vanilla clusters.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60A5A9B9</WireframeColor>
-                    <Setting name='MotherlodeHeight' avg=':= 64' range=':= 16' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaClaySize * _default_' range=':= 1 * 1 * vnlaClaySize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 64' range=':= 16' type='normal' scaleTo='SeaLevel' /> 
+                    <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaClaySize * _default_' range=':= 1 * 1 * vnlaClaySize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 2 * 1 * vnlaClayFreq * _default_'/>
+                    <Biome name='.*' />
+                    <BiomeType name='Desert' weight='-1'/>
                     <Replaces block='minecraft:sand'/>
                     <Replaces block='minecraft:gravel'/>
                     <Replaces block='minecraft:dirt'/>
-                    <BiomeType name='desert' weight='-1'/>
-                    <BiomeType name='nether' weight='-1'/>
-                    <BiomeType name='end' weight='-1'/>
                 </Veins>
                 
-                <!-- Begin Preferred Biome Distribution (Clay Small Deposits) Settings -->
-                <Veins name='vnlaClayPrefersVeins' block='minecraft:clay' inherits='vnlaClayBaseVeins'>
+                <!-- Begin Preferred Biome Distribution (Clay Deposit Veins) Settings -->
+                <Veins name='vnlaClayPrefersVeins' block='minecraft:clay'  inherits='vnlaClayBaseVeins' >
                     <Description>
                         Spawns 4 more times in preferred biomes.
                     </Description>
@@ -490,7 +486,7 @@ Nether Quartz
                     <BiomeType name='swamp'/>
                     <BiomeType name='beach'/>
                 </Veins>
-                <!-- End Preferred Biome Distribution (Clay Small Deposits) Settings -->
+                <!-- End Preferred Biome Distribution (Clay Deposit Veins) Settings -->
             
             </IfCondition>
             <!-- End  Small Deposits distribution of Clay -->
@@ -503,17 +499,21 @@ Nether Quartz
             <!-- Begin SparseVeins distribution of Coal -->
             <IfCondition condition=':= vnlaCoalDist = "sparseVeins"'>
             
-                <Veins name='vnlaCoalBaseVeins' block='minecraft:coal_ore' inherits='PresetSparseVeins'>
+                <Veins name='vnlaCoalBaseVeins' block='minecraft:coal_ore'  inherits='PresetSparseVeins' >
                     <Description>
-                        Large veins filled very lightly with ore.  Because they contain less ore per volume, 
-                        these veins are relatively wide and long.  Mining the ore from them is time consuming 
-                        compared to solid ore veins.  They are also more difficult to follow, since it is 
-                        harder to get an idea of their direction while mining.
+                        Large veins filled very lightly with ore.
+                        Because they contain less ore per volume,
+                        these veins are relatively wide and long.
+                        Mining the ore from them is time consuming
+                        compared to solid ore veins.  They are also
+                        more difficult to follow, since it is harder
+                        to get an idea of their direction while
+                        mining.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x602A2A2A</WireframeColor>
                     <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaCoalSize * _default_' range=':= 1 * 1 * vnlaCoalSize * _default_'/>
-                    <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' />
+                    <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaCoalSize * _default_' range=':= 1 * 1 * vnlaCoalSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * vnlaCoalFreq * _default_'/>
@@ -524,7 +524,7 @@ Nether Quartz
                 </Veins>
                 
                 <!-- Begin Preferred Biome Distribution (Coal Sparse Veins) Settings -->
-                <Veins name='vnlaCoalPrefersVeins' block='minecraft:coal_ore' inherits='vnlaCoalBaseVeins'>
+                <Veins name='vnlaCoalPrefersVeins' block='minecraft:coal_ore'  inherits='vnlaCoalBaseVeins' >
                     <Description>
                         Spawns 2 more times in preferred biomes.
                     </Description>
@@ -542,22 +542,26 @@ Nether Quartz
             <!-- Begin  Small Deposits distribution of Coal -->
             <IfCondition condition=':= vnlaCoalDist = "smallDeposits"'>
             
-                <Veins name='vnlaCoalBaseVeins' block='minecraft:coal_ore' inherits='PresetSmallDeposits'>
+                <Veins name='vnlaCoalBaseVeins' block='minecraft:coal_ore'  inherits='PresetSmallDeposits' >
                     <Description>
-                        Small motherlodes without any branches.
-                        Similar to the deposits produced by StandardGen distributions.
+                        Small motherlodes with no veins; similar to
+                        vanilla clusters.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x602A2A2A</WireframeColor>
-                    <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaCoalSize * _default_' range=':= 1 * 1 * vnlaCoalSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                    <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaCoalSize * _default_' range=':= 1 * 1 * vnlaCoalSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * vnlaCoalFreq * _default_'/>
+                    <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
+                    <Setting name='BranchHeightLimit' avg=':= 10'/>
+                    <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
                     <Replaces block='minecraft:stone'/>
                 </Veins>
                 
-                <!-- Begin Preferred Biome Distribution (Coal Small Deposits) Settings -->
-                <Veins name='vnlaCoalPrefersVeins' block='minecraft:coal_ore' inherits='vnlaCoalBaseVeins'>
+                <!-- Begin Preferred Biome Distribution (Coal Deposit Veins) Settings -->
+                <Veins name='vnlaCoalPrefersVeins' block='minecraft:coal_ore'  inherits='vnlaCoalBaseVeins' >
                     <Description>
                         Spawns 2 more times in preferred biomes.
                     </Description>
@@ -566,7 +570,7 @@ Nether Quartz
                     <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                     <BiomeType name='Swamp'/>
                 </Veins>
-                <!-- End Preferred Biome Distribution (Coal Small Deposits) Settings -->
+                <!-- End Preferred Biome Distribution (Coal Deposit Veins) Settings -->
             
             </IfCondition>
             <!-- End  Small Deposits distribution of Coal -->
@@ -577,12 +581,16 @@ Nether Quartz
             
                 <Cloud name='vnlaCoalBaseCloud' block='minecraft:coal_ore' inherits='PresetStrategicCloud'>
                     <Description>
-                        Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                        adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                        ore, but it takes some time and effort to mine due to low density.
-                        The intent for strategic clouds is that the player will need to actively search for
-                        one and then set up a semi-permanent mining base and spend some time actually mining
-                        the ore.
+                        Large irregular clouds filled lightly with
+                        ore.  These are huge, spanning several
+                        adjacent chunks, and consequently rather rare.
+                        They contain a sizeable amount of ore, but it
+                        takes some time and effort to mine due to low
+                        density.  The intent for strategic clouds is
+                        that the player will need to actively search
+                        for one and then set up a semi-permanent
+                        mining base and spend some time actually
+                        mining the ore.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x602A2A2A</WireframeColor>
@@ -597,10 +605,15 @@ Nether Quartz
                     <!-- Begin Coal Strategic Cloud Hint Veins -->
                     <Veins name='vnlaCoalBaseHintVeins' block='minecraft:coal_ore' inherits='PresetHintVeins'>
                         <Description>
-                            Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                            They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                            to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                            deposits that would otherwise be very difficult to find. 
+                            Single blocks, generously scattered
+                            through all heights (density is about that
+                            of vanilla iron ore).  They will replace
+                            dirt and sandstone (but not grass or
+                            sand), so they can be found nearer to the
+                            surface than most ores.  Intened to be
+                            used as a child distribution for large,
+                            rare strategic deposits that would
+                            otherwise be very difficult to find.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x602A2A2A</WireframeColor>
@@ -644,14 +657,15 @@ Nether Quartz
             <!-- Begin LayeredVeins distribution of Iron -->
             <IfCondition condition=':= vnlaIronDist = "layeredVeins"'>
             
-                <Veins name='vnlaIronBaseVeins' block='minecraft:iron_ore' inherits='PresetLayeredVeins'>
+                <Veins name='vnlaIronBaseVeins' block='minecraft:iron_ore'  inherits='PresetLayeredVeins' >
                     <Description>
-                        Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        Small, fairly rare motherlodes with 2-4
+                        horizontal veins each.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60DDC2AF</WireframeColor>
                     <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaIronSize * _default_' range=':= 1 * 1 * vnlaIronSize * _default_'/>
-                    <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel'/> 
+                    <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaIronSize * _default_' range=':= 1 * 1 * vnlaIronSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * vnlaIronFreq * _default_'/>
@@ -660,7 +674,7 @@ Nether Quartz
                 </Veins>
                 
                 <!-- Begin Preferred Biome Distribution (Iron Layered Veins) Settings -->
-                <Veins name='vnlaIronPrefersVeins' block='minecraft:iron_ore' inherits='vnlaIronBaseVeins'>
+                <Veins name='vnlaIronPrefersVeins' block='minecraft:iron_ore'  inherits='vnlaIronBaseVeins' >
                     <Description>
                         Spawns 2 more times in preferred biomes.
                     </Description>
@@ -679,22 +693,24 @@ Nether Quartz
             <!-- Begin  Small Deposits distribution of Iron -->
             <IfCondition condition=':= vnlaIronDist = "smallDeposits"'>
             
-                <Veins name='vnlaIronBaseVeins' block='minecraft:iron_ore' inherits='PresetSmallDeposits'>
+                <Veins name='vnlaIronBaseVeins' block='minecraft:iron_ore'  inherits='PresetSmallDeposits' >
                     <Description>
-                        Small motherlodes without any branches.
-                        Similar to the deposits produced by StandardGen distributions.
+                        Small motherlodes with no veins; similar to
+                        vanilla clusters.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60DDC2AF</WireframeColor>
-                    <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaIronSize * _default_' range=':= 1 * 1 * vnlaIronSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
+                    <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaIronSize * _default_' range=':= 1 * 1 * vnlaIronSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * vnlaIronFreq * _default_'/>
+                    <Setting name='BranchHeightLimit' avg=':= 10.5'/>
                     <Replaces block='minecraft:stone'/>
                 </Veins>
                 
-                <!-- Begin Preferred Biome Distribution (Iron Small Deposits) Settings -->
-                <Veins name='vnlaIronPrefersVeins' block='minecraft:iron_ore' inherits='vnlaIronBaseVeins'>
+                <!-- Begin Preferred Biome Distribution (Iron Deposit Veins) Settings -->
+                <Veins name='vnlaIronPrefersVeins' block='minecraft:iron_ore'  inherits='vnlaIronBaseVeins' >
                     <Description>
                         Spawns 2 more times in preferred biomes.
                     </Description>
@@ -704,7 +720,7 @@ Nether Quartz
                     <BiomeType name='Cold'/>
                     <BiomeType name='Ocean' weight='-1'/>
                 </Veins>
-                <!-- End Preferred Biome Distribution (Iron Small Deposits) Settings -->
+                <!-- End Preferred Biome Distribution (Iron Deposit Veins) Settings -->
             
             </IfCondition>
             <!-- End  Small Deposits distribution of Iron -->
@@ -713,16 +729,24 @@ Nether Quartz
             <!-- Begin  Huge Veins distribution of Iron -->
             <IfCondition condition=':= vnlaIronDist = "hugeVeins"'>
             
-                <Veins name='vnlaIronBaseVeins' block='minecraft:iron_ore' inherits='PresetHugeVeins'>
+                <Veins name='vnlaIronBaseVeins' block='minecraft:iron_ore'  inherits='PresetHugeVeins' >
                     <Description>
-                        Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                        parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                        branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                        enough ore to keep a player supplied for a very long time.
-                        The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                        could make finding them much easier and the motherlodes are big enough to supply several people without
-                        shortage.  This might be a good way to add challenge to multiplayer worlds.
-                        Credit: based on feedback by dyrewulf from the MC forums.
+                        Very large, extremely rare motherlodes.  Each
+                        motherlode has many long slender branches - so
+                        thin that parts of the branch won't contain
+                        any ore at all.  This, combined with the
+                        incredible length of the branches, makes them
+                        more challenging to follow underground.  Once
+                        found, however, a motherlode contains enough
+                        ore to keep a player supplied for a very long
+                        time.  The rarity of these veins might be too
+                        frustrating in a single-player setting.  In
+                        SMP, though, teamwork could make finding them
+                        much easier and the motherlodes are big enough
+                        to supply several people without shortage.
+                        This might be a good way to add challenge to
+                        multiplayer worlds.  Credit: based on feedback
+                        by dyrewulf from the MC forums.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -736,7 +760,7 @@ Nether Quartz
                 </Veins>
                 
                 <!-- Begin Preferred Biome Distribution (Iron Huge Veins) Settings -->
-                <Veins name='vnlaIronPrefersVeins' block='minecraft:iron_ore' inherits='vnlaIronBaseVeins'>
+                <Veins name='vnlaIronPrefersVeins' block='minecraft:iron_ore'  inherits='vnlaIronBaseVeins' >
                     <Description>
                         Spawns 2 more times in preferred biomes.
                     </Description>
@@ -757,12 +781,16 @@ Nether Quartz
             
                 <Cloud name='vnlaIronBaseCloud' block='minecraft:iron_ore' inherits='PresetStrategicCloud'>
                     <Description>
-                        Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                        adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                        ore, but it takes some time and effort to mine due to low density.
-                        The intent for strategic clouds is that the player will need to actively search for
-                        one and then set up a semi-permanent mining base and spend some time actually mining
-                        the ore.
+                        Large irregular clouds filled lightly with
+                        ore.  These are huge, spanning several
+                        adjacent chunks, and consequently rather rare.
+                        They contain a sizeable amount of ore, but it
+                        takes some time and effort to mine due to low
+                        density.  The intent for strategic clouds is
+                        that the player will need to actively search
+                        for one and then set up a semi-permanent
+                        mining base and spend some time actually
+                        mining the ore.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -777,10 +805,15 @@ Nether Quartz
                     <!-- Begin Iron Strategic Cloud Hint Veins -->
                     <Veins name='vnlaIronBaseHintVeins' block='minecraft:iron_ore' inherits='PresetHintVeins'>
                         <Description>
-                            Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                            They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                            to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                            deposits that would otherwise be very difficult to find. 
+                            Single blocks, generously scattered
+                            through all heights (density is about that
+                            of vanilla iron ore).  They will replace
+                            dirt and sandstone (but not grass or
+                            sand), so they can be found nearer to the
+                            surface than most ores.  Intened to be
+                            used as a child distribution for large,
+                            rare strategic deposits that would
+                            otherwise be very difficult to find.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DDC2AF</WireframeColor>
@@ -824,14 +857,15 @@ Nether Quartz
             <!-- Begin LayeredVeins distribution of Gold -->
             <IfCondition condition=':= vnlaGoldDist = "layeredVeins"'>
             
-                <Veins name='vnlaGoldBaseVeins' block='minecraft:gold_ore' inherits='PresetLayeredVeins'>
+                <Veins name='vnlaGoldBaseVeins' block='minecraft:gold_ore'  inherits='PresetLayeredVeins' >
                     <Description>
-                        Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        Small, fairly rare motherlodes with 2-4
+                        horizontal veins each.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60EAEF57</WireframeColor>
                     <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * vnlaGoldSize * _default_' range=':= 1 * 0.8 * vnlaGoldSize * _default_'/>
-                    <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel'/> 
+                    <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='SegmentRadius' avg=':= 1 * 0.8 * vnlaGoldSize * _default_' range=':= 1 * 0.8 * vnlaGoldSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * vnlaGoldFreq * _default_'/>
@@ -842,7 +876,7 @@ Nether Quartz
                 </Veins>
                 
                 <!-- Begin Preferred Biome Distribution (Gold Layered Veins) Settings -->
-                <Veins name='vnlaGoldPrefersVeins' block='minecraft:gold_ore' inherits='vnlaGoldBaseVeins'>
+                <Veins name='vnlaGoldPrefersVeins' block='minecraft:gold_ore'  inherits='vnlaGoldBaseVeins' >
                     <Description>
                         Spawns 2 more times in preferred biomes.
                     </Description>
@@ -860,22 +894,26 @@ Nether Quartz
             <!-- Begin  Small Deposits distribution of Gold -->
             <IfCondition condition=':= vnlaGoldDist = "smallDeposits"'>
             
-                <Veins name='vnlaGoldBaseVeins' block='minecraft:gold_ore' inherits='PresetSmallDeposits'>
+                <Veins name='vnlaGoldBaseVeins' block='minecraft:gold_ore'  inherits='PresetSmallDeposits' >
                     <Description>
-                        Small motherlodes without any branches.
-                        Similar to the deposits produced by StandardGen distributions.
+                        Small motherlodes with no veins; similar to
+                        vanilla clusters.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60EAEF57</WireframeColor>
-                    <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * vnlaGoldSize * _default_' range=':= 1 * 0.8 * vnlaGoldSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
+                    <Setting name='SegmentRadius' avg=':= 1 * 0.8 * vnlaGoldSize * _default_' range=':= 1 * 0.8 * vnlaGoldSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * vnlaGoldFreq * _default_'/>
+                    <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
+                    <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
+                    <Setting name='BranchHeightLimit' avg=':= 10'/>
                     <Replaces block='minecraft:stone'/>
                 </Veins>
                 
-                <!-- Begin Preferred Biome Distribution (Gold Small Deposits) Settings -->
-                <Veins name='vnlaGoldPrefersVeins' block='minecraft:gold_ore' inherits='vnlaGoldBaseVeins'>
+                <!-- Begin Preferred Biome Distribution (Gold Deposit Veins) Settings -->
+                <Veins name='vnlaGoldPrefersVeins' block='minecraft:gold_ore'  inherits='vnlaGoldBaseVeins' >
                     <Description>
                         Spawns 2 more times in preferred biomes.
                     </Description>
@@ -884,7 +922,7 @@ Nether Quartz
                     <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                     <BiomeType name='Forest'/>
                 </Veins>
-                <!-- End Preferred Biome Distribution (Gold Small Deposits) Settings -->
+                <!-- End Preferred Biome Distribution (Gold Deposit Veins) Settings -->
             
             </IfCondition>
             <!-- End  Small Deposits distribution of Gold -->
@@ -893,16 +931,24 @@ Nether Quartz
             <!-- Begin  Huge Veins distribution of Gold -->
             <IfCondition condition=':= vnlaGoldDist = "hugeVeins"'>
             
-                <Veins name='vnlaGoldBaseVeins' block='minecraft:gold_ore' inherits='PresetHugeVeins'>
+                <Veins name='vnlaGoldBaseVeins' block='minecraft:gold_ore'  inherits='PresetHugeVeins' >
                     <Description>
-                        Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                        parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                        branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                        enough ore to keep a player supplied for a very long time.
-                        The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                        could make finding them much easier and the motherlodes are big enough to supply several people without
-                        shortage.  This might be a good way to add challenge to multiplayer worlds.
-                        Credit: based on feedback by dyrewulf from the MC forums.
+                        Very large, extremely rare motherlodes.  Each
+                        motherlode has many long slender branches - so
+                        thin that parts of the branch won't contain
+                        any ore at all.  This, combined with the
+                        incredible length of the branches, makes them
+                        more challenging to follow underground.  Once
+                        found, however, a motherlode contains enough
+                        ore to keep a player supplied for a very long
+                        time.  The rarity of these veins might be too
+                        frustrating in a single-player setting.  In
+                        SMP, though, teamwork could make finding them
+                        much easier and the motherlodes are big enough
+                        to supply several people without shortage.
+                        This might be a good way to add challenge to
+                        multiplayer worlds.  Credit: based on feedback
+                        by dyrewulf from the MC forums.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60EAEF57</WireframeColor>
@@ -918,7 +964,7 @@ Nether Quartz
                 </Veins>
                 
                 <!-- Begin Preferred Biome Distribution (Gold Huge Veins) Settings -->
-                <Veins name='vnlaGoldPrefersVeins' block='minecraft:gold_ore' inherits='vnlaGoldBaseVeins'>
+                <Veins name='vnlaGoldPrefersVeins' block='minecraft:gold_ore'  inherits='vnlaGoldBaseVeins' >
                     <Description>
                         Spawns 2 more times in preferred biomes.
                     </Description>
@@ -938,12 +984,16 @@ Nether Quartz
             
                 <Cloud name='vnlaGoldBaseCloud' block='minecraft:gold_ore' inherits='PresetStrategicCloud'>
                     <Description>
-                        Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                        adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                        ore, but it takes some time and effort to mine due to low density.
-                        The intent for strategic clouds is that the player will need to actively search for
-                        one and then set up a semi-permanent mining base and spend some time actually mining
-                        the ore.
+                        Large irregular clouds filled lightly with
+                        ore.  These are huge, spanning several
+                        adjacent chunks, and consequently rather rare.
+                        They contain a sizeable amount of ore, but it
+                        takes some time and effort to mine due to low
+                        density.  The intent for strategic clouds is
+                        that the player will need to actively search
+                        for one and then set up a semi-permanent
+                        mining base and spend some time actually
+                        mining the ore.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60EAEF57</WireframeColor>
@@ -958,10 +1008,15 @@ Nether Quartz
                     <!-- Begin Gold Strategic Cloud Hint Veins -->
                     <Veins name='vnlaGoldBaseHintVeins' block='minecraft:gold_ore' inherits='PresetHintVeins'>
                         <Description>
-                            Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                            They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                            to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                            deposits that would otherwise be very difficult to find. 
+                            Single blocks, generously scattered
+                            through all heights (density is about that
+                            of vanilla iron ore).  They will replace
+                            dirt and sandstone (but not grass or
+                            sand), so they can be found nearer to the
+                            surface than most ores.  Intened to be
+                            used as a child distribution for large,
+                            rare strategic deposits that would
+                            otherwise be very difficult to find.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60EAEF57</WireframeColor>
@@ -1005,35 +1060,24 @@ Nether Quartz
             <!-- Begin VerticalVeins distribution of Redstone -->
             <IfCondition condition=':= vnlaRedstoneDist = "verticalVeins"'>
             
-                <Veins name='vnlaRedstoneBaseParentVeins' block='minecraft:redstone_ore' inherits='PresetVerticalVeins'>
+                <Veins name='vnlaRedstoneBaseVeins' block='minecraft:redstone_ore'  inherits='PresetVerticalVeins' >
                     <Description>
-                        Single vertical veins that occur with no motherlodes.
+                        Single vertical veins that occur with no
+                        motherlodes.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60A80002</WireframeColor>
+                    <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaRedstoneSize * _default_' range=':= 1 * 1 * vnlaRedstoneSize * _default_'/>
                     <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaRedstoneSize * _default_' range=':= 1 * 1 * vnlaRedstoneSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                    <Setting name='MotherlodeFrequency' avg=':=  1 * 0.4 * vnlaRedstoneFreq * _default_'/>
+                    <Setting name='MotherlodeFrequency' avg=':= 1 * 0.4 * vnlaRedstoneFreq * _default_'/>
                     <Replaces block='minecraft:stone'/>
                     <Replaces block='minecraft:sandstone'/>
-                    <Veins name='vnlaRedstoneBaseChildVeins' block='minecraft:redstone_ore' inherits='PresetVerticalVeins'>
-                        <Description>
-                            Single vertical veins that occur with no motherlodes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A80002</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaRedstoneSize * _default_' range=':= 1 * 1 * vnlaRedstoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.4 * vnlaRedstoneFreq * 3 * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:sandstone'/>
-                    </Veins>
                 </Veins>
                 
                 <!-- Begin Preferred Biome Distribution (Redstone Vertical Veins) Settings -->
-                <Veins name='vnlaRedstonePrefersParentVeins' block='minecraft:redstone_ore' inherits='vnlaRedstoneBaseParentVeins'>
+                <Veins name='vnlaRedstonePrefersVeins' block='minecraft:redstone_ore'  inherits='vnlaRedstoneBaseVeins' >
                     <Description>
                         Spawns 2 more times in preferred biomes.
                     </Description>
@@ -1041,15 +1085,6 @@ Nether Quartz
                     <WireframeColor>0x60A80002</WireframeColor>
                     <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                     <BiomeType name='Desert'/>
-                    <Veins name='vnlaRedstonePrefersChildVeins' block='minecraft:redstone_ore' inherits='vnlaRedstoneBaseChildVeins'>
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A80002</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Desert'/>
-                    </Veins>
                 </Veins>
                 <!-- End Preferred Biome Distribution (Redstone Vertical Veins) Settings -->
             
@@ -1060,23 +1095,24 @@ Nether Quartz
             <!-- Begin  Small Deposits distribution of Redstone -->
             <IfCondition condition=':= vnlaRedstoneDist = "smallDeposits"'>
             
-                <Veins name='vnlaRedstoneBaseVeins' block='minecraft:redstone_ore' inherits='PresetSmallDeposits'>
+                <Veins name='vnlaRedstoneBaseVeins' block='minecraft:redstone_ore'  inherits='PresetSmallDeposits' >
                     <Description>
-                        Small motherlodes without any branches.
-                        Similar to the deposits produced by StandardGen distributions.
+                        Small motherlodes with no veins; similar to
+                        vanilla clusters.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60A80002</WireframeColor>
-                    <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaRedstoneSize * _default_' range=':= 1 * 1 * vnlaRedstoneSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
+                    <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaRedstoneSize * _default_' range=':= 1 * 1 * vnlaRedstoneSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 1 * 0.4 * vnlaRedstoneFreq * _default_'/>
                     <Replaces block='minecraft:stone'/>
                     <Replaces block='minecraft:sandstone'/>
                 </Veins>
                 
-                <!-- Begin Preferred Biome Distribution (Redstone Small Deposits) Settings -->
-                <Veins name='vnlaRedstonePrefersVeins' block='minecraft:redstone_ore' inherits='vnlaRedstoneBaseVeins'>
+                <!-- Begin Preferred Biome Distribution (Redstone Deposit Veins) Settings -->
+                <Veins name='vnlaRedstonePrefersVeins' block='minecraft:redstone_ore'  inherits='vnlaRedstoneBaseVeins' >
                     <Description>
                         Spawns 2 more times in preferred biomes.
                     </Description>
@@ -1085,7 +1121,7 @@ Nether Quartz
                     <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                     <BiomeType name='Desert'/>
                 </Veins>
-                <!-- End Preferred Biome Distribution (Redstone Small Deposits) Settings -->
+                <!-- End Preferred Biome Distribution (Redstone Deposit Veins) Settings -->
             
             </IfCondition>
             <!-- End  Small Deposits distribution of Redstone -->
@@ -1096,12 +1132,16 @@ Nether Quartz
             
                 <Cloud name='vnlaRedstoneBaseCloud' block='minecraft:redstone_ore' inherits='PresetStrategicCloud'>
                     <Description>
-                        Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                        adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                        ore, but it takes some time and effort to mine due to low density.
-                        The intent for strategic clouds is that the player will need to actively search for
-                        one and then set up a semi-permanent mining base and spend some time actually mining
-                        the ore.
+                        Large irregular clouds filled lightly with
+                        ore.  These are huge, spanning several
+                        adjacent chunks, and consequently rather rare.
+                        They contain a sizeable amount of ore, but it
+                        takes some time and effort to mine due to low
+                        density.  The intent for strategic clouds is
+                        that the player will need to actively search
+                        for one and then set up a semi-permanent
+                        mining base and spend some time actually
+                        mining the ore.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60A80002</WireframeColor>
@@ -1117,10 +1157,15 @@ Nether Quartz
                     <!-- Begin Redstone Strategic Cloud Hint Veins -->
                     <Veins name='vnlaRedstoneBaseHintVeins' block='minecraft:redstone_ore' inherits='PresetHintVeins'>
                         <Description>
-                            Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                            They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                            to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                            deposits that would otherwise be very difficult to find. 
+                            Single blocks, generously scattered
+                            through all heights (density is about that
+                            of vanilla iron ore).  They will replace
+                            dirt and sandstone (but not grass or
+                            sand), so they can be found nearer to the
+                            surface than most ores.  Intened to be
+                            used as a child distribution for large,
+                            rare strategic deposits that would
+                            otherwise be very difficult to find.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60A80002</WireframeColor>
@@ -1166,34 +1211,31 @@ Nether Quartz
             <!-- Begin PipeVeins distribution of Diamond -->
             <IfCondition condition=':= vnlaDiamondDist = "pipeVeins"'>
             
-                
-                <!-- Begin Diamond Ore Configuration -->
-                <Veins name='vnlaDiamondBaseVeins' block='minecraft:diamond_ore' inherits='PresetPipeVeins' seed='0x197B'>
+                <Veins name='vnlaDiamondBaseVeins' block='minecraft:diamond_ore'  inherits='PresetPipeVeins' seed='0x197B'>
                     <Description>
-                        Short sparsely filled veins sloping up from near the bottom of the map.
+                        Short sparsely filled veins sloping up from
+                        near the bottom of the map.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x608BF4E3</WireframeColor>
                     <Setting name='MotherlodeSize' avg=':= 1 * 0.6 * vnlaDiamondSize * _default_' range=':= 1 * 0.6 * vnlaDiamondSize * _default_'/>
-                    <Setting name='MotherlodeHeight' avg=':= 3' range=':= _default_' type='normal' scaleTo='SeaLevel' />
+                    <Setting name='MotherlodeHeight' avg=':= 3' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='SegmentRadius' avg=':= 1 * 0.6 * vnlaDiamondSize * _default_' range=':= 1 * 0.6 * vnlaDiamondSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * vnlaDiamondFreq * _default_'/>
                     <Replaces block='minecraft:stone'/>
                 </Veins>
-                <!-- End Diamond Ore Configuration -->
                 
-                
-                <!-- Begin Diamond Pipe Configuration -->
-                <Veins name= 'vnlaDiamondBasePipe' block='minecraft:lava' inherits='vnlaDiamondBaseVeins' seed='0x197B'>
+                <!-- Begin Pipe Filling (Diamond Pipe Veins) Settings -->
+                <Veins name='vnlaDiamondPipeVeins' block='minecraft:lava'  inherits='vnlaDiamondBaseVeins' seed='0x197B'>
                     <Description>
-                        Fills center of each tube with Pipe material.
+                        Fills the vein with an additional material
+                        (minecraft:lava).
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x608BF4E3</WireframeColor>
                     <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 0.6 * vnlaDiamondSize * _default_' range=':= 0.5 * 1 * 0.6 * vnlaDiamondSize * _default_'/>
                     <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 0.6 * vnlaDiamondSize * _default_' range=':= 0.5 * 1 * 0.6 * vnlaDiamondSize * _default_'/>
-                    <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Replaces block='minecraft:stone'/>
                     <Replaces block='minecraft:diamond_ore'/>
                     <Replaces block='minecraft:dirt'/>
@@ -1202,8 +1244,7 @@ Nether Quartz
                     <Replaces block='minecraft:netherrack'/>
                     <Replaces block='minecraft:end_stone'/>
                 </Veins>
-                <!-- End Diamond Pipe Configuration -->
-                
+                <!-- End Pipe Filling (Diamond Pipe Veins) Settings -->
             
             </IfCondition>
             <!-- End PipeVeins distribution of Diamond -->
@@ -1212,15 +1253,16 @@ Nether Quartz
             <!-- Begin  Small Deposits distribution of Diamond -->
             <IfCondition condition=':= vnlaDiamondDist = "smallDeposits"'>
             
-                <Veins name='vnlaDiamondBaseVeins' block='minecraft:diamond_ore' inherits='PresetSmallDeposits'>
+                <Veins name='vnlaDiamondBaseVeins' block='minecraft:diamond_ore'  inherits='PresetSmallDeposits' >
                     <Description>
-                        Small motherlodes without any branches.
-                        Similar to the deposits produced by StandardGen distributions.
+                        Small motherlodes with no veins; similar to
+                        vanilla clusters.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x608BF4E3</WireframeColor>
-                    <Setting name='MotherlodeHeight' avg=':= 3' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='MotherlodeSize' avg=':= 1 * 0.6 * vnlaDiamondSize * _default_' range=':= 1 * 0.6 * vnlaDiamondSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 3' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
+                    <Setting name='SegmentRadius' avg=':= 1 * 0.6 * vnlaDiamondSize * _default_' range=':= 1 * 0.6 * vnlaDiamondSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * vnlaDiamondFreq * _default_'/>
                     <Replaces block='minecraft:stone'/>
@@ -1235,12 +1277,16 @@ Nether Quartz
             
                 <Cloud name='vnlaDiamondBaseCloud' block='minecraft:diamond_ore' inherits='PresetStrategicCloud'>
                     <Description>
-                        Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                        adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                        ore, but it takes some time and effort to mine due to low density.
-                        The intent for strategic clouds is that the player will need to actively search for
-                        one and then set up a semi-permanent mining base and spend some time actually mining
-                        the ore.
+                        Large irregular clouds filled lightly with
+                        ore.  These are huge, spanning several
+                        adjacent chunks, and consequently rather rare.
+                        They contain a sizeable amount of ore, but it
+                        takes some time and effort to mine due to low
+                        density.  The intent for strategic clouds is
+                        that the player will need to actively search
+                        for one and then set up a semi-permanent
+                        mining base and spend some time actually
+                        mining the ore.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x608BF4E3</WireframeColor>
@@ -1255,10 +1301,15 @@ Nether Quartz
                     <!-- Begin Diamond Strategic Cloud Hint Veins -->
                     <Veins name='vnlaDiamondBaseHintVeins' block='minecraft:diamond_ore' inherits='PresetHintVeins'>
                         <Description>
-                            Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                            They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                            to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                            deposits that would otherwise be very difficult to find. 
+                            Single blocks, generously scattered
+                            through all heights (density is about that
+                            of vanilla iron ore).  They will replace
+                            dirt and sandstone (but not grass or
+                            sand), so they can be found nearer to the
+                            surface than most ores.  Intened to be
+                            used as a child distribution for large,
+                            rare strategic deposits that would
+                            otherwise be very difficult to find.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x608BF4E3</WireframeColor>
@@ -1300,37 +1351,25 @@ Nether Quartz
             <!-- Begin VerticalVeins distribution of Lapis Lazuli -->
             <IfCondition condition=':= vnlaLapisLazuliDist = "verticalVeins"'>
             
-                <Veins name='vnlaLapisLazuliBaseParentVeins' block='minecraft:lapis_ore' inherits='PresetVerticalVeins'>
+                <Veins name='vnlaLapisLazuliBaseVeins' block='minecraft:lapis_ore'  inherits='PresetVerticalVeins' >
                     <Description>
-                        Single vertical veins that occur with no motherlodes.
+                        Single vertical veins that occur with no
+                        motherlodes.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x601442BA</WireframeColor>
+                    <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaLapisLazuliSize * _default_' range=':= 1 * 1 * vnlaLapisLazuliSize * _default_'/>
                     <Setting name='MotherlodeHeight' avg=':= 8' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaLapisLazuliSize * _default_' range=':= 1 * 1 * vnlaLapisLazuliSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                    <Setting name='MotherlodeFrequency' avg=':=  1 * 0.4 * vnlaLapisLazuliFreq * _default_'/>
+                    <Setting name='MotherlodeFrequency' avg=':= 1 * 0.4 * vnlaLapisLazuliFreq * _default_'/>
                     <Setting name='BranchLength' avg=':= 36/64 * _default_' range=':= 12 * _default_'/>
                     <Setting name='BranchInclination' avg=':= -_default_' range=':= 0'/>
                     <Replaces block='minecraft:stone'/>
-                    <Veins name='vnlaLapisLazuliBaseChildVeins' block='minecraft:lapis_ore' inherits='PresetVerticalVeins'>
-                        <Description>
-                            Single vertical veins that occur with no motherlodes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601442BA</WireframeColor>
-                        <Setting name='MotherlodeHeight' avg=':= 8' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaLapisLazuliSize * _default_' range=':= 1 * 1 * vnlaLapisLazuliSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.4 * vnlaLapisLazuliFreq * 3 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 36/64 * _default_' range=':= 12 * _default_'/>
-                        <Setting name='BranchInclination' avg=':= -_default_' range=':= 0'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
                 </Veins>
                 
                 <!-- Begin Preferred Biome Distribution (Lapis Lazuli Vertical Veins) Settings -->
-                <Veins name='vnlaLapisLazuliPrefersParentVeins' block='minecraft:lapis_ore' inherits='vnlaLapisLazuliBaseParentVeins'>
+                <Veins name='vnlaLapisLazuliPrefersVeins' block='minecraft:lapis_ore'  inherits='vnlaLapisLazuliBaseVeins' >
                     <Description>
                         Spawns 2 more times in preferred biomes.
                     </Description>
@@ -1338,15 +1377,6 @@ Nether Quartz
                     <WireframeColor>0x601442BA</WireframeColor>
                     <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                     <BiomeType name='Ocean'/>
-                    <Veins name='vnlaLapisLazuliPrefersChildVeins' block='minecraft:lapis_ore' inherits='vnlaLapisLazuliBaseChildVeins'>
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601442BA</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Ocean'/>
-                    </Veins>
                 </Veins>
                 <!-- End Preferred Biome Distribution (Lapis Lazuli Vertical Veins) Settings -->
             
@@ -1357,22 +1387,25 @@ Nether Quartz
             <!-- Begin  Small Deposits distribution of Lapis Lazuli -->
             <IfCondition condition=':= vnlaLapisLazuliDist = "smallDeposits"'>
             
-                <Veins name='vnlaLapisLazuliBaseVeins' block='minecraft:lapis_ore' inherits='PresetSmallDeposits'>
+                <Veins name='vnlaLapisLazuliBaseVeins' block='minecraft:lapis_ore'  inherits='PresetSmallDeposits' >
                     <Description>
-                        Small motherlodes without any branches.
-                        Similar to the deposits produced by StandardGen distributions.
+                        Small motherlodes with no veins; similar to
+                        vanilla clusters.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x601442BA</WireframeColor>
-                    <Setting name='MotherlodeHeight' avg=':= 8' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaLapisLazuliSize * _default_' range=':= 1 * 1 * vnlaLapisLazuliSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 8' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
+                    <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaLapisLazuliSize * _default_' range=':= 1 * 1 * vnlaLapisLazuliSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 1 * 0.4 * vnlaLapisLazuliFreq * _default_'/>
+                    <Setting name='BranchLength' avg=':= 36/64 * _default_' range=':= 12 * _default_'/>
+                    <Setting name='BranchInclination' avg=':= -_default_' range=':= 0'/>
                     <Replaces block='minecraft:stone'/>
                 </Veins>
                 
-                <!-- Begin Preferred Biome Distribution (Lapis Lazuli Small Deposits) Settings -->
-                <Veins name='vnlaLapisLazuliPrefersVeins' block='minecraft:lapis_ore' inherits='vnlaLapisLazuliBaseVeins'>
+                <!-- Begin Preferred Biome Distribution (Lapis Lazuli Deposit Veins) Settings -->
+                <Veins name='vnlaLapisLazuliPrefersVeins' block='minecraft:lapis_ore'  inherits='vnlaLapisLazuliBaseVeins' >
                     <Description>
                         Spawns 2 more times in preferred biomes.
                     </Description>
@@ -1381,7 +1414,7 @@ Nether Quartz
                     <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
                     <BiomeType name='Ocean'/>
                 </Veins>
-                <!-- End Preferred Biome Distribution (Lapis Lazuli Small Deposits) Settings -->
+                <!-- End Preferred Biome Distribution (Lapis Lazuli Deposit Veins) Settings -->
             
             </IfCondition>
             <!-- End  Small Deposits distribution of Lapis Lazuli -->
@@ -1392,12 +1425,16 @@ Nether Quartz
             
                 <Cloud name='vnlaLapisLazuliBaseCloud' block='minecraft:lapis_ore' inherits='PresetStrategicCloud'>
                     <Description>
-                        Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                        adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                        ore, but it takes some time and effort to mine due to low density.
-                        The intent for strategic clouds is that the player will need to actively search for
-                        one and then set up a semi-permanent mining base and spend some time actually mining
-                        the ore.
+                        Large irregular clouds filled lightly with
+                        ore.  These are huge, spanning several
+                        adjacent chunks, and consequently rather rare.
+                        They contain a sizeable amount of ore, but it
+                        takes some time and effort to mine due to low
+                        density.  The intent for strategic clouds is
+                        that the player will need to actively search
+                        for one and then set up a semi-permanent
+                        mining base and spend some time actually
+                        mining the ore.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x601442BA</WireframeColor>
@@ -1412,10 +1449,15 @@ Nether Quartz
                     <!-- Begin Lapis Lazuli Strategic Cloud Hint Veins -->
                     <Veins name='vnlaLapisLazuliBaseHintVeins' block='minecraft:lapis_ore' inherits='PresetHintVeins'>
                         <Description>
-                            Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                            They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                            to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                            deposits that would otherwise be very difficult to find. 
+                            Single blocks, generously scattered
+                            through all heights (density is about that
+                            of vanilla iron ore).  They will replace
+                            dirt and sandstone (but not grass or
+                            sand), so they can be found nearer to the
+                            surface than most ores.  Intened to be
+                            used as a child distribution for large,
+                            rare strategic deposits that would
+                            otherwise be very difficult to find.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x601442BA</WireframeColor>
@@ -1459,37 +1501,34 @@ Nether Quartz
             <!-- Begin PipeVeins distribution of Emerald -->
             <IfCondition condition=':= vnlaEmeraldDist = "pipeVeins"'>
             
-                
-                <!-- Begin Emerald Ore Configuration -->
-                <Veins name='vnlaEmeraldBaseVeins' block='minecraft:emerald_ore' inherits='PresetPipeVeins' seed='0x3226'>
+                <Veins name='vnlaEmeraldBaseVeins' block='minecraft:emerald_ore'  inherits='PresetPipeVeins' seed='0x3226'>
                     <Description>
-                        Short sparsely filled veins sloping up from near the bottom of the map.
+                        Short sparsely filled veins sloping up from
+                        near the bottom of the map.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x606CE391</WireframeColor>
                     <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * vnlaEmeraldSize * _default_' range=':= 1 * 0.85 * vnlaEmeraldSize * _default_'/>
-                    <Setting name='MotherlodeHeight' avg=':= 10' range=':= 4' type='normal' scaleTo='SeaLevel' />
+                    <Setting name='MotherlodeHeight' avg=':= 10' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='SegmentRadius' avg=':= 1 * 0.85 * vnlaEmeraldSize * _default_' range=':= 1 * 0.85 * vnlaEmeraldSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1.2 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 1 * 0.7 * vnlaEmeraldFreq * _default_'/>
                     <Setting name='BranchInclination' avg=':= 0.55' range=':= 0.7'/>
                     <Setting name='SegmentRadius' avg=':= 1 * 0.85 * vnlaEmeraldSize * 0.85 * _default_' range=':= 1 * 0.85 * vnlaEmeraldSize * 0.7 * _default_'/>
-                    <Replaces block='minecraft:stone'/>
                     <BiomeType name='Mountain'/>
+                    <Replaces block='minecraft:stone'/>
                 </Veins>
-                <!-- End Emerald Ore Configuration -->
                 
-                
-                <!-- Begin Emerald Pipe Configuration -->
-                <Veins name= 'vnlaEmeraldBasePipe' block='minecraft:monster_egg' inherits='vnlaEmeraldBaseVeins' seed='0x3226'>
+                <!-- Begin Pipe Filling (Emerald Pipe Veins) Settings -->
+                <Veins name='vnlaEmeraldPipeVeins' block='minecraft:monster_egg'  inherits='vnlaEmeraldBaseVeins' seed='0x3226'>
                     <Description>
-                        Fills center of each tube with Pipe material.
+                        Fills the vein with an additional material
+                        (minecraft:monster_egg).
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x606CE391</WireframeColor>
                     <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 0.85 * vnlaEmeraldSize * _default_' range=':= 0.5 * 1 * 0.85 * vnlaEmeraldSize * _default_'/>
                     <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 0.85 * vnlaEmeraldSize * _default_' range=':= 0.5 * 1 * 0.85 * vnlaEmeraldSize * _default_'/>
-                    <Setting name='OreDensity' avg=':= 1 * 1.2 * _default_' range=':= _default_'/>
                     <Replaces block='minecraft:stone'/>
                     <Replaces block='minecraft:emerald_ore'/>
                     <Replaces block='minecraft:dirt'/>
@@ -1497,10 +1536,8 @@ Nether Quartz
                     <Replaces block='minecraft:gravel'/>
                     <Replaces block='minecraft:netherrack'/>
                     <Replaces block='minecraft:end_stone'/>
-                    <BiomeType name='Mountain'/>
                 </Veins>
-                <!-- End Emerald Pipe Configuration -->
-                
+                <!-- End Pipe Filling (Emerald Pipe Veins) Settings -->
             
             </IfCondition>
             <!-- End PipeVeins distribution of Emerald -->
@@ -1509,19 +1546,22 @@ Nether Quartz
             <!-- Begin  Small Deposits distribution of Emerald -->
             <IfCondition condition=':= vnlaEmeraldDist = "smallDeposits"'>
             
-                <Veins name='vnlaEmeraldBaseVeins' block='minecraft:emerald_ore' inherits='PresetSmallDeposits'>
+                <Veins name='vnlaEmeraldBaseVeins' block='minecraft:emerald_ore'  inherits='PresetSmallDeposits' >
                     <Description>
-                        Small motherlodes without any branches.
-                        Similar to the deposits produced by StandardGen distributions.
+                        Small motherlodes with no veins; similar to
+                        vanilla clusters.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x606CE391</WireframeColor>
-                    <Setting name='MotherlodeHeight' avg=':= 10' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
                     <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * vnlaEmeraldSize * _default_' range=':= 1 * 0.85 * vnlaEmeraldSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 10' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
+                    <Setting name='SegmentRadius' avg=':= 1 * 0.85 * vnlaEmeraldSize * _default_' range=':= 1 * 0.85 * vnlaEmeraldSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1.2 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 1 * 0.7 * vnlaEmeraldFreq * _default_'/>
-                    <Replaces block='minecraft:stone'/>
+                    <Setting name='BranchInclination' avg=':= 0.55' range=':= 0.7'/>
+                    <Setting name='SegmentRadius' avg=':= 1 * 0.85 * vnlaEmeraldSize * 0.85 * _default_' range=':= 1 * 0.85 * vnlaEmeraldSize * 0.7 * _default_'/>
                     <BiomeType name='Mountain'/>
+                    <Replaces block='minecraft:stone'/>
                 </Veins>
             
             </IfCondition>
@@ -1533,12 +1573,16 @@ Nether Quartz
             
                 <Cloud name='vnlaEmeraldBaseCloud' block='minecraft:emerald_ore' inherits='PresetStrategicCloud'>
                     <Description>
-                        Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                        adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                        ore, but it takes some time and effort to mine due to low density.
-                        The intent for strategic clouds is that the player will need to actively search for
-                        one and then set up a semi-permanent mining base and spend some time actually mining
-                        the ore.
+                        Large irregular clouds filled lightly with
+                        ore.  These are huge, spanning several
+                        adjacent chunks, and consequently rather rare.
+                        They contain a sizeable amount of ore, but it
+                        takes some time and effort to mine due to low
+                        density.  The intent for strategic clouds is
+                        that the player will need to actively search
+                        for one and then set up a semi-permanent
+                        mining base and spend some time actually
+                        mining the ore.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x606CE391</WireframeColor>
@@ -1554,10 +1598,15 @@ Nether Quartz
                     <!-- Begin Emerald Strategic Cloud Hint Veins -->
                     <Veins name='vnlaEmeraldBaseHintVeins' block='minecraft:emerald_ore' inherits='PresetHintVeins'>
                         <Description>
-                            Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                            They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                            to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                            deposits that would otherwise be very difficult to find. 
+                            Single blocks, generously scattered
+                            through all heights (density is about that
+                            of vanilla iron ore).  They will replace
+                            dirt and sandstone (but not grass or
+                            sand), so they can be found nearer to the
+                            surface than most ores.  Intened to be
+                            used as a child distribution for large,
+                            rare strategic deposits that would
+                            otherwise be very difficult to find.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x606CE391</WireframeColor>
@@ -1611,7 +1660,7 @@ Nether Quartz
                 <Comment>
                     The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
                 </Comment>
-                <Replaces block='minecraft:quartz_ore:0' />
+                <Replaces block='minecraft:quartz_ore' />
             </Substitute>
             <!-- Original Nether Ore Removal Complete -->
             
@@ -1622,14 +1671,15 @@ Nether Quartz
             <!-- Begin LayeredVeins distribution of Nether Quartz -->
             <IfCondition condition=':= vnlaNetherQuartzDist = "layeredVeins"'>
             
-                <Veins name='vnlaNetherQuartzBaseVeins' block='minecraft:quartz_ore' inherits='PresetLayeredVeins'>
+                <Veins name='vnlaNetherQuartzBaseVeins' block='minecraft:quartz_ore'  inherits='PresetLayeredVeins' >
                     <Description>
-                        Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        Small, fairly rare motherlodes with 2-4
+                        horizontal veins each.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60DBCCBF</WireframeColor>
                     <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaNetherQuartzSize * _default_' range=':= 1 * 1 * vnlaNetherQuartzSize * _default_'/>
-                    <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/> 
+                    <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                     <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaNetherQuartzSize * _default_' range=':= 1 * 1 * vnlaNetherQuartzSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 4 * 1 * vnlaNetherQuartzFreq * _default_'/>
@@ -1643,15 +1693,16 @@ Nether Quartz
             <!-- Begin  Small Deposits distribution of Nether Quartz -->
             <IfCondition condition=':= vnlaNetherQuartzDist = "smallDeposits"'>
             
-                <Veins name='vnlaNetherQuartzBaseVeins' block='minecraft:quartz_ore' inherits='PresetSmallDeposits'>
+                <Veins name='vnlaNetherQuartzBaseVeins' block='minecraft:quartz_ore'  inherits='PresetSmallDeposits' >
                     <Description>
-                        Small motherlodes without any branches.
-                        Similar to the deposits produced by StandardGen distributions.
+                        Small motherlodes with no veins; similar to
+                        vanilla clusters.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60DBCCBF</WireframeColor>
-                    <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
                     <Setting name='MotherlodeSize' avg=':= 1 * 1 * vnlaNetherQuartzSize * _default_' range=':= 1 * 1 * vnlaNetherQuartzSize * _default_'/>
+                    <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
+                    <Setting name='SegmentRadius' avg=':= 1 * 1 * vnlaNetherQuartzSize * _default_' range=':= 1 * 1 * vnlaNetherQuartzSize * _default_'/>
                     <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
                     <Setting name='MotherlodeFrequency' avg=':= 4 * 1 * vnlaNetherQuartzFreq * _default_'/>
                     <Replaces block='minecraft:netherrack'/>
@@ -1664,16 +1715,24 @@ Nether Quartz
             <!-- Begin  Huge Veins distribution of Nether Quartz -->
             <IfCondition condition=':= vnlaNetherQuartzDist = "hugeVeins"'>
             
-                <Veins name='vnlaNetherQuartzBaseVeins' block='minecraft:quartz_ore' inherits='PresetHugeVeins'>
+                <Veins name='vnlaNetherQuartzBaseVeins' block='minecraft:quartz_ore'  inherits='PresetHugeVeins' >
                     <Description>
-                        Very large, extremely rare motherlodes.  Each motherlode has many long slender branches - so thin that
-                        parts of the branch won't contain any ore at all.  This, combined with the incredible length of the
-                        branches, makes them more challenging to follow underground.  Once found, however, a motherlode contains
-                        enough ore to keep a player supplied for a very long time.
-                        The rarity of these veins might be too frustrating in a single-player setting.  In SMP, though, teamwork 
-                        could make finding them much easier and the motherlodes are big enough to supply several people without
-                        shortage.  This might be a good way to add challenge to multiplayer worlds.
-                        Credit: based on feedback by dyrewulf from the MC forums.
+                        Very large, extremely rare motherlodes.  Each
+                        motherlode has many long slender branches - so
+                        thin that parts of the branch won't contain
+                        any ore at all.  This, combined with the
+                        incredible length of the branches, makes them
+                        more challenging to follow underground.  Once
+                        found, however, a motherlode contains enough
+                        ore to keep a player supplied for a very long
+                        time.  The rarity of these veins might be too
+                        frustrating in a single-player setting.  In
+                        SMP, though, teamwork could make finding them
+                        much easier and the motherlodes are big enough
+                        to supply several people without shortage.
+                        This might be a good way to add challenge to
+                        multiplayer worlds.  Credit: based on feedback
+                        by dyrewulf from the MC forums.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60DBCCBF</WireframeColor>
@@ -1694,12 +1753,16 @@ Nether Quartz
             
                 <Cloud name='vnlaNetherQuartzBaseCloud' block='minecraft:quartz_ore' inherits='PresetStrategicCloud'>
                     <Description>
-                        Large irregular clouds filled lightly with ore.  These are huge, spanning several 
-                        adjacent chunks, and consequently rather rare.  They contain a sizeable amount of 
-                        ore, but it takes some time and effort to mine due to low density.
-                        The intent for strategic clouds is that the player will need to actively search for
-                        one and then set up a semi-permanent mining base and spend some time actually mining
-                        the ore.
+                        Large irregular clouds filled lightly with
+                        ore.  These are huge, spanning several
+                        adjacent chunks, and consequently rather rare.
+                        They contain a sizeable amount of ore, but it
+                        takes some time and effort to mine due to low
+                        density.  The intent for strategic clouds is
+                        that the player will need to actively search
+                        for one and then set up a semi-permanent
+                        mining base and spend some time actually
+                        mining the ore.
                     </Description>
                     <DrawWireframe>:=drawWireframes</DrawWireframe>
                     <WireframeColor>0x60DBCCBF</WireframeColor>
@@ -1714,10 +1777,15 @@ Nether Quartz
                     <!-- Begin Nether Quartz Strategic Cloud Hint Veins -->
                     <Veins name='vnlaNetherQuartzBaseHintVeins' block='minecraft:quartz_ore' inherits='PresetHintVeins'>
                         <Description>
-                            Single blocks, generously scattered through all heights (density is about that of vanilla iron ore). 
-                            They will replace dirt and sandstone (but not grass or sand), so they can be found nearer  
-                            to the surface than most ores.  Intened to be used as a child distribution for large, rare strategic  
-                            deposits that would otherwise be very difficult to find. 
+                            Single blocks, generously scattered
+                            through all heights (density is about that
+                            of vanilla iron ore).  They will replace
+                            dirt and sandstone (but not grass or
+                            sand), so they can be found nearer to the
+                            surface than most ores.  Intened to be
+                            used as a child distribution for large,
+                            rare strategic deposits that would
+                            otherwise be very difficult to find.
                         </Description>
                         <DrawWireframe>:=drawWireframes</DrawWireframe>
                         <WireframeColor>0x60DBCCBF</WireframeColor>


### PR DESCRIPTION
This is another "I updated Sprocket" release.  Most of the changes are pretty cosmetic, but some important fixes were made, and more are on the way (including multi-block distributions, and an overhaul on the geode configuration).
* FIXED: Vanilla clay spawns in all biomes except desert, with a preference for rivers, ocean, beaches, and swamps.  Previously, despite configuration, clay would not spawn in non-watery biomes, due to negative-weight biometype assuming all other biomes were not to be used, either.
* FIXED: Railcraft Abyssal stone no longer needs a specific substitute distribution to remove it; the substitution was added to the initial stanza.
* FIXED: Previously, blocks with a meta value of 0 made it explicit (minecraft:stone:0).  The explicit ":0" has been removed from all configurations.
* CHANGED: Opening comment is more compact, and now all descriptions are word-wrapped to make them readable in smaller windows.

