### PR TITLE
Ores have been rebalanced.

### DIFF
--- a/src/main/resources/config/CustomOreGen_Config_Default.xml
+++ b/src/main/resources/config/CustomOreGen_Config_Default.xml
@@ -394,12 +394,17 @@
          directive (and optionally add something to 'modules/custom')
     -->
 
+    <!-- Vanilla minecraft should always be the first thing to load. -->
+    <Import file='modules/default/VanillaMinecraft.xml'/>
+
+    <!-- Then, the rest are free to come in. -->
     <Import file='modules/default/AppliedEnergistics.xml'/>
     <Import file='modules/default/ArsMagica2.xml'/>
     <Import file='modules/default/BiomesOPlenty.xml'/>
     <Import file='modules/default/Chisel2.xml'/>
     <Import file='modules/default/Dartcraft.xml'/>
-    <Import file='modules/default/DenseOres.xml'/>
+    <!-- DO in particular NEEDS to be run after the vanilla config! -->
+    <Import file='modules/default/DenseOres.xml'/> 
     <Import file='modules/default/ElectriCraft.xml'/>
     <Import file='modules/default/ExtraCaves.xml'/>
     <Import file='modules/default/Factorization.xml'/>
@@ -425,7 +430,6 @@
     <Import file='modules/default/Thaumcraft4.xml'/>
     <Import file='modules/default/ThermalFoundation.xml'/>
     <Import file='modules/default/TinkersConstruct.xml'/>
-    <Import file='modules/default/VanillaMinecraft.xml'/>
 
     <!-- ***************** Import Mod-provided configs ********************* -->
     <!-- NOTE: mods will overwrite these configs upon each load -->

--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -29,10 +29,15 @@
                     Distribution options for Applied Energistics Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableAppliedEnergistics' displayName='Handle Applied Energistics Setup?' default='true' displayState='shown_dynamic' displayGroup='groupAppliedEnergistics'>
+                <Description> Should Custom Ore Generation handle Applied Energistics ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Applied Energistics ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Applied Energistics ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Certus Quartz Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='apenCertusQuartzDist'  displayState='shown' displayGroup='groupAppliedEnergistics'>
+                <OptionChoice name='apenCertusQuartzDist'  displayState=':= if(?enableAppliedEnergistics, "shown", "hidden")' displayGroup='groupAppliedEnergistics'>
                     <Description> Controls how Certus Quartz is generated </Description>
                     <DisplayName>Applied Energistics Certus Quartz</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -52,11 +57,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Certus Quartz is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='apenCertusQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupAppliedEnergistics'>
+                <OptionNumeric name='apenCertusQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?enableAppliedEnergistics, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupAppliedEnergistics'>
                     <Description> Frequency multiplier for Applied Energistics Certus Quartz distributions </Description>
                     <DisplayName>Applied Energistics Certus Quartz Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='apenCertusQuartzSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupAppliedEnergistics'>
+                <OptionNumeric name='apenCertusQuartzSize' default='1'  min='0' max='5' displayState=':= if(?enableAppliedEnergistics, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupAppliedEnergistics'>
                     <Description> Size multiplier for Applied Energistics Certus Quartz distributions </Description>
                     <DisplayName>Applied Energistics Certus Quartz Size</DisplayName>
                 </OptionNumeric>
@@ -66,165 +71,173 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableAppliedEnergistics'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='apenOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='appliedenergistics2:tile.OreQuartz' weight='1.0' />
-                <Replaces block='appliedenergistics2:tile.OreQuartzCharged' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Certus Quartz Generation -->
-
-            <!-- Starting SparseVeins Preset for Certus Quartz. -->
-            <ConfigSection>
-                <IfCondition condition=':= apenCertusQuartzDist = "SparseVeins"'>
-                    <Veins name='apenCertusQuartzVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x609BBEC2' drawBoundBox='false' boundBoxColor='0x609BBEC2'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='apenOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' />
-                        <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.712 * _default_ * apenCertusQuartzFreq ' range=':=  1 * _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.394 * _default_ * apenCertusQuartzSize ' range=':=  1 * _default_ * apenCertusQuartzSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.394 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.394 * _default_ * apenCertusQuartzSize ' range=':=  1 * _default_ * apenCertusQuartzSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <Replaces block='appliedenergistics2:tile.OreQuartz' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <Replaces block='appliedenergistics2:tile.OreQuartzCharged' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Certus Quartz is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Vanilla Preset for Certus Quartz. -->
-            <ConfigSection>
-                <IfCondition condition=':= apenCertusQuartzDist = "Vanilla"'>
-                    <StandardGen name='apenCertusQuartzStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609BBEC2' drawBoundBox='false' boundBoxColor='0x609BBEC2'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' />
-                        <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 15 * apenCertusQuartzFreq ' range=':=  _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Certus Quartz is complete. -->
+                <!-- Adding blocks -->
 
+                <!-- Begin Certus Quartz Generation -->
 
-            <!-- Starting Cloud Preset for Certus Quartz. -->
-            <ConfigSection>
-                <IfCondition condition=':= apenCertusQuartzDist = "Cloud"'>
-                    <Cloud name='apenCertusQuartzCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609BBEC2' drawBoundBox='false' boundBoxColor='0x609BBEC2'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' />
-                        <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.353 * _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.353 * _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.832  * _default_ * apenCertusQuartzFreq ' range=':=  _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='apenCertusQuartzHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609BBEC2' drawBoundBox='false' boundBoxColor='0x609BBEC2'>
+                <!-- Starting SparseVeins Preset for Certus Quartz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= apenCertusQuartzDist = "SparseVeins"'>
+                        <Veins name='apenCertusQuartzVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x609BBEC2' drawBoundBox='false' boundBoxColor='0x609BBEC2'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' />
-                            <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.712 * _default_ * apenCertusQuartzFreq ' range=':=  1 * _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.394 * _default_ * apenCertusQuartzSize ' range=':=  1 * _default_ * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.394 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.394 * _default_ * apenCertusQuartzSize ' range=':=  1 * _default_ * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Certus Quartz is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Certus Quartz is complete. -->
 
-            <!-- End Certus Quartz Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Certus Quartz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= apenCertusQuartzDist = "Vanilla"'>
+                        <StandardGen name='apenCertusQuartzStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609BBEC2' drawBoundBox='false' boundBoxColor='0x609BBEC2'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 15 * apenCertusQuartzFreq ' range=':=  _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Certus Quartz is complete. -->
+
+
+                <!-- Starting Cloud Preset for Certus Quartz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= apenCertusQuartzDist = "Cloud"'>
+                        <Cloud name='apenCertusQuartzCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609BBEC2' drawBoundBox='false' boundBoxColor='0x609BBEC2'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.353 * _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.353 * _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.832  * _default_ * apenCertusQuartzFreq ' range=':=  _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='apenCertusQuartzHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609BBEC2' drawBoundBox='false' boundBoxColor='0x609BBEC2'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Certus Quartz is complete. -->
+
+                <!-- End Certus Quartz Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -4,8 +4,10 @@
      ================================================================= -->
 
 
-<!-- The highest-end storage mod there is, using matter-to-data
-     transformation. -->
+<!-- A high-end matter-to-data conversion mod that requires both
+     certus quartz and nether quartz to do its thing.  Note, charged
+     quartz is mixed in with the non-charged quartz at a ratio of
+     1:10. -->
 
 
 
@@ -110,51 +112,22 @@
                         <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.123 * _default_ * apenCertusQuartzFreq ' range=':=  1 * _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.040 * _default_ * apenCertusQuartzSize ' range=':=  1 * _default_ * apenCertusQuartzSize ' type='normal' />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.712 * _default_ * apenCertusQuartzFreq ' range=':=  1 * _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.394 * _default_ * apenCertusQuartzSize ' range=':=  1 * _default_ * apenCertusQuartzSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.040 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.394 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.040 * _default_ * apenCertusQuartzSize ' range=':=  1 * _default_ * apenCertusQuartzSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.394 * _default_ * apenCertusQuartzSize ' range=':=  1 * _default_ * apenCertusQuartzSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Veins name='apenCertusQuartzPreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x609BBEC2' drawBoundBox='false' boundBoxColor='0x609BBEC2'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' />
-                        <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Desert'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.123 * _default_ * apenCertusQuartzFreq ' range=':=  1 * _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.040 * _default_ * apenCertusQuartzSize ' range=':=  1 * _default_ * apenCertusQuartzSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.040 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.040 * _default_ * apenCertusQuartzSize ' range=':=  1 * _default_ * apenCertusQuartzSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <!-- "Preferred" configuration complete. -->
-
                 </IfCondition>
             </ConfigSection>
             <!-- SparseVeins Preset for Certus Quartz is complete. -->
@@ -172,8 +145,8 @@
                         <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 7 * apenCertusQuartzSize ' range=':=  2 * apenCertusQuartzSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2.4 * apenCertusQuartzFreq ' range=':=  0 * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 4 * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 15 * apenCertusQuartzFreq ' range=':=  _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -203,9 +176,9 @@
                         <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.516 * _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.516 * _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.266  * _default_ * apenCertusQuartzFreq ' range=':=  _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.353 * _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.353 * _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.832  * _default_ * apenCertusQuartzFreq ' range=':=  _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -239,40 +212,6 @@
                             <Replaces block='minecraft:sandstone' weight='1.0' />
                         </Veins>
                     </Cloud>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Cloud name='apenCertusQuartzPreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609BBEC2' drawBoundBox='false' boundBoxColor='0x609BBEC2'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' />
-                        <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Desert'  />
-                        <Setting name='CloudRadius' avg=':= 0.516 * _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.516 * _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.266  * _default_ * apenCertusQuartzFreq ' range=':=  _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='apenCertusQuartzPreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609BBEC2' drawBoundBox='false' boundBoxColor='0x609BBEC2'>
-                            <Description>
-                                Ore generation is doubled in
-                                preferred biomes.
-                            </Description>
-                            <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' />
-                            <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                    <!-- "Preferred" configuration complete. -->
-
                 </IfCondition>
             </ConfigSection>
             <!-- Cloud Preset for Certus Quartz is complete. -->

--- a/src/main/resources/config/modules/ArsMagica2.xml
+++ b/src/main/resources/config/modules/ArsMagica2.xml
@@ -25,10 +25,15 @@
                     Distribution options for Ars Magica 2 Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableArsMagica2' displayName='Handle Ars Magica 2 Setup?' default='true' displayState='shown_dynamic' displayGroup='groupArsMagica2'>
+                <Description> Should Custom Ore Generation handle Ars Magica 2 ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Ars Magica 2 ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Ars Magica 2 ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Vinteum Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='arsmVinteumDist'  displayState='shown' displayGroup='groupArsMagica2'>
+                <OptionChoice name='arsmVinteumDist'  displayState=':= if(?enableArsMagica2, "shown", "hidden")' displayGroup='groupArsMagica2'>
                     <Description> Controls how Vinteum is generated </Description>
                     <DisplayName>Ars Magica 2 Vinteum</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -48,11 +53,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Vinteum is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='arsmVinteumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
+                <OptionNumeric name='arsmVinteumFreq' default='1'  min='0' max='5' displayState=':= if(?enableArsMagica2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupArsMagica2'>
                     <Description> Frequency multiplier for Ars Magica 2 Vinteum distributions </Description>
                     <DisplayName>Ars Magica 2 Vinteum Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='arsmVinteumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
+                <OptionNumeric name='arsmVinteumSize' default='1'  min='0' max='5' displayState=':= if(?enableArsMagica2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupArsMagica2'>
                     <Description> Size multiplier for Ars Magica 2 Vinteum distributions </Description>
                     <DisplayName>Ars Magica 2 Vinteum Size</DisplayName>
                 </OptionNumeric>
@@ -62,7 +67,7 @@
 
             <!-- Chimerite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='arsmChimeriteDist'  displayState='shown' displayGroup='groupArsMagica2'>
+                <OptionChoice name='arsmChimeriteDist'  displayState=':= if(?enableArsMagica2, "shown", "hidden")' displayGroup='groupArsMagica2'>
                     <Description> Controls how Chimerite is generated </Description>
                     <DisplayName>Ars Magica 2 Chimerite</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -82,11 +87,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Chimerite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='arsmChimeriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
+                <OptionNumeric name='arsmChimeriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableArsMagica2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupArsMagica2'>
                     <Description> Frequency multiplier for Ars Magica 2 Chimerite distributions </Description>
                     <DisplayName>Ars Magica 2 Chimerite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='arsmChimeriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
+                <OptionNumeric name='arsmChimeriteSize' default='1'  min='0' max='5' displayState=':= if(?enableArsMagica2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupArsMagica2'>
                     <Description> Size multiplier for Ars Magica 2 Chimerite distributions </Description>
                     <DisplayName>Ars Magica 2 Chimerite Size</DisplayName>
                 </OptionNumeric>
@@ -96,7 +101,7 @@
 
             <!-- Blue Topaz Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='arsmBlueTopazDist'  displayState='shown' displayGroup='groupArsMagica2'>
+                <OptionChoice name='arsmBlueTopazDist'  displayState=':= if(?enableArsMagica2, "shown", "hidden")' displayGroup='groupArsMagica2'>
                     <Description> Controls how Blue Topaz is generated </Description>
                     <DisplayName>Ars Magica 2 Blue Topaz</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -116,11 +121,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Blue Topaz is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='arsmBlueTopazFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
+                <OptionNumeric name='arsmBlueTopazFreq' default='1'  min='0' max='5' displayState=':= if(?enableArsMagica2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupArsMagica2'>
                     <Description> Frequency multiplier for Ars Magica 2 Blue Topaz distributions </Description>
                     <DisplayName>Ars Magica 2 Blue Topaz Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='arsmBlueTopazSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
+                <OptionNumeric name='arsmBlueTopazSize' default='1'  min='0' max='5' displayState=':= if(?enableArsMagica2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupArsMagica2'>
                     <Description> Size multiplier for Ars Magica 2 Blue Topaz distributions </Description>
                     <DisplayName>Ars Magica 2 Blue Topaz Size</DisplayName>
                 </OptionNumeric>
@@ -130,408 +135,422 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableArsMagica2'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='arsmOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='arsmagica2:vinteumOre' weight='1.0' />
-                <Replaces block='arsmagica2:vinteumOre:1' weight='1.0' />
-                <Replaces block='arsmagica2:vinteumOre:2' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Vinteum Generation -->
-
-            <!-- Starting SparseVeins Preset for Vinteum. -->
-            <ConfigSection>
-                <IfCondition condition=':= arsmVinteumDist = "SparseVeins"'>
-                    <Veins name='arsmVinteumVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='arsmOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.213 * _default_ * arsmVinteumFreq ' range=':=  _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 22 ' range=':=  17 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.066 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.066 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <Replaces block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <Replaces block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <Replaces block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Vinteum is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Vinteum. -->
-            <ConfigSection>
-                <IfCondition condition=':= arsmVinteumDist = "Cloud"'>
-                    <Cloud name='arsmVinteumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * arsmVinteumFreq ' range=':=  _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 22 ' range=':=  17 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='arsmVinteumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Vinteum Generation -->
+
+                <!-- Starting SparseVeins Preset for Vinteum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= arsmVinteumDist = "SparseVeins"'>
+                        <Veins name='arsmVinteumVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.213 * _default_ * arsmVinteumFreq ' range=':=  _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':=  17 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.066 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.066 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Vinteum is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Vinteum is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Vinteum. -->
-            <ConfigSection>
-                <IfCondition condition=':= arsmVinteumDist = "Vanilla"'>
-                    <StandardGen name='arsmVinteumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * arsmVinteumFreq ' range=':=  _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 22 ' range=':=  17 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Vinteum is complete. -->
-
-            <!-- End Vinteum Generation -->
-
-
-            <!-- Begin Chimerite Generation -->
-
-            <!-- Starting SparseVeins Preset for Chimerite. -->
-            <ConfigSection>
-                <IfCondition condition=':= arsmChimeriteDist = "SparseVeins"'>
-                    <Veins name='arsmChimeriteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.485 * _default_ * arsmChimeriteFreq ' range=':=  _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.141 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.141 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.141 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Chimerite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Chimerite. -->
-            <ConfigSection>
-                <IfCondition condition=':= arsmChimeriteDist = "Cloud"'>
-                    <Cloud name='arsmChimeriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.002 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.002 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * arsmChimeriteFreq ' range=':=  _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='arsmChimeriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
+                <!-- Starting Cloud Preset for Vinteum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= arsmVinteumDist = "Cloud"'>
+                        <Cloud name='arsmVinteumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Chimerite is complete. -->
+                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * arsmVinteumFreq ' range=':=  _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 22 ' range=':=  17 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='arsmVinteumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Vinteum is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Chimerite. -->
-            <ConfigSection>
-                <IfCondition condition=':= arsmChimeriteDist = "Vanilla"'>
-                    <StandardGen name='arsmChimeriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * arsmChimeriteFreq ' range=':=  _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Chimerite is complete. -->
-
-            <!-- End Chimerite Generation -->
-
-
-            <!-- Begin Blue Topaz Generation -->
-
-            <!-- Starting SparseVeins Preset for Blue Topaz. -->
-            <ConfigSection>
-                <IfCondition condition=':= arsmBlueTopazDist = "SparseVeins"'>
-                    <Veins name='arsmBlueTopazVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.485 * _default_ * arsmBlueTopazFreq ' range=':=  _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.141 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  108 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.141 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.141 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Blue Topaz is complete. -->
-
-
-            <!-- Starting Cloud Preset for Blue Topaz. -->
-            <ConfigSection>
-                <IfCondition condition=':= arsmBlueTopazDist = "Cloud"'>
-                    <Cloud name='arsmBlueTopazCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.002 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.002 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * arsmBlueTopazFreq ' range=':=  _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 20 ' range=':=  108 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='arsmBlueTopazHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
+                <!-- Starting Vanilla Preset for Vinteum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= arsmVinteumDist = "Vanilla"'>
+                        <StandardGen name='arsmVinteumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * arsmVinteumFreq ' range=':=  _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 22 ' range=':=  17 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Vinteum is complete. -->
+
+                <!-- End Vinteum Generation -->
+
+
+                <!-- Begin Chimerite Generation -->
+
+                <!-- Starting SparseVeins Preset for Chimerite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= arsmChimeriteDist = "SparseVeins"'>
+                        <Veins name='arsmChimeriteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.485 * _default_ * arsmChimeriteFreq ' range=':=  _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.141 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.141 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.141 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Blue Topaz is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Chimerite is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Blue Topaz. -->
-            <ConfigSection>
-                <IfCondition condition=':= arsmBlueTopazDist = "Vanilla"'>
-                    <StandardGen name='arsmBlueTopazStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * arsmBlueTopazFreq ' range=':=  _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 20 ' range=':=  108 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Blue Topaz is complete. -->
+                <!-- Starting Cloud Preset for Chimerite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= arsmChimeriteDist = "Cloud"'>
+                        <Cloud name='arsmChimeriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * arsmChimeriteFreq ' range=':=  _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='arsmChimeriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Chimerite is complete. -->
 
-            <!-- End Blue Topaz Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Chimerite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= arsmChimeriteDist = "Vanilla"'>
+                        <StandardGen name='arsmChimeriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * arsmChimeriteFreq ' range=':=  _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Chimerite is complete. -->
+
+                <!-- End Chimerite Generation -->
+
+
+                <!-- Begin Blue Topaz Generation -->
+
+                <!-- Starting SparseVeins Preset for Blue Topaz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= arsmBlueTopazDist = "SparseVeins"'>
+                        <Veins name='arsmBlueTopazVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.485 * _default_ * arsmBlueTopazFreq ' range=':=  _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.141 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  108 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.141 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.141 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Blue Topaz is complete. -->
+
+
+                <!-- Starting Cloud Preset for Blue Topaz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= arsmBlueTopazDist = "Cloud"'>
+                        <Cloud name='arsmBlueTopazCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * arsmBlueTopazFreq ' range=':=  _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 20 ' range=':=  108 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='arsmBlueTopazHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Blue Topaz is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Blue Topaz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= arsmBlueTopazDist = "Vanilla"'>
+                        <StandardGen name='arsmBlueTopazStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * arsmBlueTopazFreq ' range=':=  _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 20 ' range=':=  108 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Blue Topaz is complete. -->
+
+                <!-- End Blue Topaz Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/ArsMagica2.xml
+++ b/src/main/resources/config/modules/ArsMagica2.xml
@@ -1,672 +1,552 @@
- <!-- ================================================================
-      Custom Ore Generation "Ars Magica 2" Module: This configuration
-      covers vinteum, chimerite, and blue topaz.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Ars Magica 2" Module: This configuration
+     covers vinteum, chimerite, and blue topaz.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="arsmagica2">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "Ars Magica 2" mod on the system?  Let's find out! -->
+<IfModInstalled name="arsmagica2">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupArsMagica2' displayName='Ars Magica 2' displayState='shown'>
+                <Description>
+                    Distribution options for Ars Magica 2 Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Vinteum Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupArsMagica2' displayName='Ars Magica 2' displayState='shown'> 
-                    <Description>
-                        Distribution options for Ars Magica 2 Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Vinteum Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='arsmVinteumDist'  displayState='shown' displayGroup='groupArsMagica2'> 
-                        <Description> Controls how Vinteum is generated </Description> 
-                        <DisplayName>Ars Magica 2 Vinteum</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Vinteum is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='arsmVinteumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
-                        <Description> Frequency multiplier for Ars Magica 2 Vinteum distributions </Description>
-                        <DisplayName>Ars Magica 2 Vinteum Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='arsmVinteumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
-                        <Description> Size multiplier for Ars Magica 2 Vinteum distributions </Description>
-                        <DisplayName>Ars Magica 2 Vinteum Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Vinteum Configuration UI Complete -->
-                
-                
-                <!-- Chimerite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='arsmChimeriteDist'  displayState='shown' displayGroup='groupArsMagica2'> 
-                        <Description> Controls how Chimerite is generated </Description> 
-                        <DisplayName>Ars Magica 2 Chimerite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Chimerite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='arsmChimeriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
-                        <Description> Frequency multiplier for Ars Magica 2 Chimerite distributions </Description>
-                        <DisplayName>Ars Magica 2 Chimerite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='arsmChimeriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
-                        <Description> Size multiplier for Ars Magica 2 Chimerite distributions </Description>
-                        <DisplayName>Ars Magica 2 Chimerite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Chimerite Configuration UI Complete -->
-                
-                
-                <!-- Blue Topaz Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='arsmBlueTopazDist'  displayState='shown' displayGroup='groupArsMagica2'> 
-                        <Description> Controls how Blue Topaz is generated </Description> 
-                        <DisplayName>Ars Magica 2 Blue Topaz</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Blue Topaz is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='arsmBlueTopazFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
-                        <Description> Frequency multiplier for Ars Magica 2 Blue Topaz distributions </Description>
-                        <DisplayName>Ars Magica 2 Blue Topaz Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='arsmBlueTopazSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
-                        <Description> Size multiplier for Ars Magica 2 Blue Topaz distributions </Description>
-                        <DisplayName>Ars Magica 2 Blue Topaz Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Blue Topaz Configuration UI Complete -->
-                
+                <OptionChoice name='arsmVinteumDist'  displayState='shown' displayGroup='groupArsMagica2'>
+                    <Description> Controls how Vinteum is generated </Description>
+                    <DisplayName>Ars Magica 2 Vinteum</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
+                        <Description>
+                            Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Vinteum is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='arsmVinteumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
+                    <Description> Frequency multiplier for Ars Magica 2 Vinteum distributions </Description>
+                    <DisplayName>Ars Magica 2 Vinteum Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='arsmVinteumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
+                    <Description> Size multiplier for Ars Magica 2 Vinteum distributions </Description>
+                    <DisplayName>Ars Magica 2 Vinteum Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Vinteum Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='arsmOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='arsmagica2:vinteumOre' />
-                    <Replaces block='arsmagica2:vinteumOre:1' />
-                    <Replaces block='arsmagica2:vinteumOre:2' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Vinteum Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Vinteum -->
-                <IfCondition condition=':= arsmVinteumDist = "layeredVeins"'>
-                
-                    <Veins name='arsmVinteumBaseVeins' block='arsmagica2:vinteumOre'  inherits='PresetLayeredVeins' >
+            <!-- Chimerite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='arsmChimeriteDist'  displayState='shown' displayGroup='groupArsMagica2'>
+                    <Description> Controls how Chimerite is generated </Description>
+                    <DisplayName>Ars Magica 2 Chimerite</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Large veins filled very lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605364EE</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * arsmVinteumSize * _default_' range=':= 1 * 0.8 * arsmVinteumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 8' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * arsmVinteumSize * _default_' range=':= 1 * 0.8 * arsmVinteumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * arsmVinteumFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Vinteum Layered Veins) Settings -->
-                    <Veins name='arsmVinteumPrefersVeins' block='arsmagica2:vinteumOre'  inherits='arsmVinteumBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 4 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605364EE</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Vinteum Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Vinteum -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Vinteum -->
-                <IfCondition condition=':= arsmVinteumDist = "hugeVeins"'>
-                
-                    <Veins name='arsmVinteumBaseVeins' block='arsmagica2:vinteumOre'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605364EE</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * arsmVinteumSize * _default_' range=':= 1 * 0.8 * arsmVinteumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 8' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * arsmVinteumSize * _default_' range=':= 1 * 0.8 * arsmVinteumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * arsmVinteumFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Vinteum Huge Veins) Settings -->
-                    <Veins name='arsmVinteumPrefersVeins' block='arsmagica2:vinteumOre'  inherits='arsmVinteumBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605364EE</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Vinteum Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Vinteum -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Vinteum -->
-                <IfCondition condition=':= arsmVinteumDist = "strategicCloud"'>
-                
-                    <Cloud name='arsmVinteumBaseCloud' block='arsmagica2:vinteumOre' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605364EE</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * arsmVinteumSize * _default_' range=':= 1 * 0.8 * arsmVinteumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * arsmVinteumSize * _default_' range=':= 1 * 0.8 * arsmVinteumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 30' range=':= 8' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 0.8 * arsmVinteumSize * _default_' range=':= 1 * 1 * 0.8 * arsmVinteumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * arsmVinteumFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Vinteum Strategic Cloud Hint Veins -->
-                        <Veins name='arsmVinteumBaseHintVeins' block='arsmagica2:vinteumOre' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x605364EE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Vinteum Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Chimerite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='arsmChimeriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
+                    <Description> Frequency multiplier for Ars Magica 2 Chimerite distributions </Description>
+                    <DisplayName>Ars Magica 2 Chimerite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='arsmChimeriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
+                    <Description> Size multiplier for Ars Magica 2 Chimerite distributions </Description>
+                    <DisplayName>Ars Magica 2 Chimerite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Chimerite Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Vinteum -->
-                
-                
-                <!-- Begin  Vanilla distribution of Vinteum -->
-                <IfCondition condition=':= arsmVinteumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='arsmVinteumBaseStandard' block='arsmagica2:vinteumOre' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605364EE</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * arsmVinteumSize * _default_'/>
-                        <Setting name='Height' avg=':= 30' range=':= 8' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * .8 * arsmVinteumFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Vinteum -->
-                
-                <!-- End Vinteum Generation --> 
 
-                
-                <!-- Begin Chimerite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Chimerite -->
-                <IfCondition condition=':= arsmChimeriteDist = "layeredVeins"'>
-                
-                    <Veins name='arsmChimeriteBaseVeins' block='arsmagica2:vinteumOre:1'  inherits='PresetLayeredVeins' >
+            <!-- Blue Topaz Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='arsmBlueTopazDist'  displayState='shown' displayGroup='groupArsMagica2'>
+                    <Description> Controls how Blue Topaz is generated </Description>
+                    <DisplayName>Ars Magica 2 Blue Topaz</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Large veins filled very lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B8E6C6</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * arsmChimeriteSize * _default_' range=':= 1 * 0.8 * arsmChimeriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * arsmChimeriteSize * _default_' range=':= 1 * 0.8 * arsmChimeriteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * arsmChimeriteFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Chimerite Layered Veins) Settings -->
-                    <Veins name='arsmChimeritePrefersVeins' block='arsmagica2:vinteumOre:1'  inherits='arsmChimeriteBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 4 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B8E6C6</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Chimerite Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Chimerite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Chimerite -->
-                <IfCondition condition=':= arsmChimeriteDist = "hugeVeins"'>
-                
-                    <Veins name='arsmChimeriteBaseVeins' block='arsmagica2:vinteumOre:1'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B8E6C6</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * arsmChimeriteSize * _default_' range=':= 1 * 0.8 * arsmChimeriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * arsmChimeriteSize * _default_' range=':= 1 * 0.8 * arsmChimeriteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * arsmChimeriteFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Chimerite Huge Veins) Settings -->
-                    <Veins name='arsmChimeritePrefersVeins' block='arsmagica2:vinteumOre:1'  inherits='arsmChimeriteBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B8E6C6</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Chimerite Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Chimerite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Chimerite -->
-                <IfCondition condition=':= arsmChimeriteDist = "strategicCloud"'>
-                
-                    <Cloud name='arsmChimeriteBaseCloud' block='arsmagica2:vinteumOre:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B8E6C6</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * arsmChimeriteSize * _default_' range=':= 1 * 0.8 * arsmChimeriteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * arsmChimeriteSize * _default_' range=':= 1 * 0.8 * arsmChimeriteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 64' range=':= 64' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 0.8 * arsmChimeriteSize * _default_' range=':= 1 * 1 * 0.8 * arsmChimeriteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4 * arsmChimeriteFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Chimerite Strategic Cloud Hint Veins -->
-                        <Veins name='arsmChimeriteBaseHintVeins' block='arsmagica2:vinteumOre:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60B8E6C6</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Chimerite Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Blue Topaz is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='arsmBlueTopazFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
+                    <Description> Frequency multiplier for Ars Magica 2 Blue Topaz distributions </Description>
+                    <DisplayName>Ars Magica 2 Blue Topaz Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='arsmBlueTopazSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupArsMagica2'>
+                    <Description> Size multiplier for Ars Magica 2 Blue Topaz distributions </Description>
+                    <DisplayName>Ars Magica 2 Blue Topaz Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Blue Topaz Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Chimerite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Chimerite -->
-                <IfCondition condition=':= arsmChimeriteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='arsmChimeriteBaseStandard' block='arsmagica2:vinteumOre:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B8E6C6</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * arsmChimeriteSize * _default_'/>
-                        <Setting name='Height' avg=':= 64' range=':= 64' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.1 * arsmChimeriteFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Chimerite -->
-                
-                <!-- End Chimerite Generation --> 
-
-                
-                <!-- Begin Blue Topaz Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Blue Topaz -->
-                <IfCondition condition=':= arsmBlueTopazDist = "layeredVeins"'>
-                
-                    <Veins name='arsmBlueTopazBaseVeins' block='arsmagica2:vinteumOre:2'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607EE5F4</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * arsmBlueTopazSize * _default_' range=':= 1 * 0.8 * arsmBlueTopazSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * arsmBlueTopazSize * _default_' range=':= 1 * 0.8 * arsmBlueTopazSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * arsmBlueTopazFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Blue Topaz Layered Veins) Settings -->
-                    <Veins name='arsmBlueTopazPrefersVeins' block='arsmagica2:vinteumOre:2'  inherits='arsmBlueTopazBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607EE5F4</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Blue Topaz Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Blue Topaz -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Blue Topaz -->
-                <IfCondition condition=':= arsmBlueTopazDist = "hugeVeins"'>
-                
-                    <Veins name='arsmBlueTopazBaseVeins' block='arsmagica2:vinteumOre:2'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607EE5F4</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * arsmBlueTopazSize * _default_' range=':= 1 * 0.8 * arsmBlueTopazSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * arsmBlueTopazSize * _default_' range=':= 1 * 0.8 * arsmBlueTopazSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * arsmBlueTopazFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Blue Topaz Huge Veins) Settings -->
-                    <Veins name='arsmBlueTopazPrefersVeins' block='arsmagica2:vinteumOre:2'  inherits='arsmBlueTopazBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607EE5F4</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Blue Topaz Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Blue Topaz -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Blue Topaz -->
-                <IfCondition condition=':= arsmBlueTopazDist = "strategicCloud"'>
-                
-                    <Cloud name='arsmBlueTopazBaseCloud' block='arsmagica2:vinteumOre:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607EE5F4</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * arsmBlueTopazSize * _default_' range=':= 1 * 0.8 * arsmBlueTopazSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * arsmBlueTopazSize * _default_' range=':= 1 * 0.8 * arsmBlueTopazSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 64' range=':= 64' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 0.8 * arsmBlueTopazSize * _default_' range=':= 1 * 1 * 0.8 * arsmBlueTopazSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4 * arsmBlueTopazFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Blue Topaz Strategic Cloud Hint Veins -->
-                        <Veins name='arsmBlueTopazBaseHintVeins' block='arsmagica2:vinteumOre:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x607EE5F4</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Blue Topaz Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Blue Topaz -->
-                
-                
-                <!-- Begin  Vanilla distribution of Blue Topaz -->
-                <IfCondition condition=':= arsmBlueTopazDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='arsmBlueTopazBaseStandard' block='arsmagica2:vinteumOre:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607EE5F4</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * arsmBlueTopazSize * _default_'/>
-                        <Setting name='Height' avg=':= 64' range=':= 64' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.1 * arsmBlueTopazFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Blue Topaz -->
-                
-                <!-- End Blue Topaz Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='arsmOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='arsmagica2:vinteumOre' weight='1.0' />
+                <Replaces block='arsmagica2:vinteumOre:1' weight='1.0' />
+                <Replaces block='arsmagica2:vinteumOre:2' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Vinteum Generation -->
+
+            <!-- Starting SparseVeins Preset for Vinteum. -->
+            <ConfigSection>
+                <IfCondition condition=':= arsmVinteumDist = "SparseVeins"'>
+                    <Veins name='arsmVinteumVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.213 * _default_ * arsmVinteumFreq ' range=':=  _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 22 ' range=':=  17 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.066 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.066 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Vinteum is complete. -->
+
+
+            <!-- Starting Cloud Preset for Vinteum. -->
+            <ConfigSection>
+                <IfCondition condition=':= arsmVinteumDist = "Cloud"'>
+                    <Cloud name='arsmVinteumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * arsmVinteumFreq ' range=':=  _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 22 ' range=':=  17 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='arsmVinteumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Vinteum is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Vinteum. -->
+            <ConfigSection>
+                <IfCondition condition=':= arsmVinteumDist = "Vanilla"'>
+                    <StandardGen name='arsmVinteumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * arsmVinteumFreq ' range=':=  _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 22 ' range=':=  17 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Vinteum is complete. -->
+
+            <!-- End Vinteum Generation -->
+
+
+            <!-- Begin Chimerite Generation -->
+
+            <!-- Starting SparseVeins Preset for Chimerite. -->
+            <ConfigSection>
+                <IfCondition condition=':= arsmChimeriteDist = "SparseVeins"'>
+                    <Veins name='arsmChimeriteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.485 * _default_ * arsmChimeriteFreq ' range=':=  _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.141 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.141 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.141 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Chimerite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Chimerite. -->
+            <ConfigSection>
+                <IfCondition condition=':= arsmChimeriteDist = "Cloud"'>
+                    <Cloud name='arsmChimeriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.002 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.002 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * arsmChimeriteFreq ' range=':=  _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='arsmChimeriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Chimerite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Chimerite. -->
+            <ConfigSection>
+                <IfCondition condition=':= arsmChimeriteDist = "Vanilla"'>
+                    <StandardGen name='arsmChimeriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * arsmChimeriteFreq ' range=':=  _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Chimerite is complete. -->
+
+            <!-- End Chimerite Generation -->
+
+
+            <!-- Begin Blue Topaz Generation -->
+
+            <!-- Starting SparseVeins Preset for Blue Topaz. -->
+            <ConfigSection>
+                <IfCondition condition=':= arsmBlueTopazDist = "SparseVeins"'>
+                    <Veins name='arsmBlueTopazVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.485 * _default_ * arsmBlueTopazFreq ' range=':=  _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.141 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  108 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.141 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.141 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Blue Topaz is complete. -->
+
+
+            <!-- Starting Cloud Preset for Blue Topaz. -->
+            <ConfigSection>
+                <IfCondition condition=':= arsmBlueTopazDist = "Cloud"'>
+                    <Cloud name='arsmBlueTopazCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.002 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.002 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * arsmBlueTopazFreq ' range=':=  _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 20 ' range=':=  108 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='arsmBlueTopazHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Blue Topaz is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Blue Topaz. -->
+            <ConfigSection>
+                <IfCondition condition=':= arsmBlueTopazDist = "Vanilla"'>
+                    <StandardGen name='arsmBlueTopazStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * arsmBlueTopazFreq ' range=':=  _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 20 ' range=':=  108 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Blue Topaz is complete. -->
+
+            <!-- End Blue Topaz Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Ars Magica 2" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -26,10 +26,15 @@
                     Distribution options for Biomes O Plenty Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableBiomesOPlenty' displayName='Handle Biomes O Plenty Setup?' default='true' displayState='shown_dynamic' displayGroup='groupBiomesOPlenty'>
+                <Description> Should Custom Ore Generation handle Biomes O Plenty ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Biomes O Plenty ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Biomes O Plenty ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- EnderAmathyst Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='boplEnderAmathystDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                <OptionChoice name='boplEnderAmathystDist'  displayState=':= if(?enableBiomesOPlenty, "shown", "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Controls how EnderAmathyst is generated </Description>
                     <DisplayName>Biomes O Plenty EnderAmathyst</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -49,11 +54,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='EnderAmathyst is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='boplEnderAmathystFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplEnderAmathystFreq' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Frequency multiplier for Biomes O Plenty EnderAmathyst distributions </Description>
                     <DisplayName>Biomes O Plenty EnderAmathyst Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='boplEnderAmathystSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplEnderAmathystSize' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Size multiplier for Biomes O Plenty EnderAmathyst distributions </Description>
                     <DisplayName>Biomes O Plenty EnderAmathyst Size</DisplayName>
                 </OptionNumeric>
@@ -63,7 +68,7 @@
 
             <!-- Ruby Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='boplRubyDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                <OptionChoice name='boplRubyDist'  displayState=':= if(?enableBiomesOPlenty, "shown", "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Controls how Ruby is generated </Description>
                     <DisplayName>Biomes O Plenty Ruby</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -83,11 +88,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Ruby is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='boplRubyFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplRubyFreq' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Frequency multiplier for Biomes O Plenty Ruby distributions </Description>
                     <DisplayName>Biomes O Plenty Ruby Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='boplRubySize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplRubySize' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Size multiplier for Biomes O Plenty Ruby distributions </Description>
                     <DisplayName>Biomes O Plenty Ruby Size</DisplayName>
                 </OptionNumeric>
@@ -97,7 +102,7 @@
 
             <!-- Peridot Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='boplPeridotDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                <OptionChoice name='boplPeridotDist'  displayState=':= if(?enableBiomesOPlenty, "shown", "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Controls how Peridot is generated </Description>
                     <DisplayName>Biomes O Plenty Peridot</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -117,11 +122,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Peridot is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='boplPeridotFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplPeridotFreq' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Frequency multiplier for Biomes O Plenty Peridot distributions </Description>
                     <DisplayName>Biomes O Plenty Peridot Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='boplPeridotSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplPeridotSize' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Size multiplier for Biomes O Plenty Peridot distributions </Description>
                     <DisplayName>Biomes O Plenty Peridot Size</DisplayName>
                 </OptionNumeric>
@@ -131,7 +136,7 @@
 
             <!-- Topaz Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='boplTopazDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                <OptionChoice name='boplTopazDist'  displayState=':= if(?enableBiomesOPlenty, "shown", "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Controls how Topaz is generated </Description>
                     <DisplayName>Biomes O Plenty Topaz</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -151,11 +156,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Topaz is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='boplTopazFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplTopazFreq' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Frequency multiplier for Biomes O Plenty Topaz distributions </Description>
                     <DisplayName>Biomes O Plenty Topaz Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='boplTopazSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplTopazSize' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Size multiplier for Biomes O Plenty Topaz distributions </Description>
                     <DisplayName>Biomes O Plenty Topaz Size</DisplayName>
                 </OptionNumeric>
@@ -165,7 +170,7 @@
 
             <!-- Tanzanite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='boplTanzaniteDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                <OptionChoice name='boplTanzaniteDist'  displayState=':= if(?enableBiomesOPlenty, "shown", "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Controls how Tanzanite is generated </Description>
                     <DisplayName>Biomes O Plenty Tanzanite</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -185,11 +190,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Tanzanite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='boplTanzaniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplTanzaniteFreq' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Frequency multiplier for Biomes O Plenty Tanzanite distributions </Description>
                     <DisplayName>Biomes O Plenty Tanzanite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='boplTanzaniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplTanzaniteSize' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Size multiplier for Biomes O Plenty Tanzanite distributions </Description>
                     <DisplayName>Biomes O Plenty Tanzanite Size</DisplayName>
                 </OptionNumeric>
@@ -199,7 +204,7 @@
 
             <!-- Malachite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='boplMalachiteDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                <OptionChoice name='boplMalachiteDist'  displayState=':= if(?enableBiomesOPlenty, "shown", "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Controls how Malachite is generated </Description>
                     <DisplayName>Biomes O Plenty Malachite</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -219,11 +224,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Malachite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='boplMalachiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplMalachiteFreq' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Frequency multiplier for Biomes O Plenty Malachite distributions </Description>
                     <DisplayName>Biomes O Plenty Malachite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='boplMalachiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplMalachiteSize' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Size multiplier for Biomes O Plenty Malachite distributions </Description>
                     <DisplayName>Biomes O Plenty Malachite Size</DisplayName>
                 </OptionNumeric>
@@ -233,7 +238,7 @@
 
             <!-- Sapphire Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='boplSapphireDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                <OptionChoice name='boplSapphireDist'  displayState=':= if(?enableBiomesOPlenty, "shown", "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Controls how Sapphire is generated </Description>
                     <DisplayName>Biomes O Plenty Sapphire</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -253,11 +258,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Sapphire is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='boplSapphireFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplSapphireFreq' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Frequency multiplier for Biomes O Plenty Sapphire distributions </Description>
                     <DisplayName>Biomes O Plenty Sapphire Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='boplSapphireSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplSapphireSize' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Size multiplier for Biomes O Plenty Sapphire distributions </Description>
                     <DisplayName>Biomes O Plenty Sapphire Size</DisplayName>
                 </OptionNumeric>
@@ -267,7 +272,7 @@
 
             <!-- Amber Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='boplAmberDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                <OptionChoice name='boplAmberDist'  displayState=':= if(?enableBiomesOPlenty, "shown", "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Controls how Amber is generated </Description>
                     <DisplayName>Biomes O Plenty Amber</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -287,11 +292,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Amber is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='boplAmberFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplAmberFreq' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Frequency multiplier for Biomes O Plenty Amber distributions </Description>
                     <DisplayName>Biomes O Plenty Amber Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='boplAmberSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                <OptionNumeric name='boplAmberSize' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
                     <Description> Size multiplier for Biomes O Plenty Amber distributions </Description>
                     <DisplayName>Biomes O Plenty Amber Size</DisplayName>
                 </OptionNumeric>
@@ -301,1120 +306,1144 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableBiomesOPlenty'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='boplOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' />
-                <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' />
-                <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' />
-                <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' />
-                <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' />
-                <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' />
-                <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Ruby Generation -->
-
-            <!-- Starting PipeVeins Preset for Ruby. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplRubyDist = "PipeVeins"'>
-                    <Veins name='boplRubyVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='boplOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Desert'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplRubyFreq ' range=':=  _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='boplRubyVeinsPipe'  inherits='boplRubyVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
-                        <OreBlock block='minecraft:lava' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplRubySize  * 0.5 ' range=':=  _default_ * boplRubySize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplRubySize  * 0.5 ' range=':=  _default_ * boplRubySize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Ruby is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Ruby. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplRubyDist = "Cloud"'>
-                    <Cloud name='boplRubyCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Desert'  />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplRubyFreq ' range=':=  _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='boplRubyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Ruby Generation -->
+
+                <!-- Starting PipeVeins Preset for Ruby. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplRubyDist = "PipeVeins"'>
+                        <Veins name='boplRubyVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
                             </Description>
-                            <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Desert'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplRubyFreq ' range=':=  _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Ruby is complete. -->
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='boplRubyVeinsPipe'  inherits='boplRubyVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplRubySize  * 0.5 ' range=':=  _default_ * boplRubySize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplRubySize  * 0.5 ' range=':=  _default_ * boplRubySize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Ruby is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Ruby. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplRubyDist = "Vanilla"'>
-                    <StandardGen name='boplRubyStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Desert'  />
-                        <Setting name='Size' avg=':= 1 * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * boplRubyFreq ' range=':=  _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Ruby is complete. -->
-
-            <!-- End Ruby Generation -->
-
-
-            <!-- Begin Peridot Generation -->
-
-            <!-- Starting PipeVeins Preset for Peridot. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplPeridotDist = "PipeVeins"'>
-                    <Veins name='boplPeridotVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
-                        <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Plains'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplPeridotFreq ' range=':=  _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='boplPeridotVeinsPipe'  inherits='boplPeridotVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
-                        <OreBlock block='minecraft:lava' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplPeridotSize  * 0.5 ' range=':=  _default_ * boplPeridotSize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplPeridotSize  * 0.5 ' range=':=  _default_ * boplPeridotSize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Peridot is complete. -->
-
-
-            <!-- Starting Cloud Preset for Peridot. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplPeridotDist = "Cloud"'>
-                    <Cloud name='boplPeridotCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Plains'  />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplPeridotFreq ' range=':=  _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='boplPeridotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
+                <!-- Starting Cloud Preset for Ruby. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplRubyDist = "Cloud"'>
+                        <Cloud name='boplRubyCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Peridot is complete. -->
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Desert'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplRubyFreq ' range=':=  _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='boplRubyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Ruby is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Peridot. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplPeridotDist = "Vanilla"'>
-                    <StandardGen name='boplPeridotStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Plains'  />
-                        <Setting name='Size' avg=':= 1 * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * boplPeridotFreq ' range=':=  _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Peridot is complete. -->
-
-            <!-- End Peridot Generation -->
-
-
-            <!-- Begin Topaz Generation -->
-
-            <!-- Starting PipeVeins Preset for Topaz. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplTopazDist = "PipeVeins"'>
-                    <Veins name='boplTopazVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
-                        <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Jungle'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplTopazFreq ' range=':=  _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='boplTopazVeinsPipe'  inherits='boplTopazVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
-                        <OreBlock block='minecraft:lava' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTopazSize  * 0.5 ' range=':=  _default_ * boplTopazSize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTopazSize  * 0.5 ' range=':=  _default_ * boplTopazSize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Topaz is complete. -->
-
-
-            <!-- Starting Cloud Preset for Topaz. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplTopazDist = "Cloud"'>
-                    <Cloud name='boplTopazCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Jungle'  />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplTopazFreq ' range=':=  _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='boplTopazHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
+                <!-- Starting Vanilla Preset for Ruby. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplRubyDist = "Vanilla"'>
+                        <StandardGen name='boplRubyStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Topaz is complete. -->
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Desert'  />
+                            <Setting name='Size' avg=':= 1 * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplRubyFreq ' range=':=  _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Ruby is complete. -->
+
+                <!-- End Ruby Generation -->
 
 
-            <!-- Starting Vanilla Preset for Topaz. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplTopazDist = "Vanilla"'>
-                    <StandardGen name='boplTopazStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Jungle'  />
-                        <Setting name='Size' avg=':= 1 * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * boplTopazFreq ' range=':=  _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Topaz is complete. -->
+                <!-- Begin Peridot Generation -->
 
-            <!-- End Topaz Generation -->
-
-
-            <!-- Begin Tanzanite Generation -->
-
-            <!-- Starting PipeVeins Preset for Tanzanite. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplTanzaniteDist = "PipeVeins"'>
-                    <Veins name='boplTanzaniteVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
-                        <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Frozen'  />
-                        <Biome name='Alps'  weight='-1' />
-                        <Biome name='AlpsForest'  weight='-1' />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplTanzaniteFreq ' range=':=  _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='boplTanzaniteVeinsPipe'  inherits='boplTanzaniteVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
-                        <OreBlock block='minecraft:lava' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTanzaniteSize  * 0.5 ' range=':=  _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTanzaniteSize  * 0.5 ' range=':=  _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Tanzanite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Tanzanite. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplTanzaniteDist = "Cloud"'>
-                    <Cloud name='boplTanzaniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Frozen'  />
-                        <Biome name='Alps'  weight='-1' />
-                        <Biome name='AlpsForest'  weight='-1' />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplTanzaniteFreq ' range=':=  _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='boplTanzaniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                <!-- Starting PipeVeins Preset for Peridot. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplPeridotDist = "PipeVeins"'>
+                        <Veins name='boplPeridotVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
                             </Description>
-                            <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Plains'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplPeridotFreq ' range=':=  _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Tanzanite is complete. -->
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='boplPeridotVeinsPipe'  inherits='boplPeridotVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplPeridotSize  * 0.5 ' range=':=  _default_ * boplPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplPeridotSize  * 0.5 ' range=':=  _default_ * boplPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Peridot is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Tanzanite. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplTanzaniteDist = "Vanilla"'>
-                    <StandardGen name='boplTanzaniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Frozen'  />
-                        <Biome name='Alps'  weight='-1' />
-                        <Biome name='AlpsForest'  weight='-1' />
-                        <Setting name='Size' avg=':= 1 * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * boplTanzaniteFreq ' range=':=  _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Tanzanite is complete. -->
-
-            <!-- End Tanzanite Generation -->
-
-
-            <!-- Begin Malachite Generation -->
-
-            <!-- Starting PipeVeins Preset for Malachite. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplMalachiteDist = "PipeVeins"'>
-                    <Veins name='boplMalachiteVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
-                        <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Swamp'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplMalachiteFreq ' range=':=  _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='boplMalachiteVeinsPipe'  inherits='boplMalachiteVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
-                        <OreBlock block='minecraft:lava' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplMalachiteSize  * 0.5 ' range=':=  _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplMalachiteSize  * 0.5 ' range=':=  _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Malachite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Malachite. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplMalachiteDist = "Cloud"'>
-                    <Cloud name='boplMalachiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Swamp'  />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplMalachiteFreq ' range=':=  _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='boplMalachiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                <!-- Starting Cloud Preset for Peridot. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplPeridotDist = "Cloud"'>
+                        <Cloud name='boplPeridotCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Malachite is complete. -->
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Plains'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplPeridotFreq ' range=':=  _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='boplPeridotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Peridot is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Malachite. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplMalachiteDist = "Vanilla"'>
-                    <StandardGen name='boplMalachiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Swamp'  />
-                        <Setting name='Size' avg=':= 1 * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * boplMalachiteFreq ' range=':=  _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Malachite is complete. -->
-
-            <!-- End Malachite Generation -->
-
-
-            <!-- Begin Sapphire Generation -->
-
-            <!-- Starting PipeVeins Preset for Sapphire. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplSapphireDist = "PipeVeins"'>
-                    <Veins name='boplSapphireVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
-                        <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='CoralReef'  />
-                        <Biome name='Crag'  />
-                        <Biome name='HotSprings'  />
-                        <Biome name='KelpForest'  />
-                        <Biome name='Mangrove'  />
-                        <Biome name='SacredSprings'  />
-                        <Biome name='Tropics'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplSapphireFreq ' range=':=  _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='boplSapphireVeinsPipe'  inherits='boplSapphireVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
-                        <OreBlock block='minecraft:lava' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplSapphireSize  * 0.5 ' range=':=  _default_ * boplSapphireSize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplSapphireSize  * 0.5 ' range=':=  _default_ * boplSapphireSize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Sapphire is complete. -->
-
-
-            <!-- Starting Cloud Preset for Sapphire. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplSapphireDist = "Cloud"'>
-                    <Cloud name='boplSapphireCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='CoralReef'  />
-                        <Biome name='Crag'  />
-                        <Biome name='HotSprings'  />
-                        <Biome name='KelpForest'  />
-                        <Biome name='Mangrove'  />
-                        <Biome name='SacredSprings'  />
-                        <Biome name='Tropics'  />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplSapphireFreq ' range=':=  _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='boplSapphireHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                <!-- Starting Vanilla Preset for Peridot. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplPeridotDist = "Vanilla"'>
+                        <StandardGen name='boplPeridotStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Sapphire is complete. -->
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Plains'  />
+                            <Setting name='Size' avg=':= 1 * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplPeridotFreq ' range=':=  _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Peridot is complete. -->
+
+                <!-- End Peridot Generation -->
 
 
-            <!-- Starting Vanilla Preset for Sapphire. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplSapphireDist = "Vanilla"'>
-                    <StandardGen name='boplSapphireStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='CoralReef'  />
-                        <Biome name='Crag'  />
-                        <Biome name='HotSprings'  />
-                        <Biome name='KelpForest'  />
-                        <Biome name='Mangrove'  />
-                        <Biome name='SacredSprings'  />
-                        <Biome name='Tropics'  />
-                        <Setting name='Size' avg=':= 1 * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * boplSapphireFreq ' range=':=  _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Sapphire is complete. -->
+                <!-- Begin Topaz Generation -->
 
-            <!-- End Sapphire Generation -->
-
-
-            <!-- Begin Amber Generation -->
-
-            <!-- Starting PipeVeins Preset for Amber. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplAmberDist = "PipeVeins"'>
-                    <Veins name='boplAmberVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
-                        <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='River'  />
-                        <Biome name='Grove'  />
-                        <Biome name='Shield'  />
-                        <Biome name='Thicket'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplAmberFreq ' range=':=  _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='boplAmberVeinsPipe'  inherits='boplAmberVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
-                        <OreBlock block='minecraft:lava' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplAmberSize  * 0.5 ' range=':=  _default_ * boplAmberSize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplAmberSize  * 0.5 ' range=':=  _default_ * boplAmberSize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Amber is complete. -->
-
-
-            <!-- Starting Cloud Preset for Amber. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplAmberDist = "Cloud"'>
-                    <Cloud name='boplAmberCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='River'  />
-                        <Biome name='Grove'  />
-                        <Biome name='Shield'  />
-                        <Biome name='Thicket'  />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplAmberFreq ' range=':=  _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='boplAmberHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                <!-- Starting PipeVeins Preset for Topaz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplTopazDist = "PipeVeins"'>
+                        <Veins name='boplTopazVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
                             </Description>
-                            <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Jungle'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplTopazFreq ' range=':=  _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Amber is complete. -->
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='boplTopazVeinsPipe'  inherits='boplTopazVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTopazSize  * 0.5 ' range=':=  _default_ * boplTopazSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTopazSize  * 0.5 ' range=':=  _default_ * boplTopazSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Topaz is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Amber. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplAmberDist = "Vanilla"'>
-                    <StandardGen name='boplAmberStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                <!-- Starting Cloud Preset for Topaz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplTopazDist = "Cloud"'>
+                        <Cloud name='boplTopazCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Jungle'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplTopazFreq ' range=':=  _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='boplTopazHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Topaz is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Topaz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplTopazDist = "Vanilla"'>
+                        <StandardGen name='boplTopazStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Jungle'  />
+                            <Setting name='Size' avg=':= 1 * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplTopazFreq ' range=':=  _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Topaz is complete. -->
+
+                <!-- End Topaz Generation -->
+
+
+                <!-- Begin Tanzanite Generation -->
+
+                <!-- Starting PipeVeins Preset for Tanzanite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplTanzaniteDist = "PipeVeins"'>
+                        <Veins name='boplTanzaniteVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                            <Description>
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Frozen'  />
+                            <Biome name='Alps'  weight='-1' />
+                            <Biome name='AlpsForest'  weight='-1' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplTanzaniteFreq ' range=':=  _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='boplTanzaniteVeinsPipe'  inherits='boplTanzaniteVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTanzaniteSize  * 0.5 ' range=':=  _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTanzaniteSize  * 0.5 ' range=':=  _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Tanzanite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Tanzanite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplTanzaniteDist = "Cloud"'>
+                        <Cloud name='boplTanzaniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Frozen'  />
+                            <Biome name='Alps'  weight='-1' />
+                            <Biome name='AlpsForest'  weight='-1' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplTanzaniteFreq ' range=':=  _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='boplTanzaniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tanzanite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Tanzanite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplTanzaniteDist = "Vanilla"'>
+                        <StandardGen name='boplTanzaniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Frozen'  />
+                            <Biome name='Alps'  weight='-1' />
+                            <Biome name='AlpsForest'  weight='-1' />
+                            <Setting name='Size' avg=':= 1 * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplTanzaniteFreq ' range=':=  _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tanzanite is complete. -->
+
+                <!-- End Tanzanite Generation -->
+
+
+                <!-- Begin Malachite Generation -->
+
+                <!-- Starting PipeVeins Preset for Malachite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplMalachiteDist = "PipeVeins"'>
+                        <Veins name='boplMalachiteVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                            <Description>
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Swamp'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplMalachiteFreq ' range=':=  _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='boplMalachiteVeinsPipe'  inherits='boplMalachiteVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplMalachiteSize  * 0.5 ' range=':=  _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplMalachiteSize  * 0.5 ' range=':=  _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Malachite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Malachite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplMalachiteDist = "Cloud"'>
+                        <Cloud name='boplMalachiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Swamp'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplMalachiteFreq ' range=':=  _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='boplMalachiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Malachite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Malachite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplMalachiteDist = "Vanilla"'>
+                        <StandardGen name='boplMalachiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Swamp'  />
+                            <Setting name='Size' avg=':= 1 * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplMalachiteFreq ' range=':=  _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Malachite is complete. -->
+
+                <!-- End Malachite Generation -->
+
+
+                <!-- Begin Sapphire Generation -->
+
+                <!-- Starting PipeVeins Preset for Sapphire. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplSapphireDist = "PipeVeins"'>
+                        <Veins name='boplSapphireVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                            <Description>
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='CoralReef'  />
+                            <Biome name='Crag'  />
+                            <Biome name='HotSprings'  />
+                            <Biome name='KelpForest'  />
+                            <Biome name='Mangrove'  />
+                            <Biome name='SacredSprings'  />
+                            <Biome name='Tropics'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplSapphireFreq ' range=':=  _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='boplSapphireVeinsPipe'  inherits='boplSapphireVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplSapphireSize  * 0.5 ' range=':=  _default_ * boplSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplSapphireSize  * 0.5 ' range=':=  _default_ * boplSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Sapphire is complete. -->
+
+
+                <!-- Starting Cloud Preset for Sapphire. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplSapphireDist = "Cloud"'>
+                        <Cloud name='boplSapphireCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='CoralReef'  />
+                            <Biome name='Crag'  />
+                            <Biome name='HotSprings'  />
+                            <Biome name='KelpForest'  />
+                            <Biome name='Mangrove'  />
+                            <Biome name='SacredSprings'  />
+                            <Biome name='Tropics'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplSapphireFreq ' range=':=  _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='boplSapphireHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Sapphire is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Sapphire. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplSapphireDist = "Vanilla"'>
+                        <StandardGen name='boplSapphireStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='CoralReef'  />
+                            <Biome name='Crag'  />
+                            <Biome name='HotSprings'  />
+                            <Biome name='KelpForest'  />
+                            <Biome name='Mangrove'  />
+                            <Biome name='SacredSprings'  />
+                            <Biome name='Tropics'  />
+                            <Setting name='Size' avg=':= 1 * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplSapphireFreq ' range=':=  _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Sapphire is complete. -->
+
+                <!-- End Sapphire Generation -->
+
+
+                <!-- Begin Amber Generation -->
+
+                <!-- Starting PipeVeins Preset for Amber. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplAmberDist = "PipeVeins"'>
+                        <Veins name='boplAmberVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                            <Description>
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='River'  />
+                            <Biome name='Grove'  />
+                            <Biome name='Shield'  />
+                            <Biome name='Thicket'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplAmberFreq ' range=':=  _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='boplAmberVeinsPipe'  inherits='boplAmberVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplAmberSize  * 0.5 ' range=':=  _default_ * boplAmberSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplAmberSize  * 0.5 ' range=':=  _default_ * boplAmberSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Amber is complete. -->
+
+
+                <!-- Starting Cloud Preset for Amber. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplAmberDist = "Cloud"'>
+                        <Cloud name='boplAmberCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='River'  />
+                            <Biome name='Grove'  />
+                            <Biome name='Shield'  />
+                            <Biome name='Thicket'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplAmberFreq ' range=':=  _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='boplAmberHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Amber is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Amber. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplAmberDist = "Vanilla"'>
+                        <StandardGen name='boplAmberStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='River'  />
+                            <Biome name='Grove'  />
+                            <Biome name='Shield'  />
+                            <Biome name='Thicket'  />
+                            <Setting name='Size' avg=':= 1 * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplAmberFreq ' range=':=  _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Amber is complete. -->
+
+                <!-- End Amber Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
+
+
+
+
+            <!-- End Setup Beginning -->
+
+            <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
+
+                <!-- Starting Original "End" Block Removal -->
+
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='boplEndBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            A master preset for standardgen ore
-                            distributions.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='River'  />
-                        <Biome name='Grove'  />
-                        <Biome name='Shield'  />
-                        <Biome name='Thicket'  />
-                        <Setting name='Size' avg=':= 1 * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * boplAmberFreq ' range=':=  _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <Replaces block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Amber is complete. -->
 
-            <!-- End Amber Generation -->
+                <!-- Original "End" Block Removal Complete -->
 
-            <!-- Finished adding blocks -->
+                <!-- Adding blocks -->
+
+                <!-- Begin EnderAmathyst Generation -->
+
+                <!-- Starting PipeVeins Preset for EnderAmathyst. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplEnderAmathystDist = "PipeVeins"'>
+                        <Veins name='boplEnderAmathystVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                            <Description>
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplEnderAmathystFreq ' range=':=  _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='boplEnderAmathystVeinsPipe'  inherits='boplEnderAmathystVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <Replaces block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':=  _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':=  _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for EnderAmathyst is complete. -->
+
+
+                <!-- Starting Cloud Preset for EnderAmathyst. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplEnderAmathystDist = "Cloud"'>
+                        <Cloud name='boplEnderAmathystCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplEnderAmathystFreq ' range=':=  _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='boplEnderAmathystHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for EnderAmathyst is complete. -->
+
+
+                <!-- Starting Vanilla Preset for EnderAmathyst. -->
+                <ConfigSection>
+                    <IfCondition condition=':= boplEnderAmathystDist = "Vanilla"'>
+                        <StandardGen name='boplEnderAmathystStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplEnderAmathystFreq ' range=':=  _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for EnderAmathyst is complete. -->
+
+                <!-- End EnderAmathyst Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- End Setup Complete -->
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
-
-
-
-        <!-- End Setup Beginning -->
-
-        <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
-
-            <!-- Starting Original "End" Block Removal -->
-
-            <Substitute name='boplEndBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='BiomesOPlenty:gemOre' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "End" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin EnderAmathyst Generation -->
-
-            <!-- Starting PipeVeins Preset for EnderAmathyst. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplEnderAmathystDist = "PipeVeins"'>
-                    <Veins name='boplEnderAmathystVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
-                        <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplEnderAmathystFreq ' range=':=  _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='boplEnderAmathystVeinsPipe'  inherits='boplEnderAmathystVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
-                        <OreBlock block='minecraft:lava' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='BiomesOPlenty:gemOre' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':=  _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':=  _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for EnderAmathyst is complete. -->
-
-
-            <!-- Starting Cloud Preset for EnderAmathyst. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplEnderAmathystDist = "Cloud"'>
-                    <Cloud name='boplEnderAmathystCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplEnderAmathystFreq ' range=':=  _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='boplEnderAmathystHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for EnderAmathyst is complete. -->
-
-
-            <!-- Starting Vanilla Preset for EnderAmathyst. -->
-            <ConfigSection>
-                <IfCondition condition=':= boplEnderAmathystDist = "Vanilla"'>
-                    <StandardGen name='boplEnderAmathystStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * boplEnderAmathystFreq ' range=':=  _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for EnderAmathyst is complete. -->
-
-            <!-- End EnderAmathyst Generation -->
-
-            <!-- Finished adding blocks -->
-
-        </IfCondition>
-        <!-- End Setup Complete -->
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -1,1150 +1,1435 @@
- <!-- ================================================================
-      Custom Ore Generation "Biomes O Plenty" Module: This
-      configuration covers enderamathyst, ruby, peridot, topaz,
-      tanzanite, apatite, and sapphire.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Biomes O Plenty" Module: This
+     configuration covers enderamathyst, ruby, peridot, topaz,
+     tanzanite, malachite, sapphire, and amber.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="BiomesOPlenty">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "Biomes O Plenty" mod on the system?  Let's find out! -->
+<IfModInstalled name="BiomesOPlenty">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupBiomesOPlenty' displayName='Biomes O Plenty' displayState='shown'>
+                <Description>
+                    Distribution options for Biomes O Plenty Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- EnderAmathyst Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupBiomesOPlenty' displayName='Biomes O Plenty' displayState='shown'> 
-                    <Description>
-                        Distribution options for Biomes O Plenty Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- EnderAmathyst Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='boplEnderAmathystDist'  displayState='shown' displayGroup='groupBiomesOPlenty'> 
-                        <Description> Controls how EnderAmathyst is generated </Description> 
-                        <DisplayName>Biomes O Plenty EnderAmathyst</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='EnderAmathyst is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='boplEnderAmathystFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Frequency multiplier for Biomes O Plenty EnderAmathyst distributions </Description>
-                        <DisplayName>Biomes O Plenty EnderAmathyst Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='boplEnderAmathystSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Size multiplier for Biomes O Plenty EnderAmathyst distributions </Description>
-                        <DisplayName>Biomes O Plenty EnderAmathyst Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- EnderAmathyst Configuration UI Complete -->
-                
-                
-                <!-- Ruby Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='boplRubyDist'  displayState='shown' displayGroup='groupBiomesOPlenty'> 
-                        <Description> Controls how Ruby is generated </Description> 
-                        <DisplayName>Biomes O Plenty Ruby</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Ruby is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='boplRubyFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Frequency multiplier for Biomes O Plenty Ruby distributions </Description>
-                        <DisplayName>Biomes O Plenty Ruby Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='boplRubySize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Size multiplier for Biomes O Plenty Ruby distributions </Description>
-                        <DisplayName>Biomes O Plenty Ruby Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Ruby Configuration UI Complete -->
-                
-                
-                <!-- Peridot Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='boplPeridotDist'  displayState='shown' displayGroup='groupBiomesOPlenty'> 
-                        <Description> Controls how Peridot is generated </Description> 
-                        <DisplayName>Biomes O Plenty Peridot</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Peridot is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='boplPeridotFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Frequency multiplier for Biomes O Plenty Peridot distributions </Description>
-                        <DisplayName>Biomes O Plenty Peridot Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='boplPeridotSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Size multiplier for Biomes O Plenty Peridot distributions </Description>
-                        <DisplayName>Biomes O Plenty Peridot Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Peridot Configuration UI Complete -->
-                
-                
-                <!-- Topaz Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='boplTopazDist'  displayState='shown' displayGroup='groupBiomesOPlenty'> 
-                        <Description> Controls how Topaz is generated </Description> 
-                        <DisplayName>Biomes O Plenty Topaz</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Topaz is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='boplTopazFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Frequency multiplier for Biomes O Plenty Topaz distributions </Description>
-                        <DisplayName>Biomes O Plenty Topaz Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='boplTopazSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Size multiplier for Biomes O Plenty Topaz distributions </Description>
-                        <DisplayName>Biomes O Plenty Topaz Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Topaz Configuration UI Complete -->
-                
-                
-                <!-- Tanzanite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='boplTanzaniteDist'  displayState='shown' displayGroup='groupBiomesOPlenty'> 
-                        <Description> Controls how Tanzanite is generated </Description> 
-                        <DisplayName>Biomes O Plenty Tanzanite</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Tanzanite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='boplTanzaniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Frequency multiplier for Biomes O Plenty Tanzanite distributions </Description>
-                        <DisplayName>Biomes O Plenty Tanzanite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='boplTanzaniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Size multiplier for Biomes O Plenty Tanzanite distributions </Description>
-                        <DisplayName>Biomes O Plenty Tanzanite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Tanzanite Configuration UI Complete -->
-                
-                
-                <!-- Apatite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='boplApatiteDist'  displayState='shown' displayGroup='groupBiomesOPlenty'> 
-                        <Description> Controls how Apatite is generated </Description> 
-                        <DisplayName>Biomes O Plenty Apatite</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Apatite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='boplApatiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Frequency multiplier for Biomes O Plenty Apatite distributions </Description>
-                        <DisplayName>Biomes O Plenty Apatite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='boplApatiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Size multiplier for Biomes O Plenty Apatite distributions </Description>
-                        <DisplayName>Biomes O Plenty Apatite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Apatite Configuration UI Complete -->
-                
-                
-                <!-- Sapphire Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='boplSapphireDist'  displayState='shown' displayGroup='groupBiomesOPlenty'> 
-                        <Description> Controls how Sapphire is generated </Description> 
-                        <DisplayName>Biomes O Plenty Sapphire</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Sapphire is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='boplSapphireFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Frequency multiplier for Biomes O Plenty Sapphire distributions </Description>
-                        <DisplayName>Biomes O Plenty Sapphire Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='boplSapphireSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
-                        <Description> Size multiplier for Biomes O Plenty Sapphire distributions </Description>
-                        <DisplayName>Biomes O Plenty Sapphire Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Sapphire Configuration UI Complete -->
-                
+                <OptionChoice name='boplEnderAmathystDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                    <Description> Controls how EnderAmathyst is generated </Description>
+                    <DisplayName>Biomes O Plenty EnderAmathyst</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
+                        <Description>
+                            Short and sparsely filled compound veins containing one material inside another.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='EnderAmathyst is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='boplEnderAmathystFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Frequency multiplier for Biomes O Plenty EnderAmathyst distributions </Description>
+                    <DisplayName>Biomes O Plenty EnderAmathyst Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='boplEnderAmathystSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Size multiplier for Biomes O Plenty EnderAmathyst distributions </Description>
+                    <DisplayName>Biomes O Plenty EnderAmathyst Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- EnderAmathyst Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='boplOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='BiomesOPlenty:gemOre:2' />
-                    <Replaces block='BiomesOPlenty:gemOre:4' />
-                    <Replaces block='BiomesOPlenty:gemOre:6' />
-                    <Replaces block='BiomesOPlenty:gemOre:8' />
-                    <Replaces block='BiomesOPlenty:gemOre:10' />
-                    <Replaces block='BiomesOPlenty:gemOre:12' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Ruby Generation --> 
-                
-                <!-- Begin Sparse Veins distribution of Ruby -->
-                <IfCondition condition=':= boplRubyDist = "sparseVeins"'>
-                
-                    <Veins name='boplRubyBaseVeins' block='BiomesOPlenty:gemOre:2'  inherits='PresetSparseVeins' >
+            <!-- Ruby Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='boplRubyDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                    <Description> Controls how Ruby is generated </Description>
+                    <DisplayName>Biomes O Plenty Ruby</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
-                            Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
+                            Short and sparsely filled compound veins containing one material inside another.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C60031</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * boplRubySize * _default_' range=':= 1 * 0.5 * boplRubySize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplRubySize * _default_' range=':= 1 * 0.5 * boplRubySize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.4 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * boplRubyFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.25 * _default_' range=':= 0.25 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplRubySize * 0.7 * _default_' range=':= 1 * 0.5 * boplRubySize * 0.5 * _default_'/>
-                        <Setting name='SegmentAngle' avg=':= 0.6' range=':= 0.40'/>
-                        <BiomeType name='Sandy'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Sparse Veins distribution of Ruby -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Ruby -->
-                <IfCondition condition=':= boplRubyDist = "strategicCloud"'>
-                
-                    <Cloud name='boplRubyBaseCloud' block='BiomesOPlenty:gemOre:2' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C60031</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.5 * boplRubySize * _default_' range=':= 1 * 0.5 * boplRubySize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.5 * boplRubySize * _default_' range=':= 1 * 0.5 * boplRubySize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.5 * 0.5 * boplRubySize * _default_' range=':= 1 * 0.5 * 0.5 * boplRubySize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * boplRubyFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Sandy'/>
-                        
-                        <!-- Begin Ruby Strategic Cloud Hint Veins -->
-                        <Veins name='boplRubyBaseHintVeins' block='BiomesOPlenty:gemOre:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60C60031</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Sandy'/>
-                        </Veins>
-                        <!-- End Ruby Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Ruby is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='boplRubyFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Frequency multiplier for Biomes O Plenty Ruby distributions </Description>
+                    <DisplayName>Biomes O Plenty Ruby Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='boplRubySize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Size multiplier for Biomes O Plenty Ruby distributions </Description>
+                    <DisplayName>Biomes O Plenty Ruby Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Ruby Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Ruby -->
-                
-                
-                <!-- Begin  Vanilla distribution of Ruby -->
-                <IfCondition condition=':= boplRubyDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='boplRubyBaseStandard' block='BiomesOPlenty:gemOre:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C60031</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * boplRubySize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 12' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 2 * boplRubyFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Sandy'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Ruby -->
-                
-                <!-- End Ruby Generation --> 
 
-                
-                <!-- Begin Peridot Generation --> 
-                
-                <!-- Begin Sparse Veins distribution of Peridot -->
-                <IfCondition condition=':= boplPeridotDist = "sparseVeins"'>
-                
-                    <Veins name='boplPeridotBaseVeins' block='BiomesOPlenty:gemOre:4'  inherits='PresetSparseVeins' >
+            <!-- Peridot Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='boplPeridotDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                    <Description> Controls how Peridot is generated </Description>
+                    <DisplayName>Biomes O Plenty Peridot</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
-                            Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
+                            Short and sparsely filled compound veins containing one material inside another.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60076855</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * boplPeridotSize * _default_' range=':= 1 * 0.5 * boplPeridotSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplPeridotSize * _default_' range=':= 1 * 0.5 * boplPeridotSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.4 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * boplPeridotFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.25 * _default_' range=':= 0.25 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplPeridotSize * 0.7 * _default_' range=':= 1 * 0.5 * boplPeridotSize * 0.5 * _default_'/>
-                        <Setting name='SegmentAngle' avg=':= 0.6' range=':= 0.40'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Cold' weight='-1'/>
-                        <BiomeType name='Dry' weight='-1'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Sparse Veins distribution of Peridot -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Peridot -->
-                <IfCondition condition=':= boplPeridotDist = "strategicCloud"'>
-                
-                    <Cloud name='boplPeridotBaseCloud' block='BiomesOPlenty:gemOre:4' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60076855</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.5 * boplPeridotSize * _default_' range=':= 1 * 0.5 * boplPeridotSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.5 * boplPeridotSize * _default_' range=':= 1 * 0.5 * boplPeridotSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 12' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.5 * 0.5 * boplPeridotSize * _default_' range=':= 1 * 0.5 * 0.5 * boplPeridotSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * boplPeridotFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Cold' weight='-1'/>
-                        <BiomeType name='Dry' weight='-1'/>
-                        
-                        <!-- Begin Peridot Strategic Cloud Hint Veins -->
-                        <Veins name='boplPeridotBaseHintVeins' block='BiomesOPlenty:gemOre:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60076855</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Plains'/>
-                            <BiomeType name='Cold' weight='-1'/>
-                            <BiomeType name='Dry' weight='-1'/>
-                        </Veins>
-                        <!-- End Peridot Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Peridot is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='boplPeridotFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Frequency multiplier for Biomes O Plenty Peridot distributions </Description>
+                    <DisplayName>Biomes O Plenty Peridot Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='boplPeridotSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Size multiplier for Biomes O Plenty Peridot distributions </Description>
+                    <DisplayName>Biomes O Plenty Peridot Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Peridot Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Peridot -->
-                
-                
-                <!-- Begin  Vanilla distribution of Peridot -->
-                <IfCondition condition=':= boplPeridotDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='boplPeridotBaseStandard' block='BiomesOPlenty:gemOre:4' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60076855</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * boplPeridotSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 12' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 2 * boplPeridotFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Cold' weight='-1'/>
-                        <BiomeType name='Dry' weight='-1'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Peridot -->
-                
-                <!-- End Peridot Generation --> 
 
-                
-                <!-- Begin Topaz Generation --> 
-                
-                <!-- Begin Sparse Veins distribution of Topaz -->
-                <IfCondition condition=':= boplTopazDist = "sparseVeins"'>
-                
-                    <Veins name='boplTopazBaseVeins' block='BiomesOPlenty:gemOre:6'  inherits='PresetSparseVeins' >
+            <!-- Topaz Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='boplTopazDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                    <Description> Controls how Topaz is generated </Description>
+                    <DisplayName>Biomes O Plenty Topaz</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
-                            Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
+                            Short and sparsely filled compound veins containing one material inside another.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D95A03</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * boplTopazSize * _default_' range=':= 1 * 0.5 * boplTopazSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplTopazSize * _default_' range=':= 1 * 0.5 * boplTopazSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.4 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * boplTopazFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.25 * _default_' range=':= 0.25 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplTopazSize * 0.7 * _default_' range=':= 1 * 0.5 * boplTopazSize * 0.5 * _default_'/>
-                        <Setting name='SegmentAngle' avg=':= 0.6' range=':= 0.40'/>
-                        <BiomeType name='Jungle'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Sparse Veins distribution of Topaz -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Topaz -->
-                <IfCondition condition=':= boplTopazDist = "strategicCloud"'>
-                
-                    <Cloud name='boplTopazBaseCloud' block='BiomesOPlenty:gemOre:6' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D95A03</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.5 * boplTopazSize * _default_' range=':= 1 * 0.5 * boplTopazSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.5 * boplTopazSize * _default_' range=':= 1 * 0.5 * boplTopazSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.4 * 0.5 * boplTopazSize * _default_' range=':= 1 * 0.4 * 0.5 * boplTopazSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * boplTopazFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Jungle'/>
-                        
-                        <!-- Begin Topaz Strategic Cloud Hint Veins -->
-                        <Veins name='boplTopazBaseHintVeins' block='BiomesOPlenty:gemOre:6' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60D95A03</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Jungle'/>
-                        </Veins>
-                        <!-- End Topaz Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Topaz is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='boplTopazFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Frequency multiplier for Biomes O Plenty Topaz distributions </Description>
+                    <DisplayName>Biomes O Plenty Topaz Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='boplTopazSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Size multiplier for Biomes O Plenty Topaz distributions </Description>
+                    <DisplayName>Biomes O Plenty Topaz Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Topaz Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Topaz -->
-                
-                
-                <!-- Begin  Vanilla distribution of Topaz -->
-                <IfCondition condition=':= boplTopazDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='boplTopazBaseStandard' block='BiomesOPlenty:gemOre:6' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D95A03</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * boplTopazSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 12' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 2 * boplTopazFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Jungle'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Topaz -->
-                
-                <!-- End Topaz Generation --> 
 
-                
-                <!-- Begin Tanzanite Generation --> 
-                
-                <!-- Begin Sparse Veins distribution of Tanzanite -->
-                <IfCondition condition=':= boplTanzaniteDist = "sparseVeins"'>
-                
-                    <Veins name='boplTanzaniteBaseVeins' block='BiomesOPlenty:gemOre:8'  inherits='PresetSparseVeins' >
+            <!-- Tanzanite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='boplTanzaniteDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                    <Description> Controls how Tanzanite is generated </Description>
+                    <DisplayName>Biomes O Plenty Tanzanite</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
-                            Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
+                            Short and sparsely filled compound veins containing one material inside another.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607701B9</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * boplTanzaniteSize * _default_' range=':= 1 * 0.5 * boplTanzaniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplTanzaniteSize * _default_' range=':= 1 * 0.5 * boplTanzaniteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.4 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * boplTanzaniteFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.25 * _default_' range=':= 0.25 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplTanzaniteSize * 0.7 * _default_' range=':= 1 * 0.5 * boplTanzaniteSize * 0.5 * _default_'/>
-                        <Setting name='SegmentAngle' avg=':= 0.6' range=':= 0.40'/>
-                        <BiomeType name='Cold'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Sparse Veins distribution of Tanzanite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Tanzanite -->
-                <IfCondition condition=':= boplTanzaniteDist = "strategicCloud"'>
-                
-                    <Cloud name='boplTanzaniteBaseCloud' block='BiomesOPlenty:gemOre:8' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607701B9</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.5 * boplTanzaniteSize * _default_' range=':= 1 * 0.5 * boplTanzaniteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.5 * boplTanzaniteSize * _default_' range=':= 1 * 0.5 * boplTanzaniteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.5 * 0.5 * boplTanzaniteSize * _default_' range=':= 1 * 0.5 * 0.5 * boplTanzaniteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * boplTanzaniteFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Cold'/>
-                        
-                        <!-- Begin Tanzanite Strategic Cloud Hint Veins -->
-                        <Veins name='boplTanzaniteBaseHintVeins' block='BiomesOPlenty:gemOre:8' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x607701B9</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Cold'/>
-                        </Veins>
-                        <!-- End Tanzanite Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Tanzanite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='boplTanzaniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Frequency multiplier for Biomes O Plenty Tanzanite distributions </Description>
+                    <DisplayName>Biomes O Plenty Tanzanite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='boplTanzaniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Size multiplier for Biomes O Plenty Tanzanite distributions </Description>
+                    <DisplayName>Biomes O Plenty Tanzanite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Tanzanite Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Tanzanite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Tanzanite -->
-                <IfCondition condition=':= boplTanzaniteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='boplTanzaniteBaseStandard' block='BiomesOPlenty:gemOre:8' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607701B9</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * boplTanzaniteSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 12' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 2 * boplTanzaniteFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Cold'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Tanzanite -->
-                
-                <!-- End Tanzanite Generation --> 
 
-                
-                <!-- Begin Apatite Generation --> 
-                
-                <!-- Begin Sparse Veins distribution of Apatite -->
-                <IfCondition condition=':= boplApatiteDist = "sparseVeins"'>
-                
-                    <Veins name='boplApatiteBaseVeins' block='BiomesOPlenty:gemOre:10'  inherits='PresetSparseVeins' >
+            <!-- Malachite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='boplMalachiteDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                    <Description> Controls how Malachite is generated </Description>
+                    <DisplayName>Biomes O Plenty Malachite</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
-                            Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
+                            Short and sparsely filled compound veins containing one material inside another.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60109D81</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * boplApatiteSize * _default_' range=':= 1 * 1 * boplApatiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 55' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * boplApatiteSize * _default_' range=':= 1 * 1 * boplApatiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 5 * boplApatiteFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Swamp'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Sparse Veins distribution of Apatite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Apatite -->
-                <IfCondition condition=':= boplApatiteDist = "strategicCloud"'>
-                
-                    <Cloud name='boplApatiteBaseCloud' block='BiomesOPlenty:gemOre:10' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60109D81</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1.2 * boplApatiteSize * _default_' range=':= 1 * 1.2 * boplApatiteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.2 * boplApatiteSize * _default_' range=':= 1 * 1.2 * boplApatiteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.75 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1.2 * boplApatiteSize * _default_' range=':= 1 * 1 * 1.2 * boplApatiteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 5 * boplApatiteFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Swamp'/>
-                        
-                        <!-- Begin Apatite Strategic Cloud Hint Veins -->
-                        <Veins name='boplApatiteBaseHintVeins' block='BiomesOPlenty:gemOre:10' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60109D81</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Swamp'/>
-                        </Veins>
-                        <!-- End Apatite Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Malachite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='boplMalachiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Frequency multiplier for Biomes O Plenty Malachite distributions </Description>
+                    <DisplayName>Biomes O Plenty Malachite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='boplMalachiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Size multiplier for Biomes O Plenty Malachite distributions </Description>
+                    <DisplayName>Biomes O Plenty Malachite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Malachite Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Apatite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Apatite -->
-                <IfCondition condition=':= boplApatiteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='boplApatiteBaseStandard' block='BiomesOPlenty:gemOre:10' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60109D81</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * boplApatiteSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 12' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 2 * boplApatiteFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Swamp'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Apatite -->
-                
-                <!-- End Apatite Generation --> 
 
-                
-                <!-- Begin Sapphire Generation --> 
-                
-                <!-- Begin Sparse Veins distribution of Sapphire -->
-                <IfCondition condition=':= boplSapphireDist = "sparseVeins"'>
-                
-                    <Veins name='boplSapphireBaseVeins' block='BiomesOPlenty:gemOre:12'  inherits='PresetSparseVeins' >
+            <!-- Sapphire Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='boplSapphireDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                    <Description> Controls how Sapphire is generated </Description>
+                    <DisplayName>Biomes O Plenty Sapphire</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
-                            Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
+                            Short and sparsely filled compound veins containing one material inside another.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x603494C3</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * boplSapphireSize * _default_' range=':= 1 * 0.5 * boplSapphireSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplSapphireSize * _default_' range=':= 1 * 0.5 * boplSapphireSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.4 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * boplSapphireFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.25 * _default_' range=':= 0.25 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.5 * boplSapphireSize * 0.7 * _default_' range=':= 1 * 0.5 * boplSapphireSize * 0.5 * _default_'/>
-                        <Setting name='SegmentAngle' avg=':= 0.6' range=':= 0.40'/>
-                        <BiomeType name='Ocean'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Sparse Veins distribution of Sapphire -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Sapphire -->
-                <IfCondition condition=':= boplSapphireDist = "strategicCloud"'>
-                
-                    <Cloud name='boplSapphireBaseCloud' block='BiomesOPlenty:gemOre:12' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x603494C3</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.5 * boplSapphireSize * _default_' range=':= 1 * 0.5 * boplSapphireSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.5 * boplSapphireSize * _default_' range=':= 1 * 0.5 * boplSapphireSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 32' range=':= 12' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.5 * 0.5 * boplSapphireSize * _default_' range=':= 1 * 0.5 * 0.5 * boplSapphireSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * boplSapphireFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Ocean'/>
-                        
-                        <!-- Begin Sapphire Strategic Cloud Hint Veins -->
-                        <Veins name='boplSapphireBaseHintVeins' block='BiomesOPlenty:gemOre:12' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x603494C3</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Ocean'/>
-                        </Veins>
-                        <!-- End Sapphire Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Sapphire is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='boplSapphireFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Frequency multiplier for Biomes O Plenty Sapphire distributions </Description>
+                    <DisplayName>Biomes O Plenty Sapphire Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='boplSapphireSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Size multiplier for Biomes O Plenty Sapphire distributions </Description>
+                    <DisplayName>Biomes O Plenty Sapphire Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Sapphire Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Sapphire -->
-                
-                
-                <!-- Begin  Vanilla distribution of Sapphire -->
-                <IfCondition condition=':= boplSapphireDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='boplSapphireBaseStandard' block='BiomesOPlenty:gemOre:12' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x603494C3</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * boplSapphireSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 12' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 2 * boplSapphireFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Ocean'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Sapphire -->
-                
-                <!-- End Sapphire Generation --> 
 
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-            <!-- Setup End -->
-            <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
-                
-                <!-- Starting Original End Ore Removal -->
-                <Substitute name='boplEndOreSubstitute0' block='minecraft:end_stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='BiomesOPlenty:gemOre' />
-                </Substitute>
-                <!-- Original End Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin EnderAmathyst Generation --> 
-                
-                <!-- Begin Layered Veins distribution of EnderAmathyst -->
-                <IfCondition condition=':= boplEnderAmathystDist = "layeredVeins"'>
-                
-                    <Veins name='boplEnderAmathystBaseVeins' block='BiomesOPlenty:gemOre'  inherits='PresetLayeredVeins' >
+            <!-- Amber Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='boplAmberDist'  displayState='shown' displayGroup='groupBiomesOPlenty'>
+                    <Description> Controls how Amber is generated </Description>
+                    <DisplayName>Biomes O Plenty Amber</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Short and sparsely filled compound veins containing one material inside another.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DD4EEA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * boplEnderAmathystSize * _default_' range=':= 1 * 1 * boplEnderAmathystSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * boplEnderAmathystSize * _default_' range=':= 1 * 1 * boplEnderAmathystSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * boplEnderAmathystFreq * _default_'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of EnderAmathyst -->
-                
-                
-                <!-- Begin  Huge Veins distribution of EnderAmathyst -->
-                <IfCondition condition=':= boplEnderAmathystDist = "hugeVeins"'>
-                
-                    <Veins name='boplEnderAmathystBaseVeins' block='BiomesOPlenty:gemOre'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DD4EEA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * boplEnderAmathystSize * _default_' range=':= 1 * 1 * boplEnderAmathystSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * boplEnderAmathystSize * _default_' range=':= 1 * 1 * boplEnderAmathystSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * boplEnderAmathystFreq * _default_'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of EnderAmathyst -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of EnderAmathyst -->
-                <IfCondition condition=':= boplEnderAmathystDist = "strategicCloud"'>
-                
-                    <Cloud name='boplEnderAmathystBaseCloud' block='BiomesOPlenty:gemOre' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DD4EEA</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * boplEnderAmathystSize * _default_' range=':= 1 * 1 * boplEnderAmathystSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * boplEnderAmathystSize * _default_' range=':= 1 * 1 * boplEnderAmathystSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * boplEnderAmathystSize * _default_' range=':= 1 * 1 * 1 * boplEnderAmathystSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * boplEnderAmathystFreq *_default_'/>
-                        <Replaces block='minecraft:end_stone'/>
-                        
-                        <!-- Begin EnderAmathyst Strategic Cloud Hint Veins -->
-                        <Veins name='boplEnderAmathystBaseHintVeins' block='BiomesOPlenty:gemOre' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DD4EEA</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:end_stone'/>
-                        </Veins>
-                        <!-- End EnderAmathyst Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Amber is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='boplAmberFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Frequency multiplier for Biomes O Plenty Amber distributions </Description>
+                    <DisplayName>Biomes O Plenty Amber Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='boplAmberSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Size multiplier for Biomes O Plenty Amber distributions </Description>
+                    <DisplayName>Biomes O Plenty Amber Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Amber Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of EnderAmathyst -->
-                
-                
-                <!-- Begin  Vanilla distribution of EnderAmathyst -->
-                <IfCondition condition=':= boplEnderAmathystDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='boplEnderAmathystBaseStandard' block='BiomesOPlenty:gemOre' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DD4EEA</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * boplEnderAmathystSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * boplEnderAmathystFreq * _default_'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of EnderAmathyst -->
-                
-                <!-- End EnderAmathyst Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- End Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='boplOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' />
+                <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' />
+                <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' />
+                <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' />
+                <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' />
+                <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' />
+                <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Ruby Generation -->
+
+            <!-- Starting PipeVeins Preset for Ruby. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplRubyDist = "PipeVeins"'>
+                    <Veins name='boplRubyVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
+                            from near the bottom of the map.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Desert'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplRubyFreq ' range=':=  _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='boplRubyVeinsPipe'  inherits='boplRubyVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
+                        <OreBlock block='minecraft:lava' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplRubySize  * 0.5 ' range=':=  _default_ * boplRubySize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplRubySize  * 0.5 ' range=':=  _default_ * boplRubySize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- PipeVeins Preset for Ruby is complete. -->
+
+
+            <!-- Starting Cloud Preset for Ruby. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplRubyDist = "Cloud"'>
+                    <Cloud name='boplRubyCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Desert'  />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplRubyFreq ' range=':=  _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='boplRubyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Ruby is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Ruby. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplRubyDist = "Vanilla"'>
+                    <StandardGen name='boplRubyStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Desert'  />
+                        <Setting name='Size' avg=':= 1 * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * boplRubyFreq ' range=':=  _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Ruby is complete. -->
+
+            <!-- End Ruby Generation -->
+
+
+            <!-- Begin Peridot Generation -->
+
+            <!-- Starting PipeVeins Preset for Peridot. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplPeridotDist = "PipeVeins"'>
+                    <Veins name='boplPeridotVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
+                            from near the bottom of the map.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Plains'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplPeridotFreq ' range=':=  _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='boplPeridotVeinsPipe'  inherits='boplPeridotVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
+                        <OreBlock block='minecraft:lava' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplPeridotSize  * 0.5 ' range=':=  _default_ * boplPeridotSize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplPeridotSize  * 0.5 ' range=':=  _default_ * boplPeridotSize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- PipeVeins Preset for Peridot is complete. -->
+
+
+            <!-- Starting Cloud Preset for Peridot. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplPeridotDist = "Cloud"'>
+                    <Cloud name='boplPeridotCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Plains'  />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplPeridotFreq ' range=':=  _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='boplPeridotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Peridot is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Peridot. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplPeridotDist = "Vanilla"'>
+                    <StandardGen name='boplPeridotStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Plains'  />
+                        <Setting name='Size' avg=':= 1 * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * boplPeridotFreq ' range=':=  _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Peridot is complete. -->
+
+            <!-- End Peridot Generation -->
+
+
+            <!-- Begin Topaz Generation -->
+
+            <!-- Starting PipeVeins Preset for Topaz. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplTopazDist = "PipeVeins"'>
+                    <Veins name='boplTopazVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
+                            from near the bottom of the map.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Jungle'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplTopazFreq ' range=':=  _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='boplTopazVeinsPipe'  inherits='boplTopazVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
+                        <OreBlock block='minecraft:lava' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTopazSize  * 0.5 ' range=':=  _default_ * boplTopazSize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTopazSize  * 0.5 ' range=':=  _default_ * boplTopazSize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- PipeVeins Preset for Topaz is complete. -->
+
+
+            <!-- Starting Cloud Preset for Topaz. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplTopazDist = "Cloud"'>
+                    <Cloud name='boplTopazCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Jungle'  />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplTopazFreq ' range=':=  _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='boplTopazHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Topaz is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Topaz. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplTopazDist = "Vanilla"'>
+                    <StandardGen name='boplTopazStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Jungle'  />
+                        <Setting name='Size' avg=':= 1 * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * boplTopazFreq ' range=':=  _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Topaz is complete. -->
+
+            <!-- End Topaz Generation -->
+
+
+            <!-- Begin Tanzanite Generation -->
+
+            <!-- Starting PipeVeins Preset for Tanzanite. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplTanzaniteDist = "PipeVeins"'>
+                    <Veins name='boplTanzaniteVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
+                            from near the bottom of the map.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Frozen'  />
+                        <Biome name='Alps'  weight='-1' />
+                        <Biome name='AlpsForest'  weight='-1' />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplTanzaniteFreq ' range=':=  _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='boplTanzaniteVeinsPipe'  inherits='boplTanzaniteVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                        <OreBlock block='minecraft:lava' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTanzaniteSize  * 0.5 ' range=':=  _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTanzaniteSize  * 0.5 ' range=':=  _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- PipeVeins Preset for Tanzanite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Tanzanite. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplTanzaniteDist = "Cloud"'>
+                    <Cloud name='boplTanzaniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Frozen'  />
+                        <Biome name='Alps'  weight='-1' />
+                        <Biome name='AlpsForest'  weight='-1' />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplTanzaniteFreq ' range=':=  _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='boplTanzaniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Tanzanite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Tanzanite. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplTanzaniteDist = "Vanilla"'>
+                    <StandardGen name='boplTanzaniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Frozen'  />
+                        <Biome name='Alps'  weight='-1' />
+                        <Biome name='AlpsForest'  weight='-1' />
+                        <Setting name='Size' avg=':= 1 * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * boplTanzaniteFreq ' range=':=  _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Tanzanite is complete. -->
+
+            <!-- End Tanzanite Generation -->
+
+
+            <!-- Begin Malachite Generation -->
+
+            <!-- Starting PipeVeins Preset for Malachite. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplMalachiteDist = "PipeVeins"'>
+                    <Veins name='boplMalachiteVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
+                            from near the bottom of the map.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Swamp'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplMalachiteFreq ' range=':=  _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='boplMalachiteVeinsPipe'  inherits='boplMalachiteVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                        <OreBlock block='minecraft:lava' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplMalachiteSize  * 0.5 ' range=':=  _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplMalachiteSize  * 0.5 ' range=':=  _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- PipeVeins Preset for Malachite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Malachite. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplMalachiteDist = "Cloud"'>
+                    <Cloud name='boplMalachiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Swamp'  />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplMalachiteFreq ' range=':=  _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='boplMalachiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Malachite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Malachite. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplMalachiteDist = "Vanilla"'>
+                    <StandardGen name='boplMalachiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Swamp'  />
+                        <Setting name='Size' avg=':= 1 * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * boplMalachiteFreq ' range=':=  _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Malachite is complete. -->
+
+            <!-- End Malachite Generation -->
+
+
+            <!-- Begin Sapphire Generation -->
+
+            <!-- Starting PipeVeins Preset for Sapphire. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplSapphireDist = "PipeVeins"'>
+                    <Veins name='boplSapphireVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
+                            from near the bottom of the map.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='CoralReef'  />
+                        <Biome name='Crag'  />
+                        <Biome name='HotSprings'  />
+                        <Biome name='KelpForest'  />
+                        <Biome name='Mangrove'  />
+                        <Biome name='SacredSprings'  />
+                        <Biome name='Tropics'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplSapphireFreq ' range=':=  _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='boplSapphireVeinsPipe'  inherits='boplSapphireVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                        <OreBlock block='minecraft:lava' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplSapphireSize  * 0.5 ' range=':=  _default_ * boplSapphireSize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplSapphireSize  * 0.5 ' range=':=  _default_ * boplSapphireSize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- PipeVeins Preset for Sapphire is complete. -->
+
+
+            <!-- Starting Cloud Preset for Sapphire. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplSapphireDist = "Cloud"'>
+                    <Cloud name='boplSapphireCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='CoralReef'  />
+                        <Biome name='Crag'  />
+                        <Biome name='HotSprings'  />
+                        <Biome name='KelpForest'  />
+                        <Biome name='Mangrove'  />
+                        <Biome name='SacredSprings'  />
+                        <Biome name='Tropics'  />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplSapphireFreq ' range=':=  _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='boplSapphireHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Sapphire is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Sapphire. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplSapphireDist = "Vanilla"'>
+                    <StandardGen name='boplSapphireStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='CoralReef'  />
+                        <Biome name='Crag'  />
+                        <Biome name='HotSprings'  />
+                        <Biome name='KelpForest'  />
+                        <Biome name='Mangrove'  />
+                        <Biome name='SacredSprings'  />
+                        <Biome name='Tropics'  />
+                        <Setting name='Size' avg=':= 1 * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * boplSapphireFreq ' range=':=  _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Sapphire is complete. -->
+
+            <!-- End Sapphire Generation -->
+
+
+            <!-- Begin Amber Generation -->
+
+            <!-- Starting PipeVeins Preset for Amber. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplAmberDist = "PipeVeins"'>
+                    <Veins name='boplAmberVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
+                            from near the bottom of the map.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='River'  />
+                        <Biome name='Grove'  />
+                        <Biome name='Shield'  />
+                        <Biome name='Thicket'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplAmberFreq ' range=':=  _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='boplAmberVeinsPipe'  inherits='boplAmberVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                        <OreBlock block='minecraft:lava' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplAmberSize  * 0.5 ' range=':=  _default_ * boplAmberSize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplAmberSize  * 0.5 ' range=':=  _default_ * boplAmberSize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- PipeVeins Preset for Amber is complete. -->
+
+
+            <!-- Starting Cloud Preset for Amber. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplAmberDist = "Cloud"'>
+                    <Cloud name='boplAmberCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='River'  />
+                        <Biome name='Grove'  />
+                        <Biome name='Shield'  />
+                        <Biome name='Thicket'  />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplAmberFreq ' range=':=  _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='boplAmberHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Amber is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Amber. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplAmberDist = "Vanilla"'>
+                    <StandardGen name='boplAmberStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='River'  />
+                        <Biome name='Grove'  />
+                        <Biome name='Shield'  />
+                        <Biome name='Thicket'  />
+                        <Setting name='Size' avg=':= 1 * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * boplAmberFreq ' range=':=  _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Amber is complete. -->
+
+            <!-- End Amber Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+
+
+        <!-- End Setup Beginning -->
+
+        <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
+
+            <!-- Starting Original "End" Block Removal -->
+
+            <Substitute name='boplEndBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='BiomesOPlenty:gemOre' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "End" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin EnderAmathyst Generation -->
+
+            <!-- Starting PipeVeins Preset for EnderAmathyst. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplEnderAmathystDist = "PipeVeins"'>
+                    <Veins name='boplEnderAmathystVeins'  inherits='PresetPipeVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
+                            from near the bottom of the map.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplEnderAmathystFreq ' range=':=  _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='boplEnderAmathystVeinsPipe'  inherits='boplEnderAmathystVeins' seed='0xB6C7' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                        <OreBlock block='minecraft:lava' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':=  _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':=  _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- PipeVeins Preset for EnderAmathyst is complete. -->
+
+
+            <!-- Starting Cloud Preset for EnderAmathyst. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplEnderAmathystDist = "Cloud"'>
+                    <Cloud name='boplEnderAmathystCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplEnderAmathystFreq ' range=':=  _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='boplEnderAmathystHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for EnderAmathyst is complete. -->
+
+
+            <!-- Starting Vanilla Preset for EnderAmathyst. -->
+            <ConfigSection>
+                <IfCondition condition=':= boplEnderAmathystDist = "Vanilla"'>
+                    <StandardGen name='boplEnderAmathystStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 1 * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * boplEnderAmathystFreq ' range=':=  _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for EnderAmathyst is complete. -->
+
+            <!-- End EnderAmathyst Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- End Setup Complete -->
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Biomes O Plenty" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/Chisel2.xml
+++ b/src/main/resources/config/modules/Chisel2.xml
@@ -27,10 +27,15 @@
                     Distribution options for Chisel 2 Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableChisel2' displayName='Handle Chisel 2 Setup?' default='true' displayState='shown_dynamic' displayGroup='groupChisel2'>
+                <Description> Should Custom Ore Generation handle Chisel 2 ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Chisel 2 ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Chisel 2 ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Andesite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='chslAndesiteDist'  displayState='shown' displayGroup='groupChisel2'>
+                <OptionChoice name='chslAndesiteDist'  displayState=':= if(?enableChisel2, "shown", "hidden")' displayGroup='groupChisel2'>
                     <Description> Controls how Andesite is generated </Description>
                     <DisplayName>Chisel 2 Andesite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -45,11 +50,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Andesite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='chslAndesiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupChisel2'>
+                <OptionNumeric name='chslAndesiteFreq' default='1'  min='0' max='5' displayState=':= if(?enableChisel2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupChisel2'>
                     <Description> Frequency multiplier for Chisel 2 Andesite distributions </Description>
                     <DisplayName>Chisel 2 Andesite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='chslAndesiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupChisel2'>
+                <OptionNumeric name='chslAndesiteSize' default='1'  min='0' max='5' displayState=':= if(?enableChisel2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupChisel2'>
                     <Description> Size multiplier for Chisel 2 Andesite distributions </Description>
                     <DisplayName>Chisel 2 Andesite Size</DisplayName>
                 </OptionNumeric>
@@ -59,7 +64,7 @@
 
             <!-- Diorite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='chslDioriteDist'  displayState='shown' displayGroup='groupChisel2'>
+                <OptionChoice name='chslDioriteDist'  displayState=':= if(?enableChisel2, "shown", "hidden")' displayGroup='groupChisel2'>
                     <Description> Controls how Diorite is generated </Description>
                     <DisplayName>Chisel 2 Diorite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -74,11 +79,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Diorite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='chslDioriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupChisel2'>
+                <OptionNumeric name='chslDioriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableChisel2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupChisel2'>
                     <Description> Frequency multiplier for Chisel 2 Diorite distributions </Description>
                     <DisplayName>Chisel 2 Diorite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='chslDioriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupChisel2'>
+                <OptionNumeric name='chslDioriteSize' default='1'  min='0' max='5' displayState=':= if(?enableChisel2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupChisel2'>
                     <Description> Size multiplier for Chisel 2 Diorite distributions </Description>
                     <DisplayName>Chisel 2 Diorite Size</DisplayName>
                 </OptionNumeric>
@@ -88,7 +93,7 @@
 
             <!-- Granite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='chslGraniteDist'  displayState='shown' displayGroup='groupChisel2'>
+                <OptionChoice name='chslGraniteDist'  displayState=':= if(?enableChisel2, "shown", "hidden")' displayGroup='groupChisel2'>
                     <Description> Controls how Granite is generated </Description>
                     <DisplayName>Chisel 2 Granite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -103,11 +108,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Granite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='chslGraniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupChisel2'>
+                <OptionNumeric name='chslGraniteFreq' default='1'  min='0' max='5' displayState=':= if(?enableChisel2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupChisel2'>
                     <Description> Frequency multiplier for Chisel 2 Granite distributions </Description>
                     <DisplayName>Chisel 2 Granite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='chslGraniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupChisel2'>
+                <OptionNumeric name='chslGraniteSize' default='1'  min='0' max='5' displayState=':= if(?enableChisel2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupChisel2'>
                     <Description> Size multiplier for Chisel 2 Granite distributions </Description>
                     <DisplayName>Chisel 2 Granite Size</DisplayName>
                 </OptionNumeric>
@@ -117,7 +122,7 @@
 
             <!-- Limestone Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='chslLimestoneDist'  displayState='shown' displayGroup='groupChisel2'>
+                <OptionChoice name='chslLimestoneDist'  displayState=':= if(?enableChisel2, "shown", "hidden")' displayGroup='groupChisel2'>
                     <Description> Controls how Limestone is generated </Description>
                     <DisplayName>Chisel 2 Limestone</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -132,11 +137,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Limestone is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='chslLimestoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupChisel2'>
+                <OptionNumeric name='chslLimestoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableChisel2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupChisel2'>
                     <Description> Frequency multiplier for Chisel 2 Limestone distributions </Description>
                     <DisplayName>Chisel 2 Limestone Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='chslLimestoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupChisel2'>
+                <OptionNumeric name='chslLimestoneSize' default='1'  min='0' max='5' displayState=':= if(?enableChisel2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupChisel2'>
                     <Description> Size multiplier for Chisel 2 Limestone distributions </Description>
                     <DisplayName>Chisel 2 Limestone Size</DisplayName>
                 </OptionNumeric>
@@ -146,7 +151,7 @@
 
             <!-- Marble Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='chslMarbleDist'  displayState='shown' displayGroup='groupChisel2'>
+                <OptionChoice name='chslMarbleDist'  displayState=':= if(?enableChisel2, "shown", "hidden")' displayGroup='groupChisel2'>
                     <Description> Controls how Marble is generated </Description>
                     <DisplayName>Chisel 2 Marble</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -161,11 +166,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Marble is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='chslMarbleFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupChisel2'>
+                <OptionNumeric name='chslMarbleFreq' default='1'  min='0' max='5' displayState=':= if(?enableChisel2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupChisel2'>
                     <Description> Frequency multiplier for Chisel 2 Marble distributions </Description>
                     <DisplayName>Chisel 2 Marble Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='chslMarbleSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupChisel2'>
+                <OptionNumeric name='chslMarbleSize' default='1'  min='0' max='5' displayState=':= if(?enableChisel2, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupChisel2'>
                     <Description> Size multiplier for Chisel 2 Marble distributions </Description>
                     <DisplayName>Chisel 2 Marble Size</DisplayName>
                 </OptionNumeric>
@@ -175,521 +180,536 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableChisel2'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='chslOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='chisel:andesite' weight='1.0' />
-                <Replaces block='chisel:diorite' weight='1.0' />
-                <Replaces block='chisel:granite' weight='1.0' />
-                <Replaces block='chisel:limestone' weight='1.0' />
-                <Replaces block='chisel:marble' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Andesite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Andesite. -->
-            <ConfigSection>
-                <IfCondition condition=':= chslAndesiteDist = "LayeredVeins"'>
-                    <Veins name='chslAndesiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CECABE' drawBoundBox='false' boundBoxColor='0x60CECABE'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='chslOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='chisel:andesite' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslAndesiteFreq ' range=':=  1 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslAndesiteSize ' range=':=  1 * _default_ * chslAndesiteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 43 ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslAndesiteSize ' range=':=  1 * _default_ * chslAndesiteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("chisel:andesite")'> <Replaces block='chisel:andesite' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("chisel:diorite")'> <Replaces block='chisel:diorite' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("chisel:granite")'> <Replaces block='chisel:granite' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("chisel:limestone")'> <Replaces block='chisel:limestone' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("chisel:marble")'> <Replaces block='chisel:marble' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Andesite is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Andesite. -->
-            <ConfigSection>
-                <IfCondition condition=':= chslAndesiteDist = "Cloud"'>
-                    <Cloud name='chslAndesiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CECABE' drawBoundBox='false' boundBoxColor='0x60CECABE'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='chisel:andesite' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslAndesiteFreq ' range=':=  _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 43 ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='chslAndesiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CECABE' drawBoundBox='false' boundBoxColor='0x60CECABE'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Andesite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Andesite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= chslAndesiteDist = "LayeredVeins"'>
+                        <Veins name='chslAndesiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CECABE' drawBoundBox='false' boundBoxColor='0x60CECABE'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='chisel:andesite' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("chisel:andesite")'> <OreBlock block='chisel:andesite' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslAndesiteFreq ' range=':=  1 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslAndesiteSize ' range=':=  1 * _default_ * chslAndesiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 43 ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslAndesiteSize ' range=':=  1 * _default_ * chslAndesiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Andesite is complete. -->
-
-            <!-- End Andesite Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Andesite is complete. -->
 
 
-            <!-- Begin Diorite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Diorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= chslDioriteDist = "LayeredVeins"'>
-                    <Veins name='chslDioriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E6E5D3' drawBoundBox='false' boundBoxColor='0x60E6E5D3'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='chisel:diorite' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslDioriteFreq ' range=':=  1 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslDioriteSize ' range=':=  1 * _default_ * chslDioriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslDioriteSize ' range=':=  1 * _default_ * chslDioriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Diorite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Diorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= chslDioriteDist = "Cloud"'>
-                    <Cloud name='chslDioriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E6E5D3' drawBoundBox='false' boundBoxColor='0x60E6E5D3'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='chisel:diorite' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslDioriteFreq ' range=':=  _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='chslDioriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E6E5D3' drawBoundBox='false' boundBoxColor='0x60E6E5D3'>
+                <!-- Starting Cloud Preset for Andesite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= chslAndesiteDist = "Cloud"'>
+                        <Cloud name='chslAndesiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CECABE' drawBoundBox='false' boundBoxColor='0x60CECABE'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='chisel:diorite' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Diorite is complete. -->
+                            <IfCondition condition=':= ?blockExists("chisel:andesite")'> <OreBlock block='chisel:andesite' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslAndesiteFreq ' range=':=  _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 43 ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='chslAndesiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CECABE' drawBoundBox='false' boundBoxColor='0x60CECABE'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("chisel:andesite")'> <OreBlock block='chisel:andesite' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Andesite is complete. -->
 
-            <!-- End Diorite Generation -->
+                <!-- End Andesite Generation -->
 
 
-            <!-- Begin Granite Generation -->
+                <!-- Begin Diorite Generation -->
 
-            <!-- Starting LayeredVeins Preset for Granite. -->
-            <ConfigSection>
-                <IfCondition condition=':= chslGraniteDist = "LayeredVeins"'>
-                    <Veins name='chslGraniteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60F2D9C3' drawBoundBox='false' boundBoxColor='0x60F2D9C3'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='chisel:granite' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslGraniteFreq ' range=':=  1 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslGraniteSize ' range=':=  1 * _default_ * chslGraniteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslGraniteSize ' range=':=  1 * _default_ * chslGraniteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Granite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Granite. -->
-            <ConfigSection>
-                <IfCondition condition=':= chslGraniteDist = "Cloud"'>
-                    <Cloud name='chslGraniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60F2D9C3' drawBoundBox='false' boundBoxColor='0x60F2D9C3'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='chisel:granite' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslGraniteFreq ' range=':=  _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='chslGraniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60F2D9C3' drawBoundBox='false' boundBoxColor='0x60F2D9C3'>
+                <!-- Starting LayeredVeins Preset for Diorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= chslDioriteDist = "LayeredVeins"'>
+                        <Veins name='chslDioriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E6E5D3' drawBoundBox='false' boundBoxColor='0x60E6E5D3'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='chisel:granite' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("chisel:diorite")'> <OreBlock block='chisel:diorite' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslDioriteFreq ' range=':=  1 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslDioriteSize ' range=':=  1 * _default_ * chslDioriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslDioriteSize ' range=':=  1 * _default_ * chslDioriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Granite is complete. -->
-
-            <!-- End Granite Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Diorite is complete. -->
 
 
-            <!-- Begin Limestone Generation -->
-
-            <!-- Starting LayeredVeins Preset for Limestone. -->
-            <ConfigSection>
-                <IfCondition condition=':= chslLimestoneDist = "LayeredVeins"'>
-                    <Veins name='chslLimestoneVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60A5A28F' drawBoundBox='false' boundBoxColor='0x60A5A28F'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='chisel:limestone' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.571 * _default_ * chslLimestoneFreq ' range=':=  1 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.163 * _default_ * chslLimestoneSize ' range=':=  1 * _default_ * chslLimestoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.163 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.163 * _default_ * chslLimestoneSize ' range=':=  1 * _default_ * chslLimestoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Limestone is complete. -->
-
-
-            <!-- Starting Cloud Preset for Limestone. -->
-            <ConfigSection>
-                <IfCondition condition=':= chslLimestoneDist = "Cloud"'>
-                    <Cloud name='chslLimestoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A5A28F' drawBoundBox='false' boundBoxColor='0x60A5A28F'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='chisel:limestone' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.771 * _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.771 * _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 3.137  * _default_ * chslLimestoneFreq ' range=':=  _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='chslLimestoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A5A28F' drawBoundBox='false' boundBoxColor='0x60A5A28F'>
+                <!-- Starting Cloud Preset for Diorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= chslDioriteDist = "Cloud"'>
+                        <Cloud name='chslDioriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E6E5D3' drawBoundBox='false' boundBoxColor='0x60E6E5D3'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='chisel:limestone' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Limestone is complete. -->
+                            <IfCondition condition=':= ?blockExists("chisel:diorite")'> <OreBlock block='chisel:diorite' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslDioriteFreq ' range=':=  _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='chslDioriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E6E5D3' drawBoundBox='false' boundBoxColor='0x60E6E5D3'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("chisel:diorite")'> <OreBlock block='chisel:diorite' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Diorite is complete. -->
 
-            <!-- End Limestone Generation -->
+                <!-- End Diorite Generation -->
 
 
-            <!-- Begin Marble Generation -->
+                <!-- Begin Granite Generation -->
 
-            <!-- Starting LayeredVeins Preset for Marble. -->
-            <ConfigSection>
-                <IfCondition condition=':= chslMarbleDist = "LayeredVeins"'>
-                    <Veins name='chslMarbleVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CECECE' drawBoundBox='false' boundBoxColor='0x60CECECE'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='chisel:marble' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.470 * _default_ * chslMarbleFreq ' range=':=  1 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.137 * _default_ * chslMarbleSize ' range=':=  1 * _default_ * chslMarbleSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.137 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.137 * _default_ * chslMarbleSize ' range=':=  1 * _default_ * chslMarbleSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Marble is complete. -->
-
-
-            <!-- Starting Cloud Preset for Marble. -->
-            <ConfigSection>
-                <IfCondition condition=':= chslMarbleDist = "Cloud"'>
-                    <Cloud name='chslMarbleCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CECECE' drawBoundBox='false' boundBoxColor='0x60CECECE'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='chisel:marble' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.713 * _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.713 * _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.935  * _default_ * chslMarbleFreq ' range=':=  _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='chslMarbleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CECECE' drawBoundBox='false' boundBoxColor='0x60CECECE'>
+                <!-- Starting LayeredVeins Preset for Granite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= chslGraniteDist = "LayeredVeins"'>
+                        <Veins name='chslGraniteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60F2D9C3' drawBoundBox='false' boundBoxColor='0x60F2D9C3'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='chisel:marble' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("chisel:granite")'> <OreBlock block='chisel:granite' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslGraniteFreq ' range=':=  1 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslGraniteSize ' range=':=  1 * _default_ * chslGraniteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslGraniteSize ' range=':=  1 * _default_ * chslGraniteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Marble is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Granite is complete. -->
 
-            <!-- End Marble Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Cloud Preset for Granite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= chslGraniteDist = "Cloud"'>
+                        <Cloud name='chslGraniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60F2D9C3' drawBoundBox='false' boundBoxColor='0x60F2D9C3'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("chisel:granite")'> <OreBlock block='chisel:granite' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslGraniteFreq ' range=':=  _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='chslGraniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60F2D9C3' drawBoundBox='false' boundBoxColor='0x60F2D9C3'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("chisel:granite")'> <OreBlock block='chisel:granite' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Granite is complete. -->
+
+                <!-- End Granite Generation -->
+
+
+                <!-- Begin Limestone Generation -->
+
+                <!-- Starting LayeredVeins Preset for Limestone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= chslLimestoneDist = "LayeredVeins"'>
+                        <Veins name='chslLimestoneVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60A5A28F' drawBoundBox='false' boundBoxColor='0x60A5A28F'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("chisel:limestone")'> <OreBlock block='chisel:limestone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.571 * _default_ * chslLimestoneFreq ' range=':=  1 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.163 * _default_ * chslLimestoneSize ' range=':=  1 * _default_ * chslLimestoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.163 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.163 * _default_ * chslLimestoneSize ' range=':=  1 * _default_ * chslLimestoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Limestone is complete. -->
+
+
+                <!-- Starting Cloud Preset for Limestone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= chslLimestoneDist = "Cloud"'>
+                        <Cloud name='chslLimestoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A5A28F' drawBoundBox='false' boundBoxColor='0x60A5A28F'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("chisel:limestone")'> <OreBlock block='chisel:limestone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.771 * _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.771 * _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 3.137  * _default_ * chslLimestoneFreq ' range=':=  _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='chslLimestoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A5A28F' drawBoundBox='false' boundBoxColor='0x60A5A28F'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("chisel:limestone")'> <OreBlock block='chisel:limestone' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Limestone is complete. -->
+
+                <!-- End Limestone Generation -->
+
+
+                <!-- Begin Marble Generation -->
+
+                <!-- Starting LayeredVeins Preset for Marble. -->
+                <ConfigSection>
+                    <IfCondition condition=':= chslMarbleDist = "LayeredVeins"'>
+                        <Veins name='chslMarbleVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CECECE' drawBoundBox='false' boundBoxColor='0x60CECECE'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("chisel:marble")'> <OreBlock block='chisel:marble' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.470 * _default_ * chslMarbleFreq ' range=':=  1 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.137 * _default_ * chslMarbleSize ' range=':=  1 * _default_ * chslMarbleSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.137 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.137 * _default_ * chslMarbleSize ' range=':=  1 * _default_ * chslMarbleSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Marble is complete. -->
+
+
+                <!-- Starting Cloud Preset for Marble. -->
+                <ConfigSection>
+                    <IfCondition condition=':= chslMarbleDist = "Cloud"'>
+                        <Cloud name='chslMarbleCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CECECE' drawBoundBox='false' boundBoxColor='0x60CECECE'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("chisel:marble")'> <OreBlock block='chisel:marble' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.713 * _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.713 * _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.935  * _default_ * chslMarbleFreq ' range=':=  _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='chslMarbleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CECECE' drawBoundBox='false' boundBoxColor='0x60CECECE'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("chisel:marble")'> <OreBlock block='chisel:marble' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Marble is complete. -->
+
+                <!-- End Marble Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/Chisel2.xml
+++ b/src/main/resources/config/modules/Chisel2.xml
@@ -38,11 +38,6 @@
                             Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
                     </Choice>
-                    <Choice value='Vanilla' displayValue='Vanilla'>
-                        <Description>
-                            Simulates Vanilla Minecraft.
-                        </Description>
-                    </Choice>
                     <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
                             Large irregular clouds filled lightly with ore.
@@ -222,46 +217,25 @@
                         <OreBlock block='chisel:andesite' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.344 * _default_ * chslAndesiteFreq ' range=':=  1 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.103 * _default_ * chslAndesiteSize ' range=':=  1 * _default_ * chslAndesiteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslAndesiteFreq ' range=':=  1 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslAndesiteSize ' range=':=  1 * _default_ * chslAndesiteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 43 ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.103 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.103 * _default_ * chslAndesiteSize ' range=':=  1 * _default_ * chslAndesiteSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslAndesiteSize ' range=':=  1 * _default_ * chslAndesiteSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
                 </IfCondition>
             </ConfigSection>
             <!-- LayeredVeins Preset for Andesite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Andesite. -->
-            <ConfigSection>
-                <IfCondition condition=':= chslAndesiteDist = "Vanilla"'>
-                    <StandardGen name='chslAndesiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60CECABE' drawBoundBox='false' boundBoxColor='0x60CECABE'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='chisel:andesite' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 20 * chslAndesiteSize ' range=':=  6 * chslAndesiteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 6.5 * chslAndesiteFreq ' range=':=  2 * chslAndesiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Andesite is complete. -->
 
 
             <!-- Starting Cloud Preset for Andesite. -->
@@ -284,10 +258,10 @@
                         <OreBlock block='chisel:andesite' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.564 * _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.564 * _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.318  * _default_ * chslAndesiteFreq ' range=':=  _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslAndesiteFreq ' range=':=  _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 43 ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -339,19 +313,19 @@
                         <OreBlock block='chisel:diorite' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.344 * _default_ * chslDioriteFreq ' range=':=  1 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.103 * _default_ * chslDioriteSize ' range=':=  1 * _default_ * chslDioriteSize ' type='normal' />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslDioriteFreq ' range=':=  1 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslDioriteSize ' range=':=  1 * _default_ * chslDioriteSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.103 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.103 * _default_ * chslDioriteSize ' range=':=  1 * _default_ * chslDioriteSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslDioriteSize ' range=':=  1 * _default_ * chslDioriteSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
@@ -380,9 +354,9 @@
                         <OreBlock block='chisel:diorite' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.564 * _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.564 * _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.318  * _default_ * chslDioriteFreq ' range=':=  _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslDioriteFreq ' range=':=  _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -435,19 +409,19 @@
                         <OreBlock block='chisel:granite' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.344 * _default_ * chslGraniteFreq ' range=':=  1 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.103 * _default_ * chslGraniteSize ' range=':=  1 * _default_ * chslGraniteSize ' type='normal' />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslGraniteFreq ' range=':=  1 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslGraniteSize ' range=':=  1 * _default_ * chslGraniteSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.103 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.103 * _default_ * chslGraniteSize ' range=':=  1 * _default_ * chslGraniteSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslGraniteSize ' range=':=  1 * _default_ * chslGraniteSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
@@ -476,9 +450,9 @@
                         <OreBlock block='chisel:granite' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.564 * _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.564 * _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.318  * _default_ * chslGraniteFreq ' range=':=  _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslGraniteFreq ' range=':=  _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -531,50 +505,22 @@
                         <OreBlock block='chisel:limestone' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.592 * _default_ * chslLimestoneFreq ' range=':=  1 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.168 * _default_ * chslLimestoneSize ' range=':=  1 * _default_ * chslLimestoneSize ' type='normal' />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.571 * _default_ * chslLimestoneFreq ' range=':=  1 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.163 * _default_ * chslLimestoneSize ' range=':=  1 * _default_ * chslLimestoneSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.168 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.163 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.168 * _default_ * chslLimestoneSize ' range=':=  1 * _default_ * chslLimestoneSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.163 * _default_ * chslLimestoneSize ' range=':=  1 * _default_ * chslLimestoneSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Veins name='chslLimestonePreferredVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60A5A28F' drawBoundBox='false' boundBoxColor='0x60A5A28F'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='chisel:limestone' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='swamp'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.592 * _default_ * chslLimestoneFreq ' range=':=  1 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.168 * _default_ * chslLimestoneSize ' range=':=  1 * _default_ * chslLimestoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.168 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.168 * _default_ * chslLimestoneSize ' range=':=  1 * _default_ * chslLimestoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <!-- "Preferred" configuration complete. -->
-
                 </IfCondition>
             </ConfigSection>
             <!-- LayeredVeins Preset for Limestone is complete. -->
@@ -600,9 +546,9 @@
                         <OreBlock block='chisel:limestone' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.614 * _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.614 * _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.377  * _default_ * chslLimestoneFreq ' range=':=  _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.771 * _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.771 * _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 3.137  * _default_ * chslLimestoneFreq ' range=':=  _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -635,38 +581,6 @@
                             <Replaces block='minecraft:sandstone' weight='1.0' />
                         </Veins>
                     </Cloud>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Cloud name='chslLimestonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A5A28F' drawBoundBox='false' boundBoxColor='0x60A5A28F'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='chisel:limestone' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='swamp'  />
-                        <Setting name='CloudRadius' avg=':= 0.614 * _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.614 * _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.377  * _default_ * chslLimestoneFreq ' range=':=  _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='chslLimestonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A5A28F' drawBoundBox='false' boundBoxColor='0x60A5A28F'>
-                            <Description>
-                                Ore generation is doubled in
-                                preferred biomes.
-                            </Description>
-                            <OreBlock block='chisel:limestone' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                    <!-- "Preferred" configuration complete. -->
-
                 </IfCondition>
             </ConfigSection>
             <!-- Cloud Preset for Limestone is complete. -->
@@ -687,19 +601,19 @@
                         <OreBlock block='chisel:marble' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.490 * _default_ * chslMarbleFreq ' range=':=  1 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.142 * _default_ * chslMarbleSize ' range=':=  1 * _default_ * chslMarbleSize ' type='normal' />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.470 * _default_ * chslMarbleFreq ' range=':=  1 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.137 * _default_ * chslMarbleSize ' range=':=  1 * _default_ * chslMarbleSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.142 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.137 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.142 * _default_ * chslMarbleSize ' range=':=  1 * _default_ * chslMarbleSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.137 * _default_ * chslMarbleSize ' range=':=  1 * _default_ * chslMarbleSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
@@ -728,9 +642,9 @@
                         <OreBlock block='chisel:marble' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.594 * _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.594 * _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.353  * _default_ * chslMarbleFreq ' range=':=  _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.713 * _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.713 * _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.935  * _default_ * chslMarbleFreq ' range=':=  _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -26,10 +26,15 @@
                     Distribution options for Dense Ores Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableDenseOres' displayName='Handle Dense Ores Setup?' default='true' displayState='shown_dynamic' displayGroup='groupDenseOres'>
+                <Description> Should Custom Ore Generation handle Dense Ores ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Dense Ores ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Dense Ores ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Iron Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='dnsoIronDist'  displayState='shown' displayGroup='groupDenseOres'>
+                <OptionChoice name='dnsoIronDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Iron is generated </Description>
                     <DisplayName>Dense Ores Iron</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -49,11 +54,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Iron is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='dnsoIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoIronFreq' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Frequency multiplier for Dense Ores Iron distributions </Description>
                     <DisplayName>Dense Ores Iron Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='dnsoIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoIronSize' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Size multiplier for Dense Ores Iron distributions </Description>
                     <DisplayName>Dense Ores Iron Size</DisplayName>
                 </OptionNumeric>
@@ -63,7 +68,7 @@
 
             <!-- Gold Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='dnsoGoldDist'  displayState='shown' displayGroup='groupDenseOres'>
+                <OptionChoice name='dnsoGoldDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Gold is generated </Description>
                     <DisplayName>Dense Ores Gold</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -83,11 +88,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Gold is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='dnsoGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoGoldFreq' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Frequency multiplier for Dense Ores Gold distributions </Description>
                     <DisplayName>Dense Ores Gold Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='dnsoGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoGoldSize' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Size multiplier for Dense Ores Gold distributions </Description>
                     <DisplayName>Dense Ores Gold Size</DisplayName>
                 </OptionNumeric>
@@ -97,7 +102,7 @@
 
             <!-- Lapis Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='dnsoLapisDist'  displayState='shown' displayGroup='groupDenseOres'>
+                <OptionChoice name='dnsoLapisDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Lapis is generated </Description>
                     <DisplayName>Dense Ores Lapis</DisplayName>
                     <Choice value='VerticalVeins' displayValue='Vertical Veins'>
@@ -117,11 +122,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Lapis is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='dnsoLapisFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoLapisFreq' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Frequency multiplier for Dense Ores Lapis distributions </Description>
                     <DisplayName>Dense Ores Lapis Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='dnsoLapisSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoLapisSize' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Size multiplier for Dense Ores Lapis distributions </Description>
                     <DisplayName>Dense Ores Lapis Size</DisplayName>
                 </OptionNumeric>
@@ -131,7 +136,7 @@
 
             <!-- Diamond Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='dnsoDiamondDist'  displayState='shown' displayGroup='groupDenseOres'>
+                <OptionChoice name='dnsoDiamondDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Diamond is generated </Description>
                     <DisplayName>Dense Ores Diamond</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -151,11 +156,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Diamond is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='dnsoDiamondFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoDiamondFreq' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Frequency multiplier for Dense Ores Diamond distributions </Description>
                     <DisplayName>Dense Ores Diamond Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='dnsoDiamondSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoDiamondSize' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Size multiplier for Dense Ores Diamond distributions </Description>
                     <DisplayName>Dense Ores Diamond Size</DisplayName>
                 </OptionNumeric>
@@ -165,7 +170,7 @@
 
             <!-- Emerald Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='dnsoEmeraldDist'  displayState='shown' displayGroup='groupDenseOres'>
+                <OptionChoice name='dnsoEmeraldDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Emerald is generated </Description>
                     <DisplayName>Dense Ores Emerald</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -185,11 +190,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Emerald is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='dnsoEmeraldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoEmeraldFreq' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Frequency multiplier for Dense Ores Emerald distributions </Description>
                     <DisplayName>Dense Ores Emerald Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='dnsoEmeraldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoEmeraldSize' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Size multiplier for Dense Ores Emerald distributions </Description>
                     <DisplayName>Dense Ores Emerald Size</DisplayName>
                 </OptionNumeric>
@@ -199,7 +204,7 @@
 
             <!-- Redstone Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='dnsoRedstoneDist'  displayState='shown' displayGroup='groupDenseOres'>
+                <OptionChoice name='dnsoRedstoneDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Redstone is generated </Description>
                     <DisplayName>Dense Ores Redstone</DisplayName>
                     <Choice value='VerticalVeins' displayValue='Vertical Veins'>
@@ -219,11 +224,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Redstone is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='dnsoRedstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoRedstoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Frequency multiplier for Dense Ores Redstone distributions </Description>
                     <DisplayName>Dense Ores Redstone Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='dnsoRedstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoRedstoneSize' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Size multiplier for Dense Ores Redstone distributions </Description>
                     <DisplayName>Dense Ores Redstone Size</DisplayName>
                 </OptionNumeric>
@@ -233,7 +238,7 @@
 
             <!-- Coal Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='dnsoCoalDist'  displayState='shown' displayGroup='groupDenseOres'>
+                <OptionChoice name='dnsoCoalDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Coal is generated </Description>
                     <DisplayName>Dense Ores Coal</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -258,11 +263,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Coal is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='dnsoCoalFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoCoalFreq' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Frequency multiplier for Dense Ores Coal distributions </Description>
                     <DisplayName>Dense Ores Coal Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='dnsoCoalSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoCoalSize' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Size multiplier for Dense Ores Coal distributions </Description>
                     <DisplayName>Dense Ores Coal Size</DisplayName>
                 </OptionNumeric>
@@ -272,7 +277,7 @@
 
             <!-- Nether Quartz Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='dnsoNetherQuartzDist'  displayState='shown' displayGroup='groupDenseOres'>
+                <OptionChoice name='dnsoNetherQuartzDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Nether Quartz is generated </Description>
                     <DisplayName>Dense Ores Nether Quartz</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -292,11 +297,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Nether Quartz is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='dnsoNetherQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoNetherQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Frequency multiplier for Dense Ores Nether Quartz distributions </Description>
                     <DisplayName>Dense Ores Nether Quartz Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='dnsoNetherQuartzSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                <OptionNumeric name='dnsoNetherQuartzSize' default='1'  min='0' max='5' displayState=':= if(?enableDenseOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupDenseOres'>
                     <Description> Size multiplier for Dense Ores Nether Quartz distributions </Description>
                     <DisplayName>Dense Ores Nether Quartz Size</DisplayName>
                 </OptionNumeric>
@@ -306,1263 +311,1291 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableDenseOres'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='dnsoOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='denseores:block0' weight='1.0' />
-                <Replaces block='denseores:block0:1' weight='1.0' />
-                <Replaces block='denseores:block0:2' weight='1.0' />
-                <Replaces block='denseores:block0:3' weight='1.0' />
-                <Replaces block='denseores:block0:4' weight='1.0' />
-                <Replaces block='denseores:block0:5' weight='1.0' />
-                <Replaces block='denseores:block0:6' weight='1.0' />
-                <Replaces block='minecraft:coal_ore' weight='1.0' />
-                <Replaces block='minecraft:diamond_ore' weight='1.0' />
-                <Replaces block='minecraft:emerald_ore' weight='1.0' />
-                <Replaces block='minecraft:gold_ore' weight='1.0' />
-                <Replaces block='minecraft:iron_ore' weight='1.0' />
-                <Replaces block='minecraft:lapis_ore' weight='1.0' />
-                <Replaces block='minecraft:redstone_ore' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Iron Generation -->
-
-            <!-- Starting LayeredVeins Preset for Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoIronDist = "LayeredVeins"'>
-                    <Veins name='dnsoIronVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='dnsoOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='minecraft:iron_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * dnsoIronFreq ' range=':=  1 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':=  1 * _default_ * dnsoIronSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':=  1 * _default_ * dnsoIronSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("denseores:block0")'> <Replaces block='denseores:block0' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <Replaces block='denseores:block0:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <Replaces block='denseores:block0:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <Replaces block='denseores:block0:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <Replaces block='denseores:block0:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <Replaces block='denseores:block0:5' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <Replaces block='denseores:block0:6' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <Replaces block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <Replaces block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <Replaces block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <Replaces block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <Replaces block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Iron is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Vanilla Preset for Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoIronDist = "Vanilla"'>
-                    <StandardGen name='dnsoIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='minecraft:iron_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 20 * dnsoIronFreq ' range=':=  _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Iron is complete. -->
+                <!-- Adding blocks -->
 
+                <!-- Begin Iron Generation -->
 
-            <!-- Starting Cloud Preset for Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoIronDist = "Cloud"'>
-                    <Cloud name='dnsoIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='minecraft:iron_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.730 * _default_ * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.730 * _default_ * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * dnsoIronFreq ' range=':=  _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='dnsoIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                <!-- Starting LayeredVeins Preset for Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoIronDist = "LayeredVeins"'>
+                        <Veins name='dnsoIronVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='minecraft:iron_ore' weight='0.9' />
-                            <OreBlock block='denseores:block0' weight='0.1' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * dnsoIronFreq ' range=':=  1 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':=  1 * _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':=  1 * _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Iron is complete. -->
-
-            <!-- End Iron Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Iron is complete. -->
 
 
-            <!-- Begin Gold Generation -->
-
-            <!-- Starting LayeredVeins Preset for Gold. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoGoldDist = "LayeredVeins"'>
-                    <Veins name='dnsoGoldVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='minecraft:gold_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:1' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * dnsoGoldFreq ' range=':=  1 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * dnsoGoldSize ' range=':=  1 * _default_ * dnsoGoldSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * dnsoGoldSize ' range=':=  1 * _default_ * dnsoGoldSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Gold is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Gold. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoGoldDist = "Vanilla"'>
-                    <StandardGen name='dnsoGoldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='minecraft:gold_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:1' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * dnsoGoldFreq ' range=':=  _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Gold is complete. -->
-
-
-            <!-- Starting Cloud Preset for Gold. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoGoldDist = "Cloud"'>
-                    <Cloud name='dnsoGoldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='minecraft:gold_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:1' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * dnsoGoldFreq ' range=':=  _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='dnsoGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                <!-- Starting Vanilla Preset for Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoIronDist = "Vanilla"'>
+                        <StandardGen name='dnsoIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='minecraft:gold_ore' weight='0.9' />
-                            <OreBlock block='denseores:block0:1' weight='0.1' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Gold is complete. -->
-
-            <!-- End Gold Generation -->
-
-
-            <!-- Begin Lapis Generation -->
-
-            <!-- Starting VerticalVeins Preset for Lapis. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoLapisDist = "VerticalVeins"'>
-                    <Veins name='dnsoLapisVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
-                        <Description>
-                            Single vertical veins that occur with  no
-                            motherlodes.
-                        </Description>
-                        <OreBlock block='minecraft:lapis_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:2' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * dnsoLapisFreq ' range=':=  1 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Veins name='dnsoLapisPreferredVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='minecraft:lapis_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:2' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Ocean'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * dnsoLapisFreq ' range=':=  1 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <!-- "Preferred" configuration complete. -->
-
-                </IfCondition>
-            </ConfigSection>
-            <!-- VerticalVeins Preset for Lapis is complete. -->
+                            <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 20 * dnsoIronFreq ' range=':=  _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Iron is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Lapis. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoLapisDist = "Vanilla"'>
-                    <StandardGen name='dnsoLapisStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='minecraft:lapis_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:2' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * dnsoLapisFreq ' range=':=  _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Lapis is complete. -->
-
-
-            <!-- Starting Cloud Preset for Lapis. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoLapisDist = "Cloud"'>
-                    <Cloud name='dnsoLapisCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='minecraft:lapis_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:2' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * dnsoLapisFreq ' range=':=  _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='dnsoLapisHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                <!-- Starting Cloud Preset for Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoIronDist = "Cloud"'>
+                        <Cloud name='dnsoIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='minecraft:lapis_ore' weight='0.9' />
-                            <OreBlock block='denseores:block0:2' weight='0.1' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
+                            <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.730 * _default_ * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.730 * _default_ * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * dnsoIronFreq ' range=':=  _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='dnsoIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='0.9' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Iron is complete. -->
 
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Cloud name='dnsoLapisPreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='minecraft:lapis_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:2' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Ocean'  />
-                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * dnsoLapisFreq ' range=':=  _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='dnsoLapisPreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                <!-- End Iron Generation -->
+
+
+                <!-- Begin Gold Generation -->
+
+                <!-- Starting LayeredVeins Preset for Gold. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoGoldDist = "LayeredVeins"'>
+                        <Veins name='dnsoGoldVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * dnsoGoldFreq ' range=':=  1 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * dnsoGoldSize ' range=':=  1 * _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * dnsoGoldSize ' range=':=  1 * _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Gold is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Gold. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoGoldDist = "Vanilla"'>
+                        <StandardGen name='dnsoGoldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * dnsoGoldFreq ' range=':=  _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Gold is complete. -->
+
+
+                <!-- Starting Cloud Preset for Gold. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoGoldDist = "Cloud"'>
+                        <Cloud name='dnsoGoldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * dnsoGoldFreq ' range=':=  _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='dnsoGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='0.9' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Gold is complete. -->
+
+                <!-- End Gold Generation -->
+
+
+                <!-- Begin Lapis Generation -->
+
+                <!-- Starting VerticalVeins Preset for Lapis. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoLapisDist = "VerticalVeins"'>
+                        <Veins name='dnsoLapisVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                            <Description>
+                                Single vertical veins that occur  with
+                                no motherlodes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * dnsoLapisFreq ' range=':=  1 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Veins name='dnsoLapisPreferredVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
                             <Description>
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <OreBlock block='minecraft:lapis_ore' weight='0.9' />
-                            <OreBlock block='denseores:block0:2' weight='0.1' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Ocean'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * dnsoLapisFreq ' range=':=  1 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                    <!-- "Preferred" configuration complete. -->
+                        <!-- "Preferred" configuration complete. -->
 
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Lapis is complete. -->
-
-            <!-- End Lapis Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- VerticalVeins Preset for Lapis is complete. -->
 
 
-            <!-- Begin Diamond Generation -->
-
-            <!-- Starting PipeVeins Preset for Diamond. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoDiamondDist = "PipeVeins"'>
-                    <Veins name='dnsoDiamondVeins'  inherits='PresetPipeVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
-                        <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
-                        </Description>
-                        <OreBlock block='minecraft:diamond_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:3' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.365 * _default_ * dnsoDiamondFreq ' range=':=  1 * _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * dnsoDiamondSize ' range=':=  1 * _default_ * dnsoDiamondSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.715 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * dnsoDiamondSize ' range=':=  1 * _default_ * dnsoDiamondSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='dnsoDiamondVeinsPipe'  inherits='dnsoDiamondVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
-                        <OreBlock block='minecraft:lava' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='minecraft:diamond_ore' weight='1.0' />
-                        <Replaces block='denseores:block0:3' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * dnsoDiamondSize  * 0.5 ' range=':=  1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * dnsoDiamondSize  * 0.5 ' range=':=  1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Diamond is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Diamond. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoDiamondDist = "Vanilla"'>
-                    <StandardGen name='dnsoDiamondStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='minecraft:diamond_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:3' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 7 * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * dnsoDiamondFreq ' range=':=  _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Diamond is complete. -->
-
-
-            <!-- Starting Cloud Preset for Diamond. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoDiamondDist = "Cloud"'>
-                    <Cloud name='dnsoDiamondCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='minecraft:diamond_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:3' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.791 * _default_ * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.791 * _default_ * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.626  * _default_ * dnsoDiamondFreq ' range=':=  _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='dnsoDiamondHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
+                <!-- Starting Vanilla Preset for Lapis. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoLapisDist = "Vanilla"'>
+                        <StandardGen name='dnsoLapisStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='minecraft:diamond_ore' weight='0.9' />
-                            <OreBlock block='denseores:block0:3' weight='0.1' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Diamond is complete. -->
-
-            <!-- End Diamond Generation -->
-
-
-            <!-- Begin Emerald Generation -->
-
-            <!-- Starting PipeVeins Preset for Emerald. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoEmeraldDist = "PipeVeins"'>
-                    <Veins name='dnsoEmeraldVeins'  inherits='PresetPipeVeins' seed='0xB92D' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
-                        <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
-                        </Description>
-                        <OreBlock block='minecraft:emerald_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:4' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Mountain'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * dnsoEmeraldFreq ' range=':=  1 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * dnsoEmeraldSize ' range=':=  1 * _default_ * dnsoEmeraldSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * dnsoEmeraldSize ' range=':=  1 * _default_ * dnsoEmeraldSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='dnsoEmeraldVeinsPipe'  inherits='dnsoEmeraldVeins' seed='0xB92D' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
-                        <OreBlock block='minecraft:monster_egg' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='minecraft:emerald_ore' weight='1.0' />
-                        <Replaces block='denseores:block0:4' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':=  1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':=  1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Emerald is complete. -->
+                            <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * dnsoLapisFreq ' range=':=  _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Lapis is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Emerald. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoEmeraldDist = "Vanilla"'>
-                    <StandardGen name='dnsoEmeraldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='minecraft:emerald_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:4' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Mountain'  />
-                        <Setting name='Size' avg=':= 1 * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * dnsoEmeraldFreq ' range=':=  _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Emerald is complete. -->
-
-
-            <!-- Starting Cloud Preset for Emerald. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoEmeraldDist = "Cloud"'>
-                    <Cloud name='dnsoEmeraldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='minecraft:emerald_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:4' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Mountain'  />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * dnsoEmeraldFreq ' range=':=  _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='dnsoEmeraldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                <!-- Starting Cloud Preset for Lapis. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoLapisDist = "Cloud"'>
+                        <Cloud name='dnsoLapisCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='minecraft:emerald_ore' weight='0.9' />
-                            <OreBlock block='denseores:block0:4' weight='0.1' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Emerald is complete. -->
+                            <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * dnsoLapisFreq ' range=':=  _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='dnsoLapisHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
 
-            <!-- End Emerald Generation -->
-
-
-            <!-- Begin Redstone Generation -->
-
-            <!-- Starting VerticalVeins Preset for Redstone. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoRedstoneDist = "VerticalVeins"'>
-                    <Veins name='dnsoRedstoneVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
-                        <Description>
-                            Single vertical veins that occur with  no
-                            motherlodes.
-                        </Description>
-                        <OreBlock block='minecraft:redstone_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:5' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * dnsoRedstoneFreq ' range=':=  1 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Veins name='dnsoRedstonePreferredVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='minecraft:redstone_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:5' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Desert'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * dnsoRedstoneFreq ' range=':=  1 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <!-- "Preferred" configuration complete. -->
-
-                </IfCondition>
-            </ConfigSection>
-            <!-- VerticalVeins Preset for Redstone is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Redstone. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoRedstoneDist = "Vanilla"'>
-                    <StandardGen name='dnsoRedstoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='minecraft:redstone_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:5' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 7 * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 8 * dnsoRedstoneFreq ' range=':=  _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Redstone is complete. -->
-
-
-            <!-- Starting Cloud Preset for Redstone. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoRedstoneDist = "Cloud"'>
-                    <Cloud name='dnsoRedstoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='minecraft:redstone_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:5' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * dnsoRedstoneFreq ' range=':=  _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='dnsoRedstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='minecraft:redstone_ore' weight='0.9' />
-                            <OreBlock block='denseores:block0:5' weight='0.1' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Cloud name='dnsoRedstonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='minecraft:redstone_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:5' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Desert'  />
-                        <Setting name='CloudRadius' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * dnsoRedstoneFreq ' range=':=  _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='dnsoRedstonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='dnsoLapisPreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
                             <Description>
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <OreBlock block='minecraft:redstone_ore' weight='0.9' />
-                            <OreBlock block='denseores:block0:5' weight='0.1' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                    <!-- "Preferred" configuration complete. -->
+                            <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Ocean'  />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * dnsoLapisFreq ' range=':=  _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='dnsoLapisPreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
 
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Redstone is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Lapis is complete. -->
 
-            <!-- End Redstone Generation -->
-
-
-            <!-- Begin Coal Generation -->
-
-            <!-- Starting SparseVeins Preset for Coal. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoCoalDist = "SparseVeins"'>
-                    <Veins name='dnsoCoalVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='minecraft:coal_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:6' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 6.262 * _default_ * dnsoCoalFreq ' range=':=  1 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.843 * _default_ * dnsoCoalSize ' range=':=  1 * _default_ * dnsoCoalSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.843 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.843 * _default_ * dnsoCoalSize ' range=':=  1 * _default_ * dnsoCoalSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Coal is complete. -->
+                <!-- End Lapis Generation -->
 
 
-            <!-- Starting Cloud Preset for Coal. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoCoalDist = "Cloud"'>
-                    <Cloud name='dnsoCoalCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='minecraft:coal_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:6' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * dnsoCoalFreq ' range=':=  _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='dnsoCoalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                <!-- Begin Diamond Generation -->
+
+                <!-- Starting PipeVeins Preset for Diamond. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoDiamondDist = "PipeVeins"'>
+                        <Veins name='dnsoDiamondVeins'  inherits='PresetPipeVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
                             </Description>
-                            <OreBlock block='minecraft:coal_ore' weight='0.9' />
-                            <OreBlock block='denseores:block0:6' weight='0.1' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.365 * _default_ * dnsoDiamondFreq ' range=':=  1 * _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * dnsoDiamondSize ' range=':=  1 * _default_ * dnsoDiamondSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.715 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * dnsoDiamondSize ' range=':=  1 * _default_ * dnsoDiamondSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Coal is complete. -->
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='dnsoDiamondVeinsPipe'  inherits='dnsoDiamondVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <Replaces block='denseores:block0:3' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * dnsoDiamondSize  * 0.5 ' range=':=  1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * dnsoDiamondSize  * 0.5 ' range=':=  1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Diamond is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Coal. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoCoalDist = "Vanilla"'>
-                    <StandardGen name='dnsoCoalStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='minecraft:coal_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:6' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 16 * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 20 * dnsoCoalFreq ' range=':=  _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Coal is complete. -->
-
-
-            <!-- Starting Cloud Preset for Coal. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoCoalDist = "Cloud"'>
-                    <Cloud name='dnsoCoalCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='minecraft:coal_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:6' weight='0.1' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * dnsoCoalFreq ' range=':=  _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='dnsoCoalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                <!-- Starting Vanilla Preset for Diamond. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoDiamondDist = "Vanilla"'>
+                        <StandardGen name='dnsoDiamondStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='minecraft:coal_ore' weight='0.9' />
-                            <OreBlock block='denseores:block0:6' weight='0.1' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 7 * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * dnsoDiamondFreq ' range=':=  _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Diamond is complete. -->
+
+
+                <!-- Starting Cloud Preset for Diamond. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoDiamondDist = "Cloud"'>
+                        <Cloud name='dnsoDiamondCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.791 * _default_ * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.791 * _default_ * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.626  * _default_ * dnsoDiamondFreq ' range=':=  _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='dnsoDiamondHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='0.9' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Diamond is complete. -->
+
+                <!-- End Diamond Generation -->
+
+
+                <!-- Begin Emerald Generation -->
+
+                <!-- Starting PipeVeins Preset for Emerald. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoEmeraldDist = "PipeVeins"'>
+                        <Veins name='dnsoEmeraldVeins'  inherits='PresetPipeVeins' seed='0xA4DC' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                            <Description>
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Mountain'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * dnsoEmeraldFreq ' range=':=  1 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * dnsoEmeraldSize ' range=':=  1 * _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * dnsoEmeraldSize ' range=':=  1 * _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='dnsoEmeraldVeinsPipe'  inherits='dnsoEmeraldVeins' seed='0xA4DC' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                            <IfCondition condition=':= ?blockExists("minecraft:monster_egg")'> <OreBlock block='minecraft:monster_egg' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <Replaces block='denseores:block0:4' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':=  1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':=  1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Emerald is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Emerald. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoEmeraldDist = "Vanilla"'>
+                        <StandardGen name='dnsoEmeraldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Mountain'  />
+                            <Setting name='Size' avg=':= 1 * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * dnsoEmeraldFreq ' range=':=  _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Emerald is complete. -->
+
+
+                <!-- Starting Cloud Preset for Emerald. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoEmeraldDist = "Cloud"'>
+                        <Cloud name='dnsoEmeraldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Mountain'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * dnsoEmeraldFreq ' range=':=  _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='dnsoEmeraldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='0.9' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Emerald is complete. -->
+
+                <!-- End Emerald Generation -->
+
+
+                <!-- Begin Redstone Generation -->
+
+                <!-- Starting VerticalVeins Preset for Redstone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoRedstoneDist = "VerticalVeins"'>
+                        <Veins name='dnsoRedstoneVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                            <Description>
+                                Single vertical veins that occur  with
+                                no motherlodes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * dnsoRedstoneFreq ' range=':=  1 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Veins name='dnsoRedstonePreferredVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Desert'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * dnsoRedstoneFreq ' range=':=  1 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- VerticalVeins Preset for Redstone is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Redstone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoRedstoneDist = "Vanilla"'>
+                        <StandardGen name='dnsoRedstoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 7 * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * dnsoRedstoneFreq ' range=':=  _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Redstone is complete. -->
+
+
+                <!-- Starting Cloud Preset for Redstone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoRedstoneDist = "Cloud"'>
+                        <Cloud name='dnsoRedstoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * dnsoRedstoneFreq ' range=':=  _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='dnsoRedstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='dnsoRedstonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Desert'  />
+                            <Setting name='CloudRadius' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * dnsoRedstoneFreq ' range=':=  _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='dnsoRedstonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Redstone is complete. -->
+
+                <!-- End Redstone Generation -->
+
+
+                <!-- Begin Coal Generation -->
+
+                <!-- Starting SparseVeins Preset for Coal. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoCoalDist = "SparseVeins"'>
+                        <Veins name='dnsoCoalVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 6.262 * _default_ * dnsoCoalFreq ' range=':=  1 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.843 * _default_ * dnsoCoalSize ' range=':=  1 * _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.843 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.843 * _default_ * dnsoCoalSize ' range=':=  1 * _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Coal is complete. -->
+
+
+                <!-- Starting Cloud Preset for Coal. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoCoalDist = "Cloud"'>
+                        <Cloud name='dnsoCoalCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * dnsoCoalFreq ' range=':=  _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='dnsoCoalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Coal is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Coal. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoCoalDist = "Vanilla"'>
+                        <StandardGen name='dnsoCoalStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 16 * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 20 * dnsoCoalFreq ' range=':=  _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Coal is complete. -->
+
+
+                <!-- Starting Cloud Preset for Coal. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoCoalDist = "Cloud"'>
+                        <Cloud name='dnsoCoalCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * dnsoCoalFreq ' range=':=  _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='dnsoCoalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Coal is complete. -->
+
+                <!-- End Coal Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
+
+
+
+            <!-- Nether Setup Beginning -->
+
+            <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
+
+                <!-- Starting Original "Nether" Block Removal -->
+
+                <IfCondition condition=':= ?blockExists("minecraft:netherrack")'>
+                    <Substitute name='dnsoNetherBlockSubstitute0' block='minecraft:netherrack'>
+                        <Description>
+                            Replace vanilla-generated ore clusters.
+                        </Description>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <Replaces block='denseores:block0:7' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <Replaces block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Coal is complete. -->
 
-            <!-- End Coal Generation -->
+                <!-- Original "Nether" Block Removal Complete -->
 
-            <!-- Finished adding blocks -->
+                <!-- Adding blocks -->
+
+                <!-- Begin Nether Quartz Generation -->
+
+                <!-- Starting LayeredVeins Preset for Nether Quartz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoNetherQuartzDist = "LayeredVeins"'>
+                        <Veins name='dnsoNetherQuartzVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 5.049 * _default_ * dnsoNetherQuartzFreq ' range=':=  1 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.716 * _default_ * dnsoNetherQuartzSize ' range=':=  1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.716 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.716 * _default_ * dnsoNetherQuartzSize ' range=':=  1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Nether Quartz is
+                     complete. -->
+
+
+                <!-- Starting Vanilla Preset for Nether Quartz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoNetherQuartzDist = "Vanilla"'>
+                        <StandardGen name='dnsoNetherQuartzStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 13 * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16 * dnsoNetherQuartzFreq ' range=':=  _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Nether Quartz is complete. -->
+
+
+                <!-- Starting Cloud Preset for Nether Quartz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= dnsoNetherQuartzDist = "Cloud"'>
+                        <Cloud name='dnsoNetherQuartzCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='0.9' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.847 * _default_ * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.847 * _default_ * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 3.411  * _default_ * dnsoNetherQuartzFreq ' range=':=  _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='dnsoNetherQuartzHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='0.9' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Nether Quartz is complete. -->
+
+                <!-- End Nether Quartz Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Nether Setup Complete -->
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
-
-
-        <!-- Nether Setup Beginning -->
-
-        <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
-
-            <!-- Starting Original "Nether" Block Removal -->
-
-            <Substitute name='dnsoNetherBlockSubstitute0' block='minecraft:netherrack'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='denseores:block0:7' weight='1.0' />
-                <Replaces block='minecraft:quartz_ore' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Nether" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Nether Quartz Generation -->
-
-            <!-- Starting LayeredVeins Preset for Nether Quartz. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoNetherQuartzDist = "LayeredVeins"'>
-                    <Veins name='dnsoNetherQuartzVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='minecraft:quartz_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:7' weight='0.1' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 5.049 * _default_ * dnsoNetherQuartzFreq ' range=':=  1 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.716 * _default_ * dnsoNetherQuartzSize ' range=':=  1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.716 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.716 * _default_ * dnsoNetherQuartzSize ' range=':=  1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Nether Quartz is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Nether Quartz. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoNetherQuartzDist = "Vanilla"'>
-                    <StandardGen name='dnsoNetherQuartzStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='minecraft:quartz_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:7' weight='0.1' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 13 * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 16 * dnsoNetherQuartzFreq ' range=':=  _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Nether Quartz is complete. -->
-
-
-            <!-- Starting Cloud Preset for Nether Quartz. -->
-            <ConfigSection>
-                <IfCondition condition=':= dnsoNetherQuartzDist = "Cloud"'>
-                    <Cloud name='dnsoNetherQuartzCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='minecraft:quartz_ore' weight='0.9' />
-                        <OreBlock block='denseores:block0:7' weight='0.1' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.847 * _default_ * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.847 * _default_ * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 3.411  * _default_ * dnsoNetherQuartzFreq ' range=':=  _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='dnsoNetherQuartzHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='minecraft:quartz_ore' weight='0.9' />
-                            <OreBlock block='denseores:block0:7' weight='0.1' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Nether Quartz is complete. -->
-
-            <!-- End Nether Quartz Generation -->
-
-            <!-- Finished adding blocks -->
-
-        </IfCondition>
-        <!-- Nether Setup Complete -->
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -1,1481 +1,1583 @@
- <!-- ================================================================
-      Custom Ore Generation "Dense Ores" Module: This configuration
-      covers iron, gold, lapis, diamond, emerald, redstone, coal, and
-      nether quartz.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Dense Ores" Module: This configuration
+     covers iron, gold, lapis, diamond, emerald, redstone, coal, and
+     nether quartz.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="denseores">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "Dense Ores" mod on the system?  Let's find out! -->
+<IfModInstalled name="denseores">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupDenseOres' displayName='Dense Ores' displayState='shown'>
+                <Description>
+                    Distribution options for Dense Ores Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Iron Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupDenseOres' displayName='Dense Ores' displayState='shown'> 
-                    <Description>
-                        Distribution options for Dense Ores Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Iron Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='dnsoIronDist'  displayState='shown' displayGroup='groupDenseOres'> 
-                        <Description> Controls how Iron is generated </Description> 
-                        <DisplayName>Dense Ores Iron</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Iron is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='dnsoIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Frequency multiplier for Dense Ores Iron distributions </Description>
-                        <DisplayName>Dense Ores Iron Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='dnsoIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Size multiplier for Dense Ores Iron distributions </Description>
-                        <DisplayName>Dense Ores Iron Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Iron Configuration UI Complete -->
-                
-                
-                <!-- Gold Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='dnsoGoldDist'  displayState='shown' displayGroup='groupDenseOres'> 
-                        <Description> Controls how Gold is generated </Description> 
-                        <DisplayName>Dense Ores Gold</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Gold is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='dnsoGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Frequency multiplier for Dense Ores Gold distributions </Description>
-                        <DisplayName>Dense Ores Gold Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='dnsoGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Size multiplier for Dense Ores Gold distributions </Description>
-                        <DisplayName>Dense Ores Gold Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Gold Configuration UI Complete -->
-                
-                
-                <!-- Lapis Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='dnsoLapisDist'  displayState='shown' displayGroup='groupDenseOres'> 
-                        <Description> Controls how Lapis is generated </Description> 
-                        <DisplayName>Dense Ores Lapis</DisplayName>
-                        <Choice value='verticalVeins' displayValue='Vertical Veins'>
-                            <Description>
-                                Vertical Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Lapis is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='dnsoLapisFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Frequency multiplier for Dense Ores Lapis distributions </Description>
-                        <DisplayName>Dense Ores Lapis Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='dnsoLapisSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Size multiplier for Dense Ores Lapis distributions </Description>
-                        <DisplayName>Dense Ores Lapis Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Lapis Configuration UI Complete -->
-                
-                
-                <!-- Diamond Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='dnsoDiamondDist'  displayState='shown' displayGroup='groupDenseOres'> 
-                        <Description> Controls how Diamond is generated </Description> 
-                        <DisplayName>Dense Ores Diamond</DisplayName>
-                        <Choice value='pipeVeins' displayValue='Pipe Veins'>
-                            <Description>
-                                Pipe Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Diamond is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='dnsoDiamondFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Frequency multiplier for Dense Ores Diamond distributions </Description>
-                        <DisplayName>Dense Ores Diamond Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='dnsoDiamondSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Size multiplier for Dense Ores Diamond distributions </Description>
-                        <DisplayName>Dense Ores Diamond Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Diamond Configuration UI Complete -->
-                
-                
-                <!-- Emerald Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='dnsoEmeraldDist'  displayState='shown' displayGroup='groupDenseOres'> 
-                        <Description> Controls how Emerald is generated </Description> 
-                        <DisplayName>Dense Ores Emerald</DisplayName>
-                        <Choice value='pipeVeins' displayValue='Pipe Veins'>
-                            <Description>
-                                Pipe Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Emerald is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='dnsoEmeraldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Frequency multiplier for Dense Ores Emerald distributions </Description>
-                        <DisplayName>Dense Ores Emerald Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='dnsoEmeraldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Size multiplier for Dense Ores Emerald distributions </Description>
-                        <DisplayName>Dense Ores Emerald Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Emerald Configuration UI Complete -->
-                
-                
-                <!-- Redstone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='dnsoRedstoneDist'  displayState='shown' displayGroup='groupDenseOres'> 
-                        <Description> Controls how Redstone is generated </Description> 
-                        <DisplayName>Dense Ores Redstone</DisplayName>
-                        <Choice value='verticalVeins' displayValue='Vertical Veins'>
-                            <Description>
-                                Vertical Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Redstone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='dnsoRedstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Frequency multiplier for Dense Ores Redstone distributions </Description>
-                        <DisplayName>Dense Ores Redstone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='dnsoRedstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Size multiplier for Dense Ores Redstone distributions </Description>
-                        <DisplayName>Dense Ores Redstone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Redstone Configuration UI Complete -->
-                
-                
-                <!-- Coal Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='dnsoCoalDist'  displayState='shown' displayGroup='groupDenseOres'> 
-                        <Description> Controls how Coal is generated </Description> 
-                        <DisplayName>Dense Ores Coal</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Coal is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='dnsoCoalFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Frequency multiplier for Dense Ores Coal distributions </Description>
-                        <DisplayName>Dense Ores Coal Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='dnsoCoalSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Size multiplier for Dense Ores Coal distributions </Description>
-                        <DisplayName>Dense Ores Coal Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Coal Configuration UI Complete -->
-                
-                
-                <!-- Nether Quartz Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='dnsoNetherQuartzDist'  displayState='shown' displayGroup='groupDenseOres'> 
-                        <Description> Controls how Nether Quartz is generated </Description> 
-                        <DisplayName>Dense Ores Nether Quartz</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Nether Quartz is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='dnsoNetherQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Frequency multiplier for Dense Ores Nether Quartz distributions </Description>
-                        <DisplayName>Dense Ores Nether Quartz Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='dnsoNetherQuartzSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
-                        <Description> Size multiplier for Dense Ores Nether Quartz distributions </Description>
-                        <DisplayName>Dense Ores Nether Quartz Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Nether Quartz Configuration UI Complete -->
-                
+                <OptionChoice name='dnsoIronDist'  displayState='shown' displayGroup='groupDenseOres'>
+                    <Description> Controls how Iron is generated </Description>
+                    <DisplayName>Dense Ores Iron</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Iron is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='dnsoIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Frequency multiplier for Dense Ores Iron distributions </Description>
+                    <DisplayName>Dense Ores Iron Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='dnsoIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Size multiplier for Dense Ores Iron distributions </Description>
+                    <DisplayName>Dense Ores Iron Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Iron Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='dnsoOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='denseores:block0' />
-                    <Replaces block='denseores:block0:1' />
-                    <Replaces block='denseores:block0:2' />
-                    <Replaces block='denseores:block0:3' />
-                    <Replaces block='denseores:block0:4' />
-                    <Replaces block='denseores:block0:5' />
-                    <Replaces block='denseores:block0:6' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Iron Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Iron -->
-                <IfCondition condition=':= dnsoIronDist = "layeredVeins"'>
-                
-                    <Veins name='dnsoIronBaseVeins' block='denseores:block0'  inherits='PresetLayeredVeins' >
+            <!-- Gold Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='dnsoGoldDist'  displayState='shown' displayGroup='groupDenseOres'>
+                    <Description> Controls how Gold is generated </Description>
+                    <DisplayName>Dense Ores Gold</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoIronSize * _default_' range=':= 1 * 1 * dnsoIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoIronSize * _default_' range=':= 1 * 1 * dnsoIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.45 * dnsoIronFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Iron Layered Veins) Settings -->
-                    <Veins name='dnsoIronPrefersVeins' block='denseores:block0'  inherits='dnsoIronBaseVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Iron Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Iron -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Iron -->
-                <IfCondition condition=':= dnsoIronDist = "hugeVeins"'>
-                
-                    <Veins name='dnsoIronBaseVeins' block='denseores:block0'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoIronSize * _default_' range=':= 1 * 1 * dnsoIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoIronSize * _default_' range=':= 1 * 1 * dnsoIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.45 * dnsoIronFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Iron Huge Veins) Settings -->
-                    <Veins name='dnsoIronPrefersVeins' block='denseores:block0'  inherits='dnsoIronBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Iron Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Iron -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Iron -->
-                <IfCondition condition=':= dnsoIronDist = "strategicCloud"'>
-                
-                    <Cloud name='dnsoIronBaseCloud' block='denseores:block0' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * dnsoIronSize * _default_' range=':= 1 * 1 * dnsoIronSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * dnsoIronSize * _default_' range=':= 1 * 1 * dnsoIronSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * dnsoIronSize * _default_' range=':= 1 * 1 * 1 * dnsoIronSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1.25 * dnsoIronFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Iron Strategic Cloud Hint Veins -->
-                        <Veins name='dnsoIronBaseHintVeins' block='denseores:block0' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDC2AF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Iron Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Gold is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='dnsoGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Frequency multiplier for Dense Ores Gold distributions </Description>
+                    <DisplayName>Dense Ores Gold Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='dnsoGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Size multiplier for Dense Ores Gold distributions </Description>
+                    <DisplayName>Dense Ores Gold Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Gold Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Iron -->
-                
-                
-                <!-- Begin  Vanilla distribution of Iron -->
-                <IfCondition condition=':= dnsoIronDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='dnsoIronBaseStandard' block='denseores:block0' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * dnsoIronSize * _default_'/>
-                        <Setting name='Height' avg=':= 32' range=':= 32' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.45 * dnsoIronFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Iron -->
-                
-                <!-- End Iron Generation --> 
 
-                
-                <!-- Begin Gold Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Gold -->
-                <IfCondition condition=':= dnsoGoldDist = "layeredVeins"'>
-                
-                    <Veins name='dnsoGoldBaseVeins' block='denseores:block0:1'  inherits='PresetLayeredVeins' >
+            <!-- Lapis Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='dnsoLapisDist'  displayState='shown' displayGroup='groupDenseOres'>
+                    <Description> Controls how Lapis is generated </Description>
+                    <DisplayName>Dense Ores Lapis</DisplayName>
+                    <Choice value='VerticalVeins' displayValue='Vertical Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Single vertical veins that occur with no motherlodes.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * dnsoGoldSize * _default_' range=':= 1 * 0.8 * dnsoGoldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * dnsoGoldSize * _default_' range=':= 1 * 0.8 * dnsoGoldSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.43 * dnsoGoldFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.43 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Gold Layered Veins) Settings -->
-                    <Veins name='dnsoGoldPrefersVeins' block='denseores:block0:1'  inherits='dnsoGoldBaseVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Gold Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Gold -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Gold -->
-                <IfCondition condition=':= dnsoGoldDist = "hugeVeins"'>
-                
-                    <Veins name='dnsoGoldBaseVeins' block='denseores:block0:1'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * dnsoGoldSize * _default_' range=':= 1 * 0.8 * dnsoGoldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * dnsoGoldSize * _default_' range=':= 1 * 0.8 * dnsoGoldSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.43 * dnsoGoldFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.43 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Gold Huge Veins) Settings -->
-                    <Veins name='dnsoGoldPrefersVeins' block='denseores:block0:1'  inherits='dnsoGoldBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Gold Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Gold -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Gold -->
-                <IfCondition condition=':= dnsoGoldDist = "strategicCloud"'>
-                
-                    <Cloud name='dnsoGoldBaseCloud' block='denseores:block0:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * dnsoGoldSize * _default_' range=':= 1 * 0.8 * dnsoGoldSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * dnsoGoldSize * _default_' range=':= 1 * 0.8 * dnsoGoldSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * dnsoGoldSize * _default_' range=':= 1 * 0.8 * 0.8 * dnsoGoldSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.25 * dnsoGoldFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Gold Strategic Cloud Hint Veins -->
-                        <Veins name='dnsoGoldBaseHintVeins' block='denseores:block0:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EAEF57</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Gold Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Lapis is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='dnsoLapisFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Frequency multiplier for Dense Ores Lapis distributions </Description>
+                    <DisplayName>Dense Ores Lapis Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='dnsoLapisSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Size multiplier for Dense Ores Lapis distributions </Description>
+                    <DisplayName>Dense Ores Lapis Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Lapis Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Gold -->
-                
-                
-                <!-- Begin  Vanilla distribution of Gold -->
-                <IfCondition condition=':= dnsoGoldDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='dnsoGoldBaseStandard' block='denseores:block0:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * dnsoGoldSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.5 * dnsoGoldFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Gold -->
-                
-                <!-- End Gold Generation --> 
 
-                
-                <!-- Begin Lapis Generation --> 
-                
-                <!-- Begin VerticalVeins distribution of Lapis -->
-                <IfCondition condition=':= dnsoLapisDist = "verticalVeins"'>
-                
-                    <Veins name='dnsoLapisBaseVeins' block='denseores:block0:2'  inherits='PresetVerticalVeins' >
+            <!-- Diamond Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='dnsoDiamondDist'  displayState='shown' displayGroup='groupDenseOres'>
+                    <Description> Controls how Diamond is generated </Description>
+                    <DisplayName>Dense Ores Diamond</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
-                            Single vertical veins that occur with no
-                            motherlodes.
+                            Short and sparsely filled compound veins containing one material inside another.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600646B1</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoLapisSize * _default_' range=':= 1 * 1 * dnsoLapisSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 8' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoLapisSize * _default_' range=':= 1 * 1 * dnsoLapisSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.2 * dnsoLapisFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 36/64 * _default_' range=':= 12 * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Lapis Vertical Veins) Settings -->
-                    <Veins name='dnsoLapisPrefersVeins' block='denseores:block0:2'  inherits='dnsoLapisBaseVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600646B1</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='ocean'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Lapis Vertical Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End VerticalVeins distribution of Lapis -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Lapis -->
-                <IfCondition condition=':= dnsoLapisDist = "strategicCloud"'>
-                
-                    <Cloud name='dnsoLapisBaseCloud' block='denseores:block0:2' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600646B1</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.65 * dnsoLapisSize * _default_' range=':= 1 * 0.65 * dnsoLapisSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.65 * dnsoLapisSize * _default_' range=':= 1 * 0.65 * dnsoLapisSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.7 * 0.65 * dnsoLapisSize * _default_' range=':= 1 * 0.7 * 0.65 * dnsoLapisSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1.25 * dnsoLapisFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Lapis Strategic Cloud Hint Veins -->
-                        <Veins name='dnsoLapisBaseHintVeins' block='denseores:block0:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x600646B1</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Lapis Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Diamond is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='dnsoDiamondFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Frequency multiplier for Dense Ores Diamond distributions </Description>
+                    <DisplayName>Dense Ores Diamond Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='dnsoDiamondSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Size multiplier for Dense Ores Diamond distributions </Description>
+                    <DisplayName>Dense Ores Diamond Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Diamond Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Lapis -->
-                
-                
-                <!-- Begin  Vanilla distribution of Lapis -->
-                <IfCondition condition=':= dnsoLapisDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='dnsoLapisBaseStandard' block='denseores:block0:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600646B1</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 6/8 * dnsoLapisSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.02 * dnsoLapisFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Lapis -->
-                
-                <!-- End Lapis Generation --> 
 
-                
-                <!-- Begin Diamond Generation --> 
-                
-                <!-- Begin PipeVeins distribution of Diamond -->
-                <IfCondition condition=':= dnsoDiamondDist = "pipeVeins"'>
-                
-                    <Veins name='dnsoDiamondBaseVeins' block='denseores:block0:3'  inherits='PresetPipeVeins' seed='0xB8D3'>
+            <!-- Emerald Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='dnsoEmeraldDist'  displayState='shown' displayGroup='groupDenseOres'>
+                    <Description> Controls how Emerald is generated </Description>
+                    <DisplayName>Dense Ores Emerald</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
-                            Short sparsely filled veins sloping up
-                            from near the bottom of the map.
+                            Short and sparsely filled compound veins containing one material inside another.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608BF4E3</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 0.1 * 1 * dnsoDiamondSize * _default_' range=':= 0.1 * 1 * dnsoDiamondSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 0.1 * 1 * dnsoDiamondSize * _default_' range=':= 0.1 * 1 * dnsoDiamondSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.4 * dnsoDiamondFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Pipe Filling (Diamond Pipe Veins) Settings -->
-                    <Veins name='dnsoDiamondPipeVeins' block='minecraft:lava'  inherits='dnsoDiamondBaseVeins' seed='0xB8D3'>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Fills the vein with an additional material
-                            (minecraft:lava).
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608BF4E3</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 0.5 * 0.1 * 1 * dnsoDiamondSize * _default_' range=':= 0.5 * 0.1 * 1 * dnsoDiamondSize * _default_'/>
-                        <Setting name='SegmentRadius' avg=':= 0.5 * 0.1 * 1 * dnsoDiamondSize * _default_' range=':= 0.5 * 0.1 * 1 * dnsoDiamondSize * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='denseores:block0:3'/>
-                        <Replaces block='minecraft:dirt'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:gravel'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </Veins>
-                    <!-- End Pipe Filling (Diamond Pipe Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End PipeVeins distribution of Diamond -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Diamond -->
-                <IfCondition condition=':= dnsoDiamondDist = "strategicCloud"'>
-                
-                    <Cloud name='dnsoDiamondBaseCloud' block='denseores:block0:3' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608BF4E3</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 0.1 * 0.5 * dnsoDiamondSize * _default_' range=':= 0.1 * 0.5 * dnsoDiamondSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 0.1 * 0.5 * dnsoDiamondSize * _default_' range=':= 0.1 * 0.5 * dnsoDiamondSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 14' range=':= 5' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.4 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 0.1 * 0.2 * 0.5 * dnsoDiamondSize * _default_' range=':= 0.1 * 0.2 * 0.5 * dnsoDiamondSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 5 * dnsoDiamondFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Diamond Strategic Cloud Hint Veins -->
-                        <Veins name='dnsoDiamondBaseHintVeins' block='denseores:block0:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x608BF4E3</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Diamond Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Emerald is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='dnsoEmeraldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Frequency multiplier for Dense Ores Emerald distributions </Description>
+                    <DisplayName>Dense Ores Emerald Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='dnsoEmeraldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Size multiplier for Dense Ores Emerald distributions </Description>
+                    <DisplayName>Dense Ores Emerald Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Emerald Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Diamond -->
-                
-                
-                <!-- Begin  Vanilla distribution of Diamond -->
-                <IfCondition condition=':= dnsoDiamondDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='dnsoDiamondBaseStandard' block='denseores:block0:3' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608BF4E3</WireframeColor>
-                        <Setting name='Size' avg=':= 0.1 * 7/8 * dnsoDiamondSize * _default_'/>
-                        <Setting name='Height' avg=':= 8' range=':= 8' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/40 * dnsoDiamondFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Diamond -->
-                
-                <!-- End Diamond Generation --> 
 
-                
-                <!-- Begin Emerald Generation --> 
-                
-                <!-- Begin PipeVeins distribution of Emerald -->
-                <IfCondition condition=':= dnsoEmeraldDist = "pipeVeins"'>
-                
-                    <Veins name='dnsoEmeraldBaseVeins' block='denseores:block0:4'  inherits='PresetPipeVeins' seed='0x54B3'>
+            <!-- Redstone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='dnsoRedstoneDist'  displayState='shown' displayGroup='groupDenseOres'>
+                    <Description> Controls how Redstone is generated </Description>
+                    <DisplayName>Dense Ores Redstone</DisplayName>
+                    <Choice value='VerticalVeins' displayValue='Vertical Veins'>
                         <Description>
-                            Short sparsely filled veins sloping up
-                            from near the bottom of the map.
+                            Single vertical veins that occur with no motherlodes.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606CE391</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * dnsoEmeraldSize * _default_' range=':= 1 * 0.85 * dnsoEmeraldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 4' range=':= 14' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * dnsoEmeraldSize * _default_' range=':= 1 * 0.85 * dnsoEmeraldSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.2 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.45 * dnsoEmeraldFreq * _default_'/>
-                        <Setting name='BranchInclination' avg=':= 0.55' range=':= 0.7'/>
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * dnsoEmeraldSize * 0.85 * _default_' range=':= 1 * 0.85 * dnsoEmeraldSize * 0.7 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Pipe Filling (Emerald Pipe Veins) Settings -->
-                    <Veins name='dnsoEmeraldPipeVeins' block='minecraft:monster_egg'  inherits='dnsoEmeraldBaseVeins' seed='0x54B3'>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Fills the vein with an additional material
-                            (minecraft:monster_egg).
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606CE391</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 0.85 * dnsoEmeraldSize * _default_' range=':= 0.5 * 1 * 0.85 * dnsoEmeraldSize * _default_'/>
-                        <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 0.85 * dnsoEmeraldSize * _default_' range=':= 0.5 * 1 * 0.85 * dnsoEmeraldSize * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='denseores:block0:4'/>
-                        <Replaces block='minecraft:dirt'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:gravel'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </Veins>
-                    <!-- End Pipe Filling (Emerald Pipe Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End PipeVeins distribution of Emerald -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Emerald -->
-                <IfCondition condition=':= dnsoEmeraldDist = "strategicCloud"'>
-                
-                    <Cloud name='dnsoEmeraldBaseCloud' block='denseores:block0:4' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606CE391</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.4 * dnsoEmeraldSize * _default_' range=':= 1 * 0.4 * dnsoEmeraldSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.4 * dnsoEmeraldSize * _default_' range=':= 1 * 0.4 * dnsoEmeraldSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 10' range=':= 5' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.4 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.2 * 0.4 * dnsoEmeraldSize * _default_' range=':= 1 * 0.2 * 0.4 * dnsoEmeraldSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 22.5 * dnsoEmeraldFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                        
-                        <!-- Begin Emerald Strategic Cloud Hint Veins -->
-                        <Veins name='dnsoEmeraldBaseHintVeins' block='denseores:block0:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x606CE391</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                        </Veins>
-                        <!-- End Emerald Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Redstone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='dnsoRedstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Frequency multiplier for Dense Ores Redstone distributions </Description>
+                    <DisplayName>Dense Ores Redstone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='dnsoRedstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Size multiplier for Dense Ores Redstone distributions </Description>
+                    <DisplayName>Dense Ores Redstone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Redstone Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Emerald -->
-                
-                
-                <!-- Begin  Vanilla distribution of Emerald -->
-                <IfCondition condition=':= dnsoEmeraldDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='dnsoEmeraldBaseStandard' block='denseores:block0:4' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606CE391</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 2/8 * dnsoEmeraldSize * _default_'/>
-                        <Setting name='Height' avg=':= 18' range=':= 14' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 3/20 * dnsoEmeraldFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Emerald -->
-                
-                <!-- End Emerald Generation --> 
 
-                
-                <!-- Begin Redstone Generation --> 
-                
-                <!-- Begin VerticalVeins distribution of Redstone -->
-                <IfCondition condition=':= dnsoRedstoneDist = "verticalVeins"'>
-                
-                    <Veins name='dnsoRedstoneBaseVeins' block='denseores:block0:5'  inherits='PresetVerticalVeins' >
-                        <Description>
-                            Single vertical veins that occur with no
-                            motherlodes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C70D07</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoRedstoneSize * _default_' range=':= 1 * 1 * dnsoRedstoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 8' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoRedstoneSize * _default_' range=':= 1 * 1 * dnsoRedstoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.17 * dnsoRedstoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:sandstone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Redstone Vertical Veins) Settings -->
-                    <Veins name='dnsoRedstonePrefersVeins' block='denseores:block0:5'  inherits='dnsoRedstoneBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C70D07</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Desert'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Redstone Vertical Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End VerticalVeins distribution of Redstone -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Redstone -->
-                <IfCondition condition=':= dnsoRedstoneDist = "strategicCloud"'>
-                
-                    <Cloud name='dnsoRedstoneBaseCloud' block='denseores:block0:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C70D07</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.65 * dnsoRedstoneSize * _default_' range=':= 1 * 0.65 * dnsoRedstoneSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.65 * dnsoRedstoneSize * _default_' range=':= 1 * 0.65 * dnsoRedstoneSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 8' range=':= 8' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.7 * 0.65 * dnsoRedstoneSize * _default_' range=':= 1 * 0.7 * 0.65 * dnsoRedstoneSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.25 * dnsoRedstoneFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:sandstone'/>
-                        
-                        <!-- Begin Redstone Strategic Cloud Hint Veins -->
-                        <Veins name='dnsoRedstoneBaseHintVeins' block='denseores:block0:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60C70D07</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <Replaces block='minecraft:sandstone'/>
-                        </Veins>
-                        <!-- End Redstone Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Redstone -->
-                
-                
-                <!-- Begin  Vanilla distribution of Redstone -->
-                <IfCondition condition=':= dnsoRedstoneDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='dnsoRedstoneBaseStandard' block='denseores:block0:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C70D07</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 7/8 * dnsoRedstoneSize * _default_'/>
-                        <Setting name='Height' avg=':= 8' range=':= 8' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.2 * dnsoRedstoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:sandstone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Redstone -->
-                
-                <!-- End Redstone Generation --> 
-
-                
-                <!-- Begin Coal Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Coal -->
-                <IfCondition condition=':= dnsoCoalDist = "sparseVeins"'>
-                
-                    <Veins name='dnsoCoalBaseVeins' block='denseores:block0:6'  inherits='PresetSparseVeins' >
+            <!-- Coal Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='dnsoCoalDist'  displayState='shown' displayGroup='groupDenseOres'>
+                    <Description> Controls how Coal is generated </Description>
+                    <DisplayName>Dense Ores Coal</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60252525</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoCoalSize * _default_' range=':= 1 * 1 * dnsoCoalSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoCoalSize * _default_' range=':= 1 * 1 * dnsoCoalSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 5.35 * dnsoCoalFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Coal Sparse Veins) Settings -->
-                    <Veins name='dnsoCoalPrefersVeins' block='denseores:block0:6'  inherits='dnsoCoalBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60252525</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Coal Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Coal -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Coal -->
-                <IfCondition condition=':= dnsoCoalDist = "smallDeposits"'>
-                
-                    <Veins name='dnsoCoalBaseVeins' block='denseores:block0:6'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60252525</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoCoalSize * _default_' range=':= 1 * 1 * dnsoCoalSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoCoalSize * _default_' range=':= 1 * 1 * dnsoCoalSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 5.35 * dnsoCoalFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Coal Deposit Veins) Settings -->
-                    <Veins name='dnsoCoalPrefersVeins' block='denseores:block0:6'  inherits='dnsoCoalBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60252525</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Coal Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Coal -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Coal -->
-                <IfCondition condition=':= dnsoCoalDist = "strategicCloud"'>
-                
-                    <Cloud name='dnsoCoalBaseCloud' block='denseores:block0:6' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60252525</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1.2 * dnsoCoalSize * _default_' range=':= 1 * 1.2 * dnsoCoalSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.2 * dnsoCoalSize * _default_' range=':= 1 * 1.2 * dnsoCoalSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.75 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1.2 * dnsoCoalSize * _default_' range=':= 1 * 1 * 1.2 * dnsoCoalSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * dnsoCoalFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Coal Strategic Cloud Hint Veins -->
-                        <Veins name='dnsoCoalBaseHintVeins' block='denseores:block0:6' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60252525</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Coal Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Coal is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='dnsoCoalFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Frequency multiplier for Dense Ores Coal distributions </Description>
+                    <DisplayName>Dense Ores Coal Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='dnsoCoalSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Size multiplier for Dense Ores Coal distributions </Description>
+                    <DisplayName>Dense Ores Coal Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Coal Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Coal -->
-                
-                
-                <!-- Begin  Vanilla distribution of Coal -->
-                <IfCondition condition=':= dnsoCoalDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='dnsoCoalBaseStandard' block='denseores:block0:6' inherits='PresetStandardGen'>
+
+            <!-- Nether Quartz Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='dnsoNetherQuartzDist'  displayState='shown' displayGroup='groupDenseOres'>
+                    <Description> Controls how Nether Quartz is generated </Description>
+                    <DisplayName>Dense Ores Nether Quartz</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            This mimics vanilla ore generation.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60252525</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 2 * dnsoCoalSize * _default_'/>
-                        <Setting name='Height' avg=':= _default_' range=':= _default_' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.5 * dnsoCoalFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Coal -->
-                
-                <!-- End Coal Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-            <!-- Setup Nether -->
-            <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
-                
-                <!-- Starting Original Nether Ore Removal -->
-                <Substitute name='dnsoNetherOreSubstitute0' block='minecraft:netherrack'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='denseores:block0:7' />
-                </Substitute>
-                <!-- Original Nether Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Nether Quartz Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Nether Quartz -->
-                <IfCondition condition=':= dnsoNetherQuartzDist = "layeredVeins"'>
-                
-                    <Veins name='dnsoNetherQuartzBaseVeins' block='denseores:block0:7'  inherits='PresetLayeredVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Nether Quartz is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='dnsoNetherQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Frequency multiplier for Dense Ores Nether Quartz distributions </Description>
+                    <DisplayName>Dense Ores Nether Quartz Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='dnsoNetherQuartzSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupDenseOres'>
+                    <Description> Size multiplier for Dense Ores Nether Quartz distributions </Description>
+                    <DisplayName>Dense Ores Nether Quartz Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Nether Quartz Configuration UI Complete -->
+
+        </ConfigSection>
+        <!-- Setup Screen Complete -->
+
+
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='dnsoOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='denseores:block0' weight='1.0' />
+                <Replaces block='denseores:block0:1' weight='1.0' />
+                <Replaces block='denseores:block0:2' weight='1.0' />
+                <Replaces block='denseores:block0:3' weight='1.0' />
+                <Replaces block='denseores:block0:4' weight='1.0' />
+                <Replaces block='denseores:block0:5' weight='1.0' />
+                <Replaces block='denseores:block0:6' weight='1.0' />
+                <Replaces block='minecraft:coal_ore' weight='1.0' />
+                <Replaces block='minecraft:diamond_ore' weight='1.0' />
+                <Replaces block='minecraft:emerald_ore' weight='1.0' />
+                <Replaces block='minecraft:gold_ore' weight='1.0' />
+                <Replaces block='minecraft:iron_ore' weight='1.0' />
+                <Replaces block='minecraft:lapis_ore' weight='1.0' />
+                <Replaces block='minecraft:redstone_ore' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Iron Generation -->
+
+            <!-- Starting LayeredVeins Preset for Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoIronDist = "LayeredVeins"'>
+                    <Veins name='dnsoIronVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
                             horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CDC1B3</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoNetherQuartzSize * _default_' range=':= 1 * 1 * dnsoNetherQuartzSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoNetherQuartzSize * _default_' range=':= 1 * 1 * dnsoNetherQuartzSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * 1 * dnsoNetherQuartzFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
+                        <OreBlock block='minecraft:iron_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * dnsoIronFreq ' range=':=  1 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':=  1 * _default_ * dnsoIronSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':=  1 * _default_ * dnsoIronSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-                
                 </IfCondition>
-                <!-- End Layered Veins distribution of Nether Quartz -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Nether Quartz -->
-                <IfCondition condition=':= dnsoNetherQuartzDist = "hugeVeins"'>
-                
-                    <Veins name='dnsoNetherQuartzBaseVeins' block='denseores:block0:7'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CDC1B3</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * dnsoNetherQuartzSize * _default_' range=':= 1 * 1 * dnsoNetherQuartzSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * dnsoNetherQuartzSize * _default_' range=':= 1 * 1 * dnsoNetherQuartzSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * 1 * dnsoNetherQuartzFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Nether Quartz -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Nether Quartz -->
-                <IfCondition condition=':= dnsoNetherQuartzDist = "strategicCloud"'>
-                
-                    <Cloud name='dnsoNetherQuartzBaseCloud' block='denseores:block0:7' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CDC1B3</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * dnsoNetherQuartzSize * _default_' range=':= 1 * 1 * dnsoNetherQuartzSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * dnsoNetherQuartzSize * _default_' range=':= 1 * 1 * dnsoNetherQuartzSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * dnsoNetherQuartzSize * _default_' range=':= 1 * 1 * 1 * dnsoNetherQuartzSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 2 * 1 * dnsoNetherQuartzFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Nether Quartz Strategic Cloud Hint Veins -->
-                        <Veins name='dnsoNetherQuartzBaseHintVeins' block='denseores:block0:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60CDC1B3</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Nether Quartz Strategic Cloud Hint Veins -->
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Iron is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Nether Quartz -->
-                
-                
-                <!-- Begin  Vanilla distribution of Nether Quartz -->
-                <IfCondition condition=':= dnsoNetherQuartzDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='dnsoNetherQuartzBaseStandard' block='denseores:block0:7' inherits='PresetStandardGen'>
+
+            <!-- Starting Vanilla Preset for Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoIronDist = "Vanilla"'>
+                    <StandardGen name='dnsoIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                         <Description>
-                            This mimics vanilla ore generation.
+                            A master preset for standardgen ore
+                            distributions.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CDC1B3</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * dnsoNetherQuartzSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 2 * 1 * dnsoNetherQuartzFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
+                        <OreBlock block='minecraft:iron_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 20 * dnsoIronFreq ' range=':=  _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
-                
                 </IfCondition>
-                <!-- End  Vanilla distribution of Nether Quartz -->
-                
-                <!-- End Nether Quartz Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Nether Setup Complete -->
-
-        
-        </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+            </ConfigSection>
+            <!-- Vanilla Preset for Iron is complete. -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+            <!-- Starting Cloud Preset for Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoIronDist = "Cloud"'>
+                    <Cloud name='dnsoIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='minecraft:iron_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.730 * _default_ * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.730 * _default_ * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * dnsoIronFreq ' range=':=  _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='dnsoIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='minecraft:iron_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0' weight='0.1' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Iron is complete. -->
+
+            <!-- End Iron Generation -->
+
+
+            <!-- Begin Gold Generation -->
+
+            <!-- Starting LayeredVeins Preset for Gold. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoGoldDist = "LayeredVeins"'>
+                    <Veins name='dnsoGoldVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='minecraft:gold_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:1' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * dnsoGoldFreq ' range=':=  1 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * dnsoGoldSize ' range=':=  1 * _default_ * dnsoGoldSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * dnsoGoldSize ' range=':=  1 * _default_ * dnsoGoldSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Gold is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Gold. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoGoldDist = "Vanilla"'>
+                    <StandardGen name='dnsoGoldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='minecraft:gold_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:1' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * dnsoGoldFreq ' range=':=  _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Gold is complete. -->
+
+
+            <!-- Starting Cloud Preset for Gold. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoGoldDist = "Cloud"'>
+                    <Cloud name='dnsoGoldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='minecraft:gold_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:1' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * dnsoGoldFreq ' range=':=  _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='dnsoGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='minecraft:gold_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:1' weight='0.1' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Gold is complete. -->
+
+            <!-- End Gold Generation -->
+
+
+            <!-- Begin Lapis Generation -->
+
+            <!-- Starting VerticalVeins Preset for Lapis. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoLapisDist = "VerticalVeins"'>
+                    <Veins name='dnsoLapisVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                        <Description>
+                            Single vertical veins that occur with  no
+                            motherlodes.
+                        </Description>
+                        <OreBlock block='minecraft:lapis_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:2' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * dnsoLapisFreq ' range=':=  1 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Veins name='dnsoLapisPreferredVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='minecraft:lapis_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:2' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Ocean'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * dnsoLapisFreq ' range=':=  1 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- VerticalVeins Preset for Lapis is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Lapis. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoLapisDist = "Vanilla"'>
+                    <StandardGen name='dnsoLapisStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='minecraft:lapis_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:2' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * dnsoLapisFreq ' range=':=  _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Lapis is complete. -->
+
+
+            <!-- Starting Cloud Preset for Lapis. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoLapisDist = "Cloud"'>
+                    <Cloud name='dnsoLapisCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='minecraft:lapis_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:2' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * dnsoLapisFreq ' range=':=  _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='dnsoLapisHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='minecraft:lapis_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:2' weight='0.1' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Cloud name='dnsoLapisPreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='minecraft:lapis_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:2' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Ocean'  />
+                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * dnsoLapisFreq ' range=':=  _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='dnsoLapisPreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='minecraft:lapis_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:2' weight='0.1' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Lapis is complete. -->
+
+            <!-- End Lapis Generation -->
+
+
+            <!-- Begin Diamond Generation -->
+
+            <!-- Starting PipeVeins Preset for Diamond. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoDiamondDist = "PipeVeins"'>
+                    <Veins name='dnsoDiamondVeins'  inherits='PresetPipeVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
+                            from near the bottom of the map.
+                        </Description>
+                        <OreBlock block='minecraft:diamond_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:3' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.365 * _default_ * dnsoDiamondFreq ' range=':=  1 * _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * dnsoDiamondSize ' range=':=  1 * _default_ * dnsoDiamondSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.715 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * dnsoDiamondSize ' range=':=  1 * _default_ * dnsoDiamondSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='dnsoDiamondVeinsPipe'  inherits='dnsoDiamondVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
+                        <OreBlock block='minecraft:lava' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='minecraft:diamond_ore' weight='1.0' />
+                        <Replaces block='denseores:block0:3' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * dnsoDiamondSize  * 0.5 ' range=':=  1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * dnsoDiamondSize  * 0.5 ' range=':=  1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- PipeVeins Preset for Diamond is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Diamond. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoDiamondDist = "Vanilla"'>
+                    <StandardGen name='dnsoDiamondStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='minecraft:diamond_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:3' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 7 * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * dnsoDiamondFreq ' range=':=  _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Diamond is complete. -->
+
+
+            <!-- Starting Cloud Preset for Diamond. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoDiamondDist = "Cloud"'>
+                    <Cloud name='dnsoDiamondCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='minecraft:diamond_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:3' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.791 * _default_ * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.791 * _default_ * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.626  * _default_ * dnsoDiamondFreq ' range=':=  _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='dnsoDiamondHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='minecraft:diamond_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:3' weight='0.1' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Diamond is complete. -->
+
+            <!-- End Diamond Generation -->
+
+
+            <!-- Begin Emerald Generation -->
+
+            <!-- Starting PipeVeins Preset for Emerald. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoEmeraldDist = "PipeVeins"'>
+                    <Veins name='dnsoEmeraldVeins'  inherits='PresetPipeVeins' seed='0xB92D' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
+                            from near the bottom of the map.
+                        </Description>
+                        <OreBlock block='minecraft:emerald_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:4' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Mountain'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * dnsoEmeraldFreq ' range=':=  1 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * dnsoEmeraldSize ' range=':=  1 * _default_ * dnsoEmeraldSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * dnsoEmeraldSize ' range=':=  1 * _default_ * dnsoEmeraldSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='dnsoEmeraldVeinsPipe'  inherits='dnsoEmeraldVeins' seed='0xB92D' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                        <OreBlock block='minecraft:monster_egg' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='minecraft:emerald_ore' weight='1.0' />
+                        <Replaces block='denseores:block0:4' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':=  1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':=  1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- PipeVeins Preset for Emerald is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Emerald. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoEmeraldDist = "Vanilla"'>
+                    <StandardGen name='dnsoEmeraldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='minecraft:emerald_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:4' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Mountain'  />
+                        <Setting name='Size' avg=':= 1 * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * dnsoEmeraldFreq ' range=':=  _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Emerald is complete. -->
+
+
+            <!-- Starting Cloud Preset for Emerald. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoEmeraldDist = "Cloud"'>
+                    <Cloud name='dnsoEmeraldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='minecraft:emerald_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:4' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Mountain'  />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * dnsoEmeraldFreq ' range=':=  _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='dnsoEmeraldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='minecraft:emerald_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:4' weight='0.1' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Emerald is complete. -->
+
+            <!-- End Emerald Generation -->
+
+
+            <!-- Begin Redstone Generation -->
+
+            <!-- Starting VerticalVeins Preset for Redstone. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoRedstoneDist = "VerticalVeins"'>
+                    <Veins name='dnsoRedstoneVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                        <Description>
+                            Single vertical veins that occur with  no
+                            motherlodes.
+                        </Description>
+                        <OreBlock block='minecraft:redstone_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:5' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * dnsoRedstoneFreq ' range=':=  1 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Veins name='dnsoRedstonePreferredVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='minecraft:redstone_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:5' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Desert'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * dnsoRedstoneFreq ' range=':=  1 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- VerticalVeins Preset for Redstone is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Redstone. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoRedstoneDist = "Vanilla"'>
+                    <StandardGen name='dnsoRedstoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='minecraft:redstone_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:5' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 7 * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 8 * dnsoRedstoneFreq ' range=':=  _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Redstone is complete. -->
+
+
+            <!-- Starting Cloud Preset for Redstone. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoRedstoneDist = "Cloud"'>
+                    <Cloud name='dnsoRedstoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='minecraft:redstone_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:5' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * dnsoRedstoneFreq ' range=':=  _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='dnsoRedstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='minecraft:redstone_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:5' weight='0.1' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Cloud name='dnsoRedstonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='minecraft:redstone_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:5' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Desert'  />
+                        <Setting name='CloudRadius' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * dnsoRedstoneFreq ' range=':=  _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='dnsoRedstonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='minecraft:redstone_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:5' weight='0.1' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Redstone is complete. -->
+
+            <!-- End Redstone Generation -->
+
+
+            <!-- Begin Coal Generation -->
+
+            <!-- Starting SparseVeins Preset for Coal. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoCoalDist = "SparseVeins"'>
+                    <Veins name='dnsoCoalVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='minecraft:coal_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:6' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 6.262 * _default_ * dnsoCoalFreq ' range=':=  1 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.843 * _default_ * dnsoCoalSize ' range=':=  1 * _default_ * dnsoCoalSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.843 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.843 * _default_ * dnsoCoalSize ' range=':=  1 * _default_ * dnsoCoalSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Coal is complete. -->
+
+
+            <!-- Starting Cloud Preset for Coal. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoCoalDist = "Cloud"'>
+                    <Cloud name='dnsoCoalCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='minecraft:coal_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:6' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * dnsoCoalFreq ' range=':=  _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='dnsoCoalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='minecraft:coal_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:6' weight='0.1' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Coal is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Coal. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoCoalDist = "Vanilla"'>
+                    <StandardGen name='dnsoCoalStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='minecraft:coal_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:6' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 16 * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 20 * dnsoCoalFreq ' range=':=  _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Coal is complete. -->
+
+
+            <!-- Starting Cloud Preset for Coal. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoCoalDist = "Cloud"'>
+                    <Cloud name='dnsoCoalCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='minecraft:coal_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:6' weight='0.1' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * dnsoCoalFreq ' range=':=  _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='dnsoCoalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='minecraft:coal_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:6' weight='0.1' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Coal is complete. -->
+
+            <!-- End Coal Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+
+        <!-- Nether Setup Beginning -->
+
+        <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
+
+            <!-- Starting Original "Nether" Block Removal -->
+
+            <Substitute name='dnsoNetherBlockSubstitute0' block='minecraft:netherrack'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='denseores:block0:7' weight='1.0' />
+                <Replaces block='minecraft:quartz_ore' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Nether" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Nether Quartz Generation -->
+
+            <!-- Starting LayeredVeins Preset for Nether Quartz. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoNetherQuartzDist = "LayeredVeins"'>
+                    <Veins name='dnsoNetherQuartzVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='minecraft:quartz_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:7' weight='0.1' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 5.049 * _default_ * dnsoNetherQuartzFreq ' range=':=  1 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.716 * _default_ * dnsoNetherQuartzSize ' range=':=  1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.716 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.716 * _default_ * dnsoNetherQuartzSize ' range=':=  1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Nether Quartz is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Nether Quartz. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoNetherQuartzDist = "Vanilla"'>
+                    <StandardGen name='dnsoNetherQuartzStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='minecraft:quartz_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:7' weight='0.1' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 13 * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 16 * dnsoNetherQuartzFreq ' range=':=  _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Nether Quartz is complete. -->
+
+
+            <!-- Starting Cloud Preset for Nether Quartz. -->
+            <ConfigSection>
+                <IfCondition condition=':= dnsoNetherQuartzDist = "Cloud"'>
+                    <Cloud name='dnsoNetherQuartzCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='minecraft:quartz_ore' weight='0.9' />
+                        <OreBlock block='denseores:block0:7' weight='0.1' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.847 * _default_ * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.847 * _default_ * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 3.411  * _default_ * dnsoNetherQuartzFreq ' range=':=  _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='dnsoNetherQuartzHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='minecraft:quartz_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:7' weight='0.1' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Nether Quartz is complete. -->
+
+            <!-- End Nether Quartz Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Nether Setup Complete -->
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Dense Ores" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -28,10 +28,15 @@
                     Distribution options for ElectriCraft Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableElectriCraft' displayName='Handle ElectriCraft Setup?' default='true' displayState='shown_dynamic' displayGroup='groupElectriCraft'>
+                <Description> Should Custom Ore Generation handle ElectriCraft ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle ElectriCraft ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='ElectriCraft ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Copper Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='elcrCopperDist'  displayState='shown' displayGroup='groupElectriCraft'>
+                <OptionChoice name='elcrCopperDist'  displayState=':= if(?enableElectriCraft, "shown", "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Controls how Copper is generated </Description>
                     <DisplayName>ElectriCraft Copper</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -51,11 +56,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='elcrCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupElectriCraft'>
+                <OptionNumeric name='elcrCopperFreq' default='1'  min='0' max='5' displayState=':= if(?enableElectriCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Frequency multiplier for ElectriCraft Copper distributions </Description>
                     <DisplayName>ElectriCraft Copper Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='elcrCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupElectriCraft'>
+                <OptionNumeric name='elcrCopperSize' default='1'  min='0' max='5' displayState=':= if(?enableElectriCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Size multiplier for ElectriCraft Copper distributions </Description>
                     <DisplayName>ElectriCraft Copper Size</DisplayName>
                 </OptionNumeric>
@@ -65,7 +70,7 @@
 
             <!-- Tin Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='elcrTinDist'  displayState='shown' displayGroup='groupElectriCraft'>
+                <OptionChoice name='elcrTinDist'  displayState=':= if(?enableElectriCraft, "shown", "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Controls how Tin is generated </Description>
                     <DisplayName>ElectriCraft Tin</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -85,11 +90,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='elcrTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupElectriCraft'>
+                <OptionNumeric name='elcrTinFreq' default='1'  min='0' max='5' displayState=':= if(?enableElectriCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Frequency multiplier for ElectriCraft Tin distributions </Description>
                     <DisplayName>ElectriCraft Tin Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='elcrTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupElectriCraft'>
+                <OptionNumeric name='elcrTinSize' default='1'  min='0' max='5' displayState=':= if(?enableElectriCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Size multiplier for ElectriCraft Tin distributions </Description>
                     <DisplayName>ElectriCraft Tin Size</DisplayName>
                 </OptionNumeric>
@@ -99,7 +104,7 @@
 
             <!-- Silver Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='elcrSilverDist'  displayState='shown' displayGroup='groupElectriCraft'>
+                <OptionChoice name='elcrSilverDist'  displayState=':= if(?enableElectriCraft, "shown", "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Controls how Silver is generated </Description>
                     <DisplayName>ElectriCraft Silver</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -119,11 +124,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='elcrSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupElectriCraft'>
+                <OptionNumeric name='elcrSilverFreq' default='1'  min='0' max='5' displayState=':= if(?enableElectriCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Frequency multiplier for ElectriCraft Silver distributions </Description>
                     <DisplayName>ElectriCraft Silver Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='elcrSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupElectriCraft'>
+                <OptionNumeric name='elcrSilverSize' default='1'  min='0' max='5' displayState=':= if(?enableElectriCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Size multiplier for ElectriCraft Silver distributions </Description>
                     <DisplayName>ElectriCraft Silver Size</DisplayName>
                 </OptionNumeric>
@@ -133,7 +138,7 @@
 
             <!-- Nickel Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='elcrNickelDist'  displayState='shown' displayGroup='groupElectriCraft'>
+                <OptionChoice name='elcrNickelDist'  displayState=':= if(?enableElectriCraft, "shown", "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Controls how Nickel is generated </Description>
                     <DisplayName>ElectriCraft Nickel</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -153,11 +158,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Nickel is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='elcrNickelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupElectriCraft'>
+                <OptionNumeric name='elcrNickelFreq' default='1'  min='0' max='5' displayState=':= if(?enableElectriCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Frequency multiplier for ElectriCraft Nickel distributions </Description>
                     <DisplayName>ElectriCraft Nickel Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='elcrNickelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupElectriCraft'>
+                <OptionNumeric name='elcrNickelSize' default='1'  min='0' max='5' displayState=':= if(?enableElectriCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Size multiplier for ElectriCraft Nickel distributions </Description>
                     <DisplayName>ElectriCraft Nickel Size</DisplayName>
                 </OptionNumeric>
@@ -167,7 +172,7 @@
 
             <!-- Aluminum Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='elcrAluminumDist'  displayState='shown' displayGroup='groupElectriCraft'>
+                <OptionChoice name='elcrAluminumDist'  displayState=':= if(?enableElectriCraft, "shown", "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Controls how Aluminum is generated </Description>
                     <DisplayName>ElectriCraft Aluminum</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -187,11 +192,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Aluminum is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='elcrAluminumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupElectriCraft'>
+                <OptionNumeric name='elcrAluminumFreq' default='1'  min='0' max='5' displayState=':= if(?enableElectriCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Frequency multiplier for ElectriCraft Aluminum distributions </Description>
                     <DisplayName>ElectriCraft Aluminum Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='elcrAluminumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupElectriCraft'>
+                <OptionNumeric name='elcrAluminumSize' default='1'  min='0' max='5' displayState=':= if(?enableElectriCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Size multiplier for ElectriCraft Aluminum distributions </Description>
                     <DisplayName>ElectriCraft Aluminum Size</DisplayName>
                 </OptionNumeric>
@@ -201,7 +206,7 @@
 
             <!-- Platinum Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='elcrPlatinumDist'  displayState='shown' displayGroup='groupElectriCraft'>
+                <OptionChoice name='elcrPlatinumDist'  displayState=':= if(?enableElectriCraft, "shown", "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Controls how Platinum is generated </Description>
                     <DisplayName>ElectriCraft Platinum</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -221,11 +226,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Platinum is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='elcrPlatinumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupElectriCraft'>
+                <OptionNumeric name='elcrPlatinumFreq' default='1'  min='0' max='5' displayState=':= if(?enableElectriCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Frequency multiplier for ElectriCraft Platinum distributions </Description>
                     <DisplayName>ElectriCraft Platinum Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='elcrPlatinumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupElectriCraft'>
+                <OptionNumeric name='elcrPlatinumSize' default='1'  min='0' max='5' displayState=':= if(?enableElectriCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupElectriCraft'>
                     <Description> Size multiplier for ElectriCraft Platinum distributions </Description>
                     <DisplayName>ElectriCraft Platinum Size</DisplayName>
                 </OptionNumeric>
@@ -235,744 +240,761 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableElectriCraft'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='elcrOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='ElectriCraft:electricraft_block_ore' weight='1.0' />
-                <Replaces block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
-                <Replaces block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
-                <Replaces block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
-                <Replaces block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
-                <Replaces block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Copper Generation -->
-
-            <!-- Starting LayeredVeins Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrCopperDist = "LayeredVeins"'>
-                    <Veins name='elcrCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BB6E30' drawBoundBox='false' boundBoxColor='0x60BB6E30'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='elcrOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * elcrCopperFreq ' range=':=  1 * _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * elcrCopperSize ' range=':=  1 * _default_ * elcrCopperSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * elcrCopperSize ' range=':=  1 * _default_ * elcrCopperSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <Replaces block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <Replaces block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <Replaces block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <Replaces block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <Replaces block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <Replaces block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Copper is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Vanilla Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrCopperDist = "Vanilla"'>
-                    <StandardGen name='elcrCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BB6E30' drawBoundBox='false' boundBoxColor='0x60BB6E30'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 8 * elcrCopperFreq ' range=':=  _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Copper is complete. -->
+                <!-- Adding blocks -->
 
+                <!-- Begin Copper Generation -->
 
-            <!-- Starting Cloud Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrCopperDist = "Cloud"'>
-                    <Cloud name='elcrCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BB6E30' drawBoundBox='false' boundBoxColor='0x60BB6E30'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * elcrCopperFreq ' range=':=  _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='elcrCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BB6E30' drawBoundBox='false' boundBoxColor='0x60BB6E30'>
+                <!-- Starting LayeredVeins Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrCopperDist = "LayeredVeins"'>
+                        <Veins name='elcrCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BB6E30' drawBoundBox='false' boundBoxColor='0x60BB6E30'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * elcrCopperFreq ' range=':=  1 * _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * elcrCopperSize ' range=':=  1 * _default_ * elcrCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * elcrCopperSize ' range=':=  1 * _default_ * elcrCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Copper is complete. -->
-
-            <!-- End Copper Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Copper is complete. -->
 
 
-            <!-- Begin Tin Generation -->
-
-            <!-- Starting LayeredVeins Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrTinDist = "LayeredVeins"'>
-                    <Veins name='elcrTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60A9C7CF' drawBoundBox='false' boundBoxColor='0x60A9C7CF'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * elcrTinFreq ' range=':=  1 * _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * elcrTinSize ' range=':=  1 * _default_ * elcrTinSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 60 ' range=':=  12 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * elcrTinSize ' range=':=  1 * _default_ * elcrTinSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Tin is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrTinDist = "Vanilla"'>
-                    <StandardGen name='elcrTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60A9C7CF' drawBoundBox='false' boundBoxColor='0x60A9C7CF'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 8 * elcrTinFreq ' range=':=  _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 60 ' range=':=  12 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Tin is complete. -->
-
-
-            <!-- Starting Cloud Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrTinDist = "Cloud"'>
-                    <Cloud name='elcrTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A9C7CF' drawBoundBox='false' boundBoxColor='0x60A9C7CF'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * elcrTinFreq ' range=':=  _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 60 ' range=':=  12 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='elcrTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A9C7CF' drawBoundBox='false' boundBoxColor='0x60A9C7CF'>
+                <!-- Starting Vanilla Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrCopperDist = "Vanilla"'>
+                        <StandardGen name='elcrCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BB6E30' drawBoundBox='false' boundBoxColor='0x60BB6E30'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Tin is complete. -->
-
-            <!-- End Tin Generation -->
-
-
-            <!-- Begin Silver Generation -->
-
-            <!-- Starting LayeredVeins Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrSilverDist = "LayeredVeins"'>
-                    <Veins name='elcrSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60B6D2EA' drawBoundBox='false' boundBoxColor='0x60B6D2EA'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * elcrSilverFreq ' range=':=  1 * _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * elcrSilverSize ' range=':=  1 * _default_ * elcrSilverSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * elcrSilverSize ' range=':=  1 * _default_ * elcrSilverSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Silver is complete. -->
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * elcrCopperFreq ' range=':=  _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrSilverDist = "Vanilla"'>
-                    <StandardGen name='elcrSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B6D2EA' drawBoundBox='false' boundBoxColor='0x60B6D2EA'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * elcrSilverFreq ' range=':=  _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Silver is complete. -->
-
-
-            <!-- Starting Cloud Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrSilverDist = "Cloud"'>
-                    <Cloud name='elcrSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B6D2EA' drawBoundBox='false' boundBoxColor='0x60B6D2EA'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.076 * _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.076 * _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.159 * _default_ * elcrSilverFreq ' range=':=  _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='elcrSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B6D2EA' drawBoundBox='false' boundBoxColor='0x60B6D2EA'>
+                <!-- Starting Cloud Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrCopperDist = "Cloud"'>
+                        <Cloud name='elcrCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BB6E30' drawBoundBox='false' boundBoxColor='0x60BB6E30'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Silver is complete. -->
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * elcrCopperFreq ' range=':=  _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='elcrCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BB6E30' drawBoundBox='false' boundBoxColor='0x60BB6E30'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Copper is complete. -->
 
-            <!-- End Silver Generation -->
-
-
-            <!-- Begin Nickel Generation -->
-
-            <!-- Starting LayeredVeins Preset for Nickel. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrNickelDist = "LayeredVeins"'>
-                    <Veins name='elcrNickelVeins'  inherits='PresetLayeredVeins' drawWireframe='false' wireframeColor='0x60D2D1B6' drawBoundBox='false' boundBoxColor='0x60D2D1B6'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * elcrNickelFreq ' range=':=  1 * _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * elcrNickelSize ' range=':=  1 * _default_ * elcrNickelSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * elcrNickelSize ' range=':=  1 * _default_ * elcrNickelSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Nickel is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Nickel. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrNickelDist = "Vanilla"'>
-                    <StandardGen name='elcrNickelStandard'  inherits='PresetStandardGen' drawWireframe='false' wireframeColor='0x60D2D1B6' drawBoundBox='false' boundBoxColor='0x60D2D1B6'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 6 * elcrNickelFreq ' range=':=  _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Nickel is complete. -->
+                <!-- End Copper Generation -->
 
 
-            <!-- Starting Cloud Preset for Nickel. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrNickelDist = "Cloud"'>
-                    <Cloud name='elcrNickelCloud'  inherits='PresetStrategicCloud' drawWireframe='false' wireframeColor='0x60D2D1B6' drawBoundBox='false' boundBoxColor='0x60D2D1B6'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * elcrNickelFreq ' range=':=  _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='elcrNickelHintVeins'  inherits='PresetHintVeins' drawWireframe='false' wireframeColor='0x60D2D1B6' drawBoundBox='false' boundBoxColor='0x60D2D1B6'>
+                <!-- Begin Tin Generation -->
+
+                <!-- Starting LayeredVeins Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrTinDist = "LayeredVeins"'>
+                        <Veins name='elcrTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60A9C7CF' drawBoundBox='false' boundBoxColor='0x60A9C7CF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * elcrTinFreq ' range=':=  1 * _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * elcrTinSize ' range=':=  1 * _default_ * elcrTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 60 ' range=':=  12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * elcrTinSize ' range=':=  1 * _default_ * elcrTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Nickel is complete. -->
-
-            <!-- End Nickel Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Tin is complete. -->
 
 
-            <!-- Begin Aluminum Generation -->
-
-            <!-- Starting LayeredVeins Preset for Aluminum. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrAluminumDist = "LayeredVeins"'>
-                    <Veins name='elcrAluminumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DAD9DB' drawBoundBox='false' boundBoxColor='0x60DAD9DB'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * elcrAluminumFreq ' range=':=  1 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * elcrAluminumSize ' range=':=  1 * _default_ * elcrAluminumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.019 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.019 * _default_ * elcrAluminumSize ' range=':=  1 * _default_ * elcrAluminumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Aluminum is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Aluminum. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrAluminumDist = "Vanilla"'>
-                    <StandardGen name='elcrAluminumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DAD9DB' drawBoundBox='false' boundBoxColor='0x60DAD9DB'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 10 * elcrAluminumFreq ' range=':=  _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Aluminum is complete. -->
-
-
-            <!-- Starting Cloud Preset for Aluminum. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrAluminumDist = "Cloud"'>
-                    <Cloud name='elcrAluminumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DAD9DB' drawBoundBox='false' boundBoxColor='0x60DAD9DB'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.454 * _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.454 * _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.115 * _default_ * elcrAluminumFreq ' range=':=  _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='elcrAluminumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DAD9DB' drawBoundBox='false' boundBoxColor='0x60DAD9DB'>
+                <!-- Starting Vanilla Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrTinDist = "Vanilla"'>
+                        <StandardGen name='elcrTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60A9C7CF' drawBoundBox='false' boundBoxColor='0x60A9C7CF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Aluminum is complete. -->
-
-            <!-- End Aluminum Generation -->
-
-
-            <!-- Begin Platinum Generation -->
-
-            <!-- Starting LayeredVeins Preset for Platinum. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrPlatinumDist = "LayeredVeins"'>
-                    <Veins name='elcrPlatinumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x602D84E7' drawBoundBox='false' boundBoxColor='0x602D84E7'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * elcrPlatinumFreq ' range=':=  1 * _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * elcrPlatinumSize ' range=':=  1 * _default_ * elcrPlatinumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * elcrPlatinumSize ' range=':=  1 * _default_ * elcrPlatinumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Platinum is complete. -->
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * elcrTinFreq ' range=':=  _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 60 ' range=':=  12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tin is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Platinum. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrPlatinumDist = "Vanilla"'>
-                    <StandardGen name='elcrPlatinumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x602D84E7' drawBoundBox='false' boundBoxColor='0x602D84E7'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * elcrPlatinumFreq ' range=':=  _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Platinum is complete. -->
-
-
-            <!-- Starting Cloud Preset for Platinum. -->
-            <ConfigSection>
-                <IfCondition condition=':= elcrPlatinumDist = "Cloud"'>
-                    <Cloud name='elcrPlatinumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x602D84E7' drawBoundBox='false' boundBoxColor='0x602D84E7'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.669 * _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.669 * _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.447  * _default_ * elcrPlatinumFreq ' range=':=  _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='elcrPlatinumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602D84E7' drawBoundBox='false' boundBoxColor='0x602D84E7'>
+                <!-- Starting Cloud Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrTinDist = "Cloud"'>
+                        <Cloud name='elcrTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A9C7CF' drawBoundBox='false' boundBoxColor='0x60A9C7CF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * elcrTinFreq ' range=':=  _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 60 ' range=':=  12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='elcrTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A9C7CF' drawBoundBox='false' boundBoxColor='0x60A9C7CF'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tin is complete. -->
+
+                <!-- End Tin Generation -->
+
+
+                <!-- Begin Silver Generation -->
+
+                <!-- Starting LayeredVeins Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrSilverDist = "LayeredVeins"'>
+                        <Veins name='elcrSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60B6D2EA' drawBoundBox='false' boundBoxColor='0x60B6D2EA'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * elcrSilverFreq ' range=':=  1 * _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * elcrSilverSize ' range=':=  1 * _default_ * elcrSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * elcrSilverSize ' range=':=  1 * _default_ * elcrSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Platinum is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Silver is complete. -->
 
-            <!-- End Platinum Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrSilverDist = "Vanilla"'>
+                        <StandardGen name='elcrSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B6D2EA' drawBoundBox='false' boundBoxColor='0x60B6D2EA'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * elcrSilverFreq ' range=':=  _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Silver is complete. -->
+
+
+                <!-- Starting Cloud Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrSilverDist = "Cloud"'>
+                        <Cloud name='elcrSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B6D2EA' drawBoundBox='false' boundBoxColor='0x60B6D2EA'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159 * _default_ * elcrSilverFreq ' range=':=  _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='elcrSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B6D2EA' drawBoundBox='false' boundBoxColor='0x60B6D2EA'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Silver is complete. -->
+
+                <!-- End Silver Generation -->
+
+
+                <!-- Begin Nickel Generation -->
+
+                <!-- Starting LayeredVeins Preset for Nickel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrNickelDist = "LayeredVeins"'>
+                        <Veins name='elcrNickelVeins'  inherits='PresetLayeredVeins' drawWireframe='false' wireframeColor='0x60D2D1B6' drawBoundBox='false' boundBoxColor='0x60D2D1B6'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * elcrNickelFreq ' range=':=  1 * _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * elcrNickelSize ' range=':=  1 * _default_ * elcrNickelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * elcrNickelSize ' range=':=  1 * _default_ * elcrNickelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Nickel is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Nickel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrNickelDist = "Vanilla"'>
+                        <StandardGen name='elcrNickelStandard'  inherits='PresetStandardGen' drawWireframe='false' wireframeColor='0x60D2D1B6' drawBoundBox='false' boundBoxColor='0x60D2D1B6'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * elcrNickelFreq ' range=':=  _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Nickel is complete. -->
+
+
+                <!-- Starting Cloud Preset for Nickel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrNickelDist = "Cloud"'>
+                        <Cloud name='elcrNickelCloud'  inherits='PresetStrategicCloud' drawWireframe='false' wireframeColor='0x60D2D1B6' drawBoundBox='false' boundBoxColor='0x60D2D1B6'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * elcrNickelFreq ' range=':=  _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='elcrNickelHintVeins'  inherits='PresetHintVeins' drawWireframe='false' wireframeColor='0x60D2D1B6' drawBoundBox='false' boundBoxColor='0x60D2D1B6'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Nickel is complete. -->
+
+                <!-- End Nickel Generation -->
+
+
+                <!-- Begin Aluminum Generation -->
+
+                <!-- Starting LayeredVeins Preset for Aluminum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrAluminumDist = "LayeredVeins"'>
+                        <Veins name='elcrAluminumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DAD9DB' drawBoundBox='false' boundBoxColor='0x60DAD9DB'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * elcrAluminumFreq ' range=':=  1 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * elcrAluminumSize ' range=':=  1 * _default_ * elcrAluminumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.019 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.019 * _default_ * elcrAluminumSize ' range=':=  1 * _default_ * elcrAluminumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Aluminum is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Aluminum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrAluminumDist = "Vanilla"'>
+                        <StandardGen name='elcrAluminumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DAD9DB' drawBoundBox='false' boundBoxColor='0x60DAD9DB'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10 * elcrAluminumFreq ' range=':=  _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Aluminum is complete. -->
+
+
+                <!-- Starting Cloud Preset for Aluminum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrAluminumDist = "Cloud"'>
+                        <Cloud name='elcrAluminumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DAD9DB' drawBoundBox='false' boundBoxColor='0x60DAD9DB'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.454 * _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.454 * _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.115 * _default_ * elcrAluminumFreq ' range=':=  _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='elcrAluminumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DAD9DB' drawBoundBox='false' boundBoxColor='0x60DAD9DB'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Aluminum is complete. -->
+
+                <!-- End Aluminum Generation -->
+
+
+                <!-- Begin Platinum Generation -->
+
+                <!-- Starting LayeredVeins Preset for Platinum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrPlatinumDist = "LayeredVeins"'>
+                        <Veins name='elcrPlatinumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x602D84E7' drawBoundBox='false' boundBoxColor='0x602D84E7'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * elcrPlatinumFreq ' range=':=  1 * _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * elcrPlatinumSize ' range=':=  1 * _default_ * elcrPlatinumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * elcrPlatinumSize ' range=':=  1 * _default_ * elcrPlatinumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Platinum is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Platinum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrPlatinumDist = "Vanilla"'>
+                        <StandardGen name='elcrPlatinumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x602D84E7' drawBoundBox='false' boundBoxColor='0x602D84E7'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * elcrPlatinumFreq ' range=':=  _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Platinum is complete. -->
+
+
+                <!-- Starting Cloud Preset for Platinum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= elcrPlatinumDist = "Cloud"'>
+                        <Cloud name='elcrPlatinumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x602D84E7' drawBoundBox='false' boundBoxColor='0x602D84E7'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.669 * _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.669 * _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.447  * _default_ * elcrPlatinumFreq ' range=':=  _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='elcrPlatinumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602D84E7' drawBoundBox='false' boundBoxColor='0x602D84E7'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Platinum is complete. -->
+
+                <!-- End Platinum Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -4,6 +4,9 @@
      ================================================================= -->
 
 
+<!-- An expansion to Rotarycraft, this mod adds oregen appropriate to
+     the formation of various wires with different electrical
+     advantages/disadvantages. -->
 
 
 
@@ -307,8 +310,8 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * elcrCopperSize ' range=':=  2 * elcrCopperSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 8 * elcrCopperFreq ' range=':=  2 * elcrCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 6 * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 8 * elcrCopperFreq ' range=':=  _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -337,9 +340,9 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.441 * _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.441 * _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.194  * _default_ * elcrCopperFreq ' range=':=  _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * elcrCopperFreq ' range=':=  _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -424,8 +427,8 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * elcrTinSize ' range=':=  2 * elcrTinSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 8 * elcrTinFreq ' range=':=  2 * elcrTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 8 * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 8 * elcrTinFreq ' range=':=  _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 60 ' range=':=  12 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -454,9 +457,9 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.474 * _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.474 * _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.224  * _default_ * elcrTinFreq ' range=':=  _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * elcrTinFreq ' range=':=  _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 60 ' range=':=  12 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -541,8 +544,8 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * elcrSilverSize ' range=':=  2 * elcrSilverSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * elcrSilverFreq ' range=':=  1 * elcrSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 6 * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 4 * elcrSilverFreq ' range=':=  _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -571,9 +574,9 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.371 * _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.371 * _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.137  * _default_ * elcrSilverFreq ' range=':=  _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.076 * _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.076 * _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.159 * _default_ * elcrSilverFreq ' range=':=  _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -658,8 +661,8 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * elcrNickelSize ' range=':=  2 * elcrNickelSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 8 * elcrNickelFreq ' range=':=  2 * elcrNickelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 8 * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 6 * elcrNickelFreq ' range=':=  _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -688,9 +691,9 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.441 * _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.441 * _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.194  * _default_ * elcrNickelFreq ' range=':=  _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * elcrNickelFreq ' range=':=  _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -743,19 +746,19 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.060 * _default_ * elcrAluminumFreq ' range=':=  1 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.020 * _default_ * elcrAluminumSize ' range=':=  1 * _default_ * elcrAluminumSize ' type='normal' />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * elcrAluminumFreq ' range=':=  1 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * elcrAluminumSize ' range=':=  1 * _default_ * elcrAluminumSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.020 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.019 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.020 * _default_ * elcrAluminumSize ' range=':=  1 * _default_ * elcrAluminumSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.019 * _default_ * elcrAluminumSize ' range=':=  1 * _default_ * elcrAluminumSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
@@ -775,8 +778,8 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * elcrAluminumSize ' range=':=  2 * elcrAluminumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 10 * elcrAluminumFreq ' range=':=  3 * elcrAluminumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 8 * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 10 * elcrAluminumFreq ' range=':=  _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -805,9 +808,9 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.501 * _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.501 * _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.251  * _default_ * elcrAluminumFreq ' range=':=  _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.454 * _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.454 * _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.115 * _default_ * elcrAluminumFreq ' range=':=  _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -892,8 +895,8 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * elcrPlatinumSize ' range=':=  2 * elcrPlatinumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * elcrPlatinumFreq ' range=':=  0 * elcrPlatinumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 4 * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * elcrPlatinumFreq ' range=':=  _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -922,9 +925,9 @@
                         <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.282 * _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.282 * _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.079  * _default_ * elcrPlatinumFreq ' range=':=  _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 0.669 * _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.669 * _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.447  * _default_ * elcrPlatinumFreq ' range=':=  _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -25,10 +25,15 @@
                     Distribution options for Factorization Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableFactorization' displayName='Handle Factorization Setup?' default='true' displayState='shown_dynamic' displayGroup='groupFactorization'>
+                <Description> Should Custom Ore Generation handle Factorization ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Factorization ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Factorization ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Silver Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='fctrSilverDist'  displayState='shown' displayGroup='groupFactorization'>
+                <OptionChoice name='fctrSilverDist'  displayState=':= if(?enableFactorization, "shown", "hidden")' displayGroup='groupFactorization'>
                     <Description> Controls how Silver is generated </Description>
                     <DisplayName>Factorization Silver</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -48,11 +53,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='fctrSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFactorization'>
+                <OptionNumeric name='fctrSilverFreq' default='1'  min='0' max='5' displayState=':= if(?enableFactorization, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupFactorization'>
                     <Description> Frequency multiplier for Factorization Silver distributions </Description>
                     <DisplayName>Factorization Silver Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='fctrSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFactorization'>
+                <OptionNumeric name='fctrSilverSize' default='1'  min='0' max='5' displayState=':= if(?enableFactorization, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupFactorization'>
                     <Description> Size multiplier for Factorization Silver distributions </Description>
                     <DisplayName>Factorization Silver Size</DisplayName>
                 </OptionNumeric>
@@ -62,7 +67,7 @@
 
             <!-- Dark Iron Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='fctrDarkIronDist'  displayState='shown' displayGroup='groupFactorization'>
+                <OptionChoice name='fctrDarkIronDist'  displayState=':= if(?enableFactorization, "shown", "hidden")' displayGroup='groupFactorization'>
                     <Description> Controls how Dark Iron is generated </Description>
                     <DisplayName>Factorization Dark Iron</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -82,11 +87,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Dark Iron is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='fctrDarkIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFactorization'>
+                <OptionNumeric name='fctrDarkIronFreq' default='1'  min='0' max='5' displayState=':= if(?enableFactorization, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupFactorization'>
                     <Description> Frequency multiplier for Factorization Dark Iron distributions </Description>
                     <DisplayName>Factorization Dark Iron Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='fctrDarkIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFactorization'>
+                <OptionNumeric name='fctrDarkIronSize' default='1'  min='0' max='5' displayState=':= if(?enableFactorization, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupFactorization'>
                     <Description> Size multiplier for Factorization Dark Iron distributions </Description>
                     <DisplayName>Factorization Dark Iron Size</DisplayName>
                 </OptionNumeric>
@@ -96,284 +101,294 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableFactorization'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='fctrOverworldBlockSubstitute2' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='factorization:DarkIronOre' weight='1.0' />
-                <Replaces block='factorization:ResourceBlock' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Silver Generation -->
-
-            <!-- Starting LayeredVeins Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= fctrSilverDist = "LayeredVeins"'>
-                    <Veins name='fctrSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='fctrOverworldBlockSubstitute2' block='minecraft:stone'>
                         <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='factorization:ResourceBlock' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.543 * _default_ * fctrSilverFreq ' range=':=  _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.816 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 25 ' range=':=  10 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.816 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.816 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <Replaces block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <Replaces block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Silver is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= fctrSilverDist = "Cloud"'>
-                    <Cloud name='fctrSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='factorization:ResourceBlock' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.041 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.041 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.084  * _default_ * fctrSilverFreq ' range=':=  _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 25 ' range=':=  10 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='fctrSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Silver Generation -->
+
+                <!-- Starting LayeredVeins Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= fctrSilverDist = "LayeredVeins"'>
+                        <Veins name='fctrSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='factorization:ResourceBlock' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.543 * _default_ * fctrSilverFreq ' range=':=  _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.816 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 25 ' range=':=  10 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.816 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.816 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Silver is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Silver is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= fctrSilverDist = "Vanilla"'>
-                    <StandardGen name='fctrSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='factorization:ResourceBlock' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 7 * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * fctrSilverFreq ' range=':=  _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 25 ' range=':=  10 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Silver is complete. -->
-
-            <!-- End Silver Generation -->
-
-
-            <!-- Begin Dark Iron Generation -->
-
-            <!-- Starting SparseVeins Preset for Dark Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= fctrDarkIronDist = "SparseVeins"'>
-                    <Veins name='fctrDarkIronVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='factorization:DarkIronOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.350 * _default_ * fctrDarkIronFreq ' range=':=  _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.705 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 3 ' range=':=  2 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.705 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.705 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Dark Iron is complete. -->
-
-
-            <!-- Starting Cloud Preset for Dark Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= fctrDarkIronDist = "Cloud"'>
-                    <Cloud name='fctrDarkIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='factorization:DarkIronOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * fctrDarkIronFreq ' range=':=  _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 3 ' range=':=  2 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='fctrDarkIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
+                <!-- Starting Cloud Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= fctrSilverDist = "Cloud"'>
+                        <Cloud name='fctrSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='factorization:DarkIronOre' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.041 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.041 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.084  * _default_ * fctrSilverFreq ' range=':=  _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 25 ' range=':=  10 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='fctrSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Silver is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= fctrSilverDist = "Vanilla"'>
+                        <StandardGen name='fctrSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 7 * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * fctrSilverFreq ' range=':=  _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 25 ' range=':=  10 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Silver is complete. -->
+
+                <!-- End Silver Generation -->
+
+
+                <!-- Begin Dark Iron Generation -->
+
+                <!-- Starting SparseVeins Preset for Dark Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= fctrDarkIronDist = "SparseVeins"'>
+                        <Veins name='fctrDarkIronVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.350 * _default_ * fctrDarkIronFreq ' range=':=  _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.705 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 3 ' range=':=  2 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.705 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.705 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Dark Iron is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Dark Iron is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Dark Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= fctrDarkIronDist = "Vanilla"'>
-                    <StandardGen name='fctrDarkIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='factorization:DarkIronOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * fctrDarkIronFreq ' range=':=  _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 3 ' range=':=  2 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Dark Iron is complete. -->
+                <!-- Starting Cloud Preset for Dark Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= fctrDarkIronDist = "Cloud"'>
+                        <Cloud name='fctrDarkIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * fctrDarkIronFreq ' range=':=  _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 3 ' range=':=  2 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='fctrDarkIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Dark Iron is complete. -->
 
-            <!-- End Dark Iron Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Dark Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= fctrDarkIronDist = "Vanilla"'>
+                        <StandardGen name='fctrDarkIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * fctrDarkIronFreq ' range=':=  _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 3 ' range=':=  2 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Dark Iron is complete. -->
+
+                <!-- End Dark Iron Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -1,362 +1,394 @@
- <!-- ================================================================
-      Custom Ore Generation "Factorization" Module: This configuration
-      covers silver and dark iron.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Factorization" Module: This configuration
+     covers silver and dark iron.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="factorization">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "Factorization" mod on the system?  Let's find out! -->
+<IfModInstalled name="factorization">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupFactorization' displayName='Factorization' displayState='shown'>
+                <Description>
+                    Distribution options for Factorization Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Silver Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupFactorization' displayName='Factorization' displayState='shown'> 
-                    <Description>
-                        Distribution options for Factorization Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Silver Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='fctrSilverDist'  displayState='shown' displayGroup='groupFactorization'> 
-                        <Description> Controls how Silver is generated </Description> 
-                        <DisplayName>Factorization Silver</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='fctrSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFactorization'>
-                        <Description> Frequency multiplier for Factorization Silver distributions </Description>
-                        <DisplayName>Factorization Silver Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='fctrSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFactorization'>
-                        <Description> Size multiplier for Factorization Silver distributions </Description>
-                        <DisplayName>Factorization Silver Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Silver Configuration UI Complete -->
-                
-                
-                <!-- Dark Iron Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='fctrDarkIronDist'  displayState='shown' displayGroup='groupFactorization'> 
-                        <Description> Controls how Dark Iron is generated </Description> 
-                        <DisplayName>Factorization Dark Iron</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Dark Iron is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='fctrDarkIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFactorization'>
-                        <Description> Frequency multiplier for Factorization Dark Iron distributions </Description>
-                        <DisplayName>Factorization Dark Iron Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='fctrDarkIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFactorization'>
-                        <Description> Size multiplier for Factorization Dark Iron distributions </Description>
-                        <DisplayName>Factorization Dark Iron Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Dark Iron Configuration UI Complete -->
-                
+                <OptionChoice name='fctrSilverDist'  displayState='shown' displayGroup='groupFactorization'>
+                    <Description> Controls how Silver is generated </Description>
+                    <DisplayName>Factorization Silver</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='fctrSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFactorization'>
+                    <Description> Frequency multiplier for Factorization Silver distributions </Description>
+                    <DisplayName>Factorization Silver Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='fctrSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFactorization'>
+                    <Description> Size multiplier for Factorization Silver distributions </Description>
+                    <DisplayName>Factorization Silver Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Silver Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='fctrOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='factorization:ResourceBlock' />
-                    <Replaces block='factorization:DarkIronOre' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Silver Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Silver -->
-                <IfCondition condition=':= fctrSilverDist = "layeredVeins"'>
-                
-                    <Veins name='fctrSilverBaseVeins' block='factorization:ResourceBlock'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608C9EBE</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * fctrSilverSize * _default_' range=':= 1 * 0.8 * fctrSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * fctrSilverSize * _default_' range=':= 1 * 0.8 * fctrSilverSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * fctrSilverFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                    <Veins name='fctrSilverPrefersVeins' block='factorization:ResourceBlock'  inherits='fctrSilverBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608C9EBE</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Silver -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Silver -->
-                <IfCondition condition=':= fctrSilverDist = "smallDeposits"'>
-                
-                    <Veins name='fctrSilverBaseVeins' block='factorization:ResourceBlock'  inherits='PresetSmallDeposits' >
-                        <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608C9EBE</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * fctrSilverSize * _default_' range=':= 1 * 0.8 * fctrSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * fctrSilverSize * _default_' range=':= 1 * 0.8 * fctrSilverSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * fctrSilverFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Silver Deposit Veins) Settings -->
-                    <Veins name='fctrSilverPrefersVeins' block='factorization:ResourceBlock'  inherits='fctrSilverBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608C9EBE</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Silver Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Silver -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Silver -->
-                <IfCondition condition=':= fctrSilverDist = "strategicCloud"'>
-                
-                    <Cloud name='fctrSilverBaseCloud' block='factorization:ResourceBlock' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608C9EBE</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * fctrSilverSize * _default_' range=':= 1 * 0.8 * fctrSilverSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * fctrSilverSize * _default_' range=':= 1 * 0.8 * fctrSilverSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * fctrSilverSize * _default_' range=':= 1 * 0.8 * 0.8 * fctrSilverSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * fctrSilverFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Silver Strategic Cloud Hint Veins -->
-                        <Veins name='fctrSilverBaseHintVeins' block='factorization:ResourceBlock' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x608C9EBE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Silver Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Silver -->
-                
-                
-                <!-- Begin  Vanilla distribution of Silver -->
-                <IfCondition condition=':= fctrSilverDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='fctrSilverBaseStandard' block='factorization:ResourceBlock' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608C9EBE</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * fctrSilverSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * fctrSilverFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Silver -->
-                
-                <!-- End Silver Generation --> 
-
-                
-                <!-- Begin Dark Iron Generation --> 
-                
-                <!-- Begin Sparse Veins distribution of Dark Iron -->
-                <IfCondition condition=':= fctrDarkIronDist = "sparseVeins"'>
-                
-                    <Veins name='fctrDarkIronBaseVeins' block='factorization:DarkIronOre'  inherits='PresetSparseVeins' >
+            <!-- Dark Iron Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='fctrDarkIronDist'  displayState='shown' displayGroup='groupFactorization'>
+                    <Description> Controls how Dark Iron is generated </Description>
+                    <DisplayName>Factorization Dark Iron</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60781CCB</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * fctrDarkIronSize * _default_' range=':= 1 * 1 * fctrDarkIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= 3' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * fctrDarkIronSize * _default_' range=':= 1 * 1 * fctrDarkIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * fctrDarkIronFreq * _default_'/>
-                        <PlacesBeside block='minecraft:bedrock'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:dirt'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Sparse Veins distribution of Dark Iron -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Dark Iron -->
-                <IfCondition condition=':= fctrDarkIronDist = "smallDeposits"'>
-                
-                    <Veins name='fctrDarkIronBaseVeins' block='factorization:DarkIronOre'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60781CCB</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * fctrDarkIronSize * _default_' range=':= 1 * 1 * fctrDarkIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= 3' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * fctrDarkIronSize * _default_' range=':= 1 * 1 * fctrDarkIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * fctrDarkIronFreq * _default_'/>
-                        <PlacesBeside block='minecraft:bedrock'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:dirt'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Dark Iron -->
-                
-                
-                <!-- Begin  Vanilla distribution of Dark Iron -->
-                <IfCondition condition=':= fctrDarkIronDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='fctrDarkIronBaseStandard' block='factorization:DarkIronOre' inherits='PresetStandardGen'>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            This mimics vanilla ore generation.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60781CCB</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * fctrDarkIronSize * _default_'/>
-                        <Setting name='Height' avg=':= 3' range=':= 3' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * fctrDarkIronFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:dirt'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Dark Iron -->
-                
-                <!-- End Dark Iron Generation --> 
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Dark Iron is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='fctrDarkIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFactorization'>
+                    <Description> Frequency multiplier for Factorization Dark Iron distributions </Description>
+                    <DisplayName>Factorization Dark Iron Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='fctrDarkIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFactorization'>
+                    <Description> Size multiplier for Factorization Dark Iron distributions </Description>
+                    <DisplayName>Factorization Dark Iron Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Dark Iron Configuration UI Complete -->
 
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='fctrOverworldBlockSubstitute2' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='factorization:DarkIronOre' weight='1.0' />
+                <Replaces block='factorization:ResourceBlock' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Silver Generation -->
+
+            <!-- Starting LayeredVeins Preset for Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= fctrSilverDist = "LayeredVeins"'>
+                    <Veins name='fctrSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='factorization:ResourceBlock' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.543 * _default_ * fctrSilverFreq ' range=':=  _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.816 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 25 ' range=':=  10 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.816 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.816 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Silver is complete. -->
+
+
+            <!-- Starting Cloud Preset for Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= fctrSilverDist = "Cloud"'>
+                    <Cloud name='fctrSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='factorization:ResourceBlock' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.041 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.041 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.084  * _default_ * fctrSilverFreq ' range=':=  _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 25 ' range=':=  10 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='fctrSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='factorization:ResourceBlock' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Silver is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= fctrSilverDist = "Vanilla"'>
+                    <StandardGen name='fctrSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='factorization:ResourceBlock' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 7 * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * fctrSilverFreq ' range=':=  _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 25 ' range=':=  10 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Silver is complete. -->
+
+            <!-- End Silver Generation -->
+
+
+            <!-- Begin Dark Iron Generation -->
+
+            <!-- Starting SparseVeins Preset for Dark Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= fctrDarkIronDist = "SparseVeins"'>
+                    <Veins name='fctrDarkIronVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='factorization:DarkIronOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.350 * _default_ * fctrDarkIronFreq ' range=':=  _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.705 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 3 ' range=':=  2 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.705 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.705 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Dark Iron is complete. -->
+
+
+            <!-- Starting Cloud Preset for Dark Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= fctrDarkIronDist = "Cloud"'>
+                    <Cloud name='fctrDarkIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='factorization:DarkIronOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * fctrDarkIronFreq ' range=':=  _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 3 ' range=':=  2 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='fctrDarkIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='factorization:DarkIronOre' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Dark Iron is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Dark Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= fctrDarkIronDist = "Vanilla"'>
+                    <StandardGen name='fctrDarkIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='factorization:DarkIronOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 1 * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * fctrDarkIronFreq ' range=':=  _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 3 ' range=':=  2 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Dark Iron is complete. -->
+
+            <!-- End Dark Iron Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Factorization" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -25,10 +25,15 @@
                     Distribution options for Forestry Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableForestry' displayName='Handle Forestry Setup?' default='true' displayState='shown_dynamic' displayGroup='groupForestry'>
+                <Description> Should Custom Ore Generation handle Forestry ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Forestry ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Forestry ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Apatite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='frstApatiteDist'  displayState='shown' displayGroup='groupForestry'>
+                <OptionChoice name='frstApatiteDist'  displayState=':= if(?enableForestry, "shown", "hidden")' displayGroup='groupForestry'>
                     <Description> Controls how Apatite is generated </Description>
                     <DisplayName>Forestry Apatite</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -48,11 +53,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Apatite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='frstApatiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
+                <OptionNumeric name='frstApatiteFreq' default='1'  min='0' max='5' displayState=':= if(?enableForestry, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupForestry'>
                     <Description> Frequency multiplier for Forestry Apatite distributions </Description>
                     <DisplayName>Forestry Apatite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='frstApatiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
+                <OptionNumeric name='frstApatiteSize' default='1'  min='0' max='5' displayState=':= if(?enableForestry, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupForestry'>
                     <Description> Size multiplier for Forestry Apatite distributions </Description>
                     <DisplayName>Forestry Apatite Size</DisplayName>
                 </OptionNumeric>
@@ -62,7 +67,7 @@
 
             <!-- Copper Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='frstCopperDist'  displayState='shown' displayGroup='groupForestry'>
+                <OptionChoice name='frstCopperDist'  displayState=':= if(?enableForestry, "shown", "hidden")' displayGroup='groupForestry'>
                     <Description> Controls how Copper is generated </Description>
                     <DisplayName>Forestry Copper</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -82,11 +87,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='frstCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
+                <OptionNumeric name='frstCopperFreq' default='1'  min='0' max='5' displayState=':= if(?enableForestry, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupForestry'>
                     <Description> Frequency multiplier for Forestry Copper distributions </Description>
                     <DisplayName>Forestry Copper Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='frstCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
+                <OptionNumeric name='frstCopperSize' default='1'  min='0' max='5' displayState=':= if(?enableForestry, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupForestry'>
                     <Description> Size multiplier for Forestry Copper distributions </Description>
                     <DisplayName>Forestry Copper Size</DisplayName>
                 </OptionNumeric>
@@ -96,7 +101,7 @@
 
             <!-- Tin Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='frstTinDist'  displayState='shown' displayGroup='groupForestry'>
+                <OptionChoice name='frstTinDist'  displayState=':= if(?enableForestry, "shown", "hidden")' displayGroup='groupForestry'>
                     <Description> Controls how Tin is generated </Description>
                     <DisplayName>Forestry Tin</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -116,11 +121,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='frstTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
+                <OptionNumeric name='frstTinFreq' default='1'  min='0' max='5' displayState=':= if(?enableForestry, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupForestry'>
                     <Description> Frequency multiplier for Forestry Tin distributions </Description>
                     <DisplayName>Forestry Tin Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='frstTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
+                <OptionNumeric name='frstTinSize' default='1'  min='0' max='5' displayState=':= if(?enableForestry, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupForestry'>
                     <Description> Size multiplier for Forestry Tin distributions </Description>
                     <DisplayName>Forestry Tin Size</DisplayName>
                 </OptionNumeric>
@@ -130,396 +135,408 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableForestry'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='frstOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='Forestry:resources' weight='1.0' />
-                <Replaces block='Forestry:resources:1' weight='1.0' />
-                <Replaces block='Forestry:resources:2' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Apatite Generation -->
-
-            <!-- Starting SparseVeins Preset for Apatite. -->
-            <ConfigSection>
-                <IfCondition condition=':= frstApatiteDist = "SparseVeins"'>
-                    <Veins name='frstApatiteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='frstOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='Forestry:resources' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.100 * _default_ * frstApatiteFreq ' range=':=  _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.281 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 120 ' range=':=  64 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.281 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.281 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("Forestry:resources")'> <Replaces block='Forestry:resources' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <Replaces block='Forestry:resources:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <Replaces block='Forestry:resources:2' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Apatite is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Apatite. -->
-            <ConfigSection>
-                <IfCondition condition=':= frstApatiteDist = "Cloud"'>
-                    <Cloud name='frstApatiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Forestry:resources' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.191 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.191 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * frstApatiteFreq ' range=':=  _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 120 ' range=':=  64 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='frstApatiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Apatite Generation -->
+
+                <!-- Starting SparseVeins Preset for Apatite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= frstApatiteDist = "SparseVeins"'>
+                        <Veins name='frstApatiteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='Forestry:resources' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.100 * _default_ * frstApatiteFreq ' range=':=  _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.281 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 120 ' range=':=  64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.281 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.281 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Apatite is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Apatite is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Apatite. -->
-            <ConfigSection>
-                <IfCondition condition=':= frstApatiteDist = "Vanilla"'>
-                    <StandardGen name='frstApatiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Forestry:resources' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 36 * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * frstApatiteFreq ' range=':=  _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 120 ' range=':=  64 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Apatite is complete. -->
-
-            <!-- End Apatite Generation -->
-
-
-            <!-- Begin Copper Generation -->
-
-            <!-- Starting LayeredVeins Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= frstCopperDist = "LayeredVeins"'>
-                    <Veins name='frstCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Forestry:resources:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.297 * _default_ * frstCopperFreq ' range=':=  _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.091 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 106 ' range=':=  74 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.091 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Copper is complete. -->
-
-
-            <!-- Starting Cloud Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= frstCopperDist = "Cloud"'>
-                    <Cloud name='frstCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Forestry:resources:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.610 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.610 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.591  * _default_ * frstCopperFreq ' range=':=  _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 106 ' range=':=  74 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='frstCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
+                <!-- Starting Cloud Preset for Apatite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= frstApatiteDist = "Cloud"'>
+                        <Cloud name='frstApatiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Forestry:resources:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Copper is complete. -->
+                            <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.191 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.191 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * frstApatiteFreq ' range=':=  _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 120 ' range=':=  64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='frstApatiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Apatite is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= frstCopperDist = "Vanilla"'>
-                    <StandardGen name='frstCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Forestry:resources:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 20 * frstCopperFreq ' range=':=  _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 106 ' range=':=  74 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Copper is complete. -->
-
-            <!-- End Copper Generation -->
-
-
-            <!-- Begin Tin Generation -->
-
-            <!-- Starting LayeredVeins Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= frstTinDist = "LayeredVeins"'>
-                    <Veins name='frstTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Forestry:resources:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.231 * _default_ * frstTinFreq ' range=':=  _default_ * frstTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.072 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 98 ' range=':=  82 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.072 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.072 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Tin is complete. -->
-
-
-            <!-- Starting Cloud Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= frstTinDist = "Cloud"'>
-                    <Cloud name='frstTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Forestry:resources:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.568 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.568 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.458  * _default_ * frstTinFreq ' range=':=  _default_ * frstTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 98 ' range=':=  82 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='frstTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
+                <!-- Starting Vanilla Preset for Apatite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= frstApatiteDist = "Vanilla"'>
+                        <StandardGen name='frstApatiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Forestry:resources:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 36 * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * frstApatiteFreq ' range=':=  _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 120 ' range=':=  64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Apatite is complete. -->
+
+                <!-- End Apatite Generation -->
+
+
+                <!-- Begin Copper Generation -->
+
+                <!-- Starting LayeredVeins Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= frstCopperDist = "LayeredVeins"'>
+                        <Veins name='frstCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.297 * _default_ * frstCopperFreq ' range=':=  _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.091 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 106 ' range=':=  74 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.091 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Tin is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= frstTinDist = "Vanilla"'>
-                    <StandardGen name='frstTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Forestry:resources:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 18 * frstTinFreq ' range=':=  _default_ * frstTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 98 ' range=':=  82 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Tin is complete. -->
+                <!-- Starting Cloud Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= frstCopperDist = "Cloud"'>
+                        <Cloud name='frstCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.610 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.610 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.591  * _default_ * frstCopperFreq ' range=':=  _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 106 ' range=':=  74 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='frstCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Copper is complete. -->
 
-            <!-- End Tin Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= frstCopperDist = "Vanilla"'>
+                        <StandardGen name='frstCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 20 * frstCopperFreq ' range=':=  _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 106 ' range=':=  74 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Copper is complete. -->
+
+                <!-- End Copper Generation -->
+
+
+                <!-- Begin Tin Generation -->
+
+                <!-- Starting LayeredVeins Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= frstTinDist = "LayeredVeins"'>
+                        <Veins name='frstTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.231 * _default_ * frstTinFreq ' range=':=  _default_ * frstTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.072 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 98 ' range=':=  82 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.072 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.072 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Tin is complete. -->
+
+
+                <!-- Starting Cloud Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= frstTinDist = "Cloud"'>
+                        <Cloud name='frstTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.568 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.568 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.458  * _default_ * frstTinFreq ' range=':=  _default_ * frstTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 98 ' range=':=  82 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='frstTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tin is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= frstTinDist = "Vanilla"'>
+                        <StandardGen name='frstTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 18 * frstTinFreq ' range=':=  _default_ * frstTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 98 ' range=':=  82 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tin is complete. -->
+
+                <!-- End Tin Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -1,547 +1,540 @@
- <!-- ================================================================
-      Custom Ore Generation "Forestry" Module: This configuration
-      covers apatite, copper, and tin.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Forestry" Module: This configuration
+     covers apatite, copper, and tin.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="Forestry">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "Forestry" mod on the system?  Let's find out! -->
+<IfModInstalled name="Forestry">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupForestry' displayName='Forestry' displayState='shown'>
+                <Description>
+                    Distribution options for Forestry Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Apatite Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupForestry' displayName='Forestry' displayState='shown'> 
-                    <Description>
-                        Distribution options for Forestry Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Apatite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='frstApatiteDist'  displayState='shown' displayGroup='groupForestry'> 
-                        <Description> Controls how Apatite is generated </Description> 
-                        <DisplayName>Forestry Apatite</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Apatite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='frstApatiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
-                        <Description> Frequency multiplier for Forestry Apatite distributions </Description>
-                        <DisplayName>Forestry Apatite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='frstApatiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
-                        <Description> Size multiplier for Forestry Apatite distributions </Description>
-                        <DisplayName>Forestry Apatite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Apatite Configuration UI Complete -->
-                
-                
-                <!-- Copper Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='frstCopperDist'  displayState='shown' displayGroup='groupForestry'> 
-                        <Description> Controls how Copper is generated </Description> 
-                        <DisplayName>Forestry Copper</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='frstCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
-                        <Description> Frequency multiplier for Forestry Copper distributions </Description>
-                        <DisplayName>Forestry Copper Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='frstCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
-                        <Description> Size multiplier for Forestry Copper distributions </Description>
-                        <DisplayName>Forestry Copper Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Copper Configuration UI Complete -->
-                
-                
-                <!-- Tin Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='frstTinDist'  displayState='shown' displayGroup='groupForestry'> 
-                        <Description> Controls how Tin is generated </Description> 
-                        <DisplayName>Forestry Tin</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='frstTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
-                        <Description> Frequency multiplier for Forestry Tin distributions </Description>
-                        <DisplayName>Forestry Tin Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='frstTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
-                        <Description> Size multiplier for Forestry Tin distributions </Description>
-                        <DisplayName>Forestry Tin Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Tin Configuration UI Complete -->
-                
-            </ConfigSection>
-            <!-- Setup Screen Complete -->
-
-
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='frstOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='Forestry:resources' />
-                    <Replaces block='Forestry:resources:1' />
-                    <Replaces block='Forestry:resources:2' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Apatite Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Apatite -->
-                <IfCondition condition=':= frstApatiteDist = "sparseVeins"'>
-                
-                    <Veins name='frstApatiteBaseVeins' block='Forestry:resources'  inherits='PresetSparseVeins' >
+                <OptionChoice name='frstApatiteDist'  displayState='shown' displayGroup='groupForestry'>
+                    <Description> Controls how Apatite is generated </Description>
+                    <DisplayName>Forestry Apatite</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6052BBEF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * frstApatiteSize * _default_' range=':= 1 * 1 * frstApatiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 4' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * frstApatiteSize * _default_' range=':= 1 * 1 * frstApatiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * frstApatiteFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 1.2 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchInclination' avg=':= -_default_' range=':= 0'/>
-                        <BiomeType name='Forest'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Apatite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Apatite -->
-                <IfCondition condition=':= frstApatiteDist = "hugeVeins"'>
-                
-                    <Veins name='frstApatiteBaseVeins' block='Forestry:resources'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6052BBEF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * frstApatiteSize * _default_' range=':= 1 * 1 * frstApatiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 4' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * frstApatiteSize * _default_' range=':= 1 * 1 * frstApatiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * frstApatiteFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 1.2 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchInclination' avg=':= -_default_' range=':= 0'/>
-                        <BiomeType name='Forest'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Apatite -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Apatite -->
-                <IfCondition condition=':= frstApatiteDist = "strategicCloud"'>
-                
-                    <Cloud name='frstApatiteBaseCloud' block='Forestry:resources' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6052BBEF</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.7 * frstApatiteSize * _default_' range=':= 1 * 0.7 * frstApatiteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.7 * frstApatiteSize * _default_' range=':= 1 * 0.7 * frstApatiteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.8 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.7 * 0.7 * frstApatiteSize * _default_' range=':= 1 * 0.7 * 0.7 * frstApatiteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4 * frstApatiteFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Forest'/>
-                        
-                        <!-- Begin Apatite Strategic Cloud Hint Veins -->
-                        <Veins name='frstApatiteBaseHintVeins' block='Forestry:resources' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6052BBEF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                        </Veins>
-                        <!-- End Apatite Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Apatite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='frstApatiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
+                    <Description> Frequency multiplier for Forestry Apatite distributions </Description>
+                    <DisplayName>Forestry Apatite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='frstApatiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
+                    <Description> Size multiplier for Forestry Apatite distributions </Description>
+                    <DisplayName>Forestry Apatite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Apatite Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Apatite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Apatite -->
-                <IfCondition condition=':= frstApatiteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='frstApatiteBaseStandard' block='Forestry:resources' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6052BBEF</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * frstApatiteSize * _default_'/>
-                        <Setting name='Height' avg=':= 54' range=':= 38' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.3 * frstApatiteFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Forest'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Apatite -->
-                
-                <!-- End Apatite Generation --> 
 
-                
-                <!-- Begin Copper Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Copper -->
-                <IfCondition condition=':= frstCopperDist = "layeredVeins"'>
-                
-                    <Veins name='frstCopperBaseVeins' block='Forestry:resources:1'  inherits='PresetLayeredVeins' >
+            <!-- Copper Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='frstCopperDist'  displayState='shown' displayGroup='groupForestry'>
+                    <Description> Controls how Copper is generated </Description>
+                    <DisplayName>Forestry Copper</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3B78E</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * frstCopperSize * _default_' range=':= 1 * 1 * frstCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 40' range=':= 12' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * frstCopperSize * _default_' range=':= 1 * 1 * frstCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.75 * frstCopperFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.7 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='frstCopperPrefersVeins' block='Forestry:resources:1'  inherits='frstCopperBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3B78E</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Copper -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Copper -->
-                <IfCondition condition=':= frstCopperDist = "strategicCloud"'>
-                
-                    <Cloud name='frstCopperBaseCloud' block='Forestry:resources:1' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3B78E</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.85 * frstCopperSize * _default_' range=':= 1 * 0.85 * frstCopperSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.85 * frstCopperSize * _default_' range=':= 1 * 0.85 * frstCopperSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.9 * 0.85 * frstCopperSize * _default_' range=':= 1 * 0.9 * 0.85 * frstCopperSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * frstCopperFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Copper Strategic Cloud Hint Veins -->
-                        <Veins name='frstCopperBaseHintVeins' block='Forestry:resources:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E3B78E</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Copper Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='frstCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
+                    <Description> Frequency multiplier for Forestry Copper distributions </Description>
+                    <DisplayName>Forestry Copper Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='frstCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
+                    <Description> Size multiplier for Forestry Copper distributions </Description>
+                    <DisplayName>Forestry Copper Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Copper Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Copper -->
-                
-                
-                <!-- Begin  Vanilla distribution of Copper -->
-                <IfCondition condition=':= frstCopperDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='frstCopperBaseStandard' block='Forestry:resources:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3B78E</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 0.75 * frstCopperSize * _default_'/>
-                        <Setting name='Height' avg=':= 38' range=':= 38' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * frstCopperFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Copper -->
-                
-                <!-- End Copper Generation --> 
 
-                
-                <!-- Begin Tin Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Tin -->
-                <IfCondition condition=':= frstTinDist = "layeredVeins"'>
-                
-                    <Veins name='frstTinBaseVeins' block='Forestry:resources:2'  inherits='PresetLayeredVeins' >
+            <!-- Tin Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='frstTinDist'  displayState='shown' displayGroup='groupForestry'>
+                    <Description> Controls how Tin is generated </Description>
+                    <DisplayName>Forestry Tin</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D1EDF1</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * frstTinSize * _default_' range=':= 1 * 1 * frstTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * frstTinSize * _default_' range=':= 1 * 1 * frstTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.70 * frstTinFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.7 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='frstTinPrefersVeins' block='Forestry:resources:2'  inherits='frstTinBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D1EDF1</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Tin -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Tin -->
-                <IfCondition condition=':= frstTinDist = "strategicCloud"'>
-                
-                    <Cloud name='frstTinBaseCloud' block='Forestry:resources:2' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D1EDF1</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.85 * frstTinSize * _default_' range=':= 1 * 0.85 * frstTinSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.85 * frstTinSize * _default_' range=':= 1 * 0.85 * frstTinSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.9 * 0.85 * frstTinSize * _default_' range=':= 1 * 0.9 * 0.85 * frstTinSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * frstTinFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Tin Strategic Cloud Hint Veins -->
-                        <Veins name='frstTinBaseHintVeins' block='Forestry:resources:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60D1EDF1</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Tin Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='frstTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
+                    <Description> Frequency multiplier for Forestry Tin distributions </Description>
+                    <DisplayName>Forestry Tin Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='frstTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupForestry'>
+                    <Description> Size multiplier for Forestry Tin distributions </Description>
+                    <DisplayName>Forestry Tin Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Tin Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Tin -->
-                
-                
-                <!-- Begin  Vanilla distribution of Tin -->
-                <IfCondition condition=':= frstTinDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='frstTinBaseStandard' block='Forestry:resources:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D1EDF1</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 0.75 * frstTinSize * _default_'/>
-                        <Setting name='Height' avg=':= 38' range=':= 38' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.9 * frstTinFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Tin -->
-                
-                <!-- End Tin Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='frstOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='Forestry:resources' weight='1.0' />
+                <Replaces block='Forestry:resources:1' weight='1.0' />
+                <Replaces block='Forestry:resources:2' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Apatite Generation -->
+
+            <!-- Starting SparseVeins Preset for Apatite. -->
+            <ConfigSection>
+                <IfCondition condition=':= frstApatiteDist = "SparseVeins"'>
+                    <Veins name='frstApatiteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Forestry:resources' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.100 * _default_ * frstApatiteFreq ' range=':=  _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.281 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 120 ' range=':=  64 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.281 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.281 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Apatite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Apatite. -->
+            <ConfigSection>
+                <IfCondition condition=':= frstApatiteDist = "Cloud"'>
+                    <Cloud name='frstApatiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Forestry:resources' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.191 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.191 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * frstApatiteFreq ' range=':=  _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 120 ' range=':=  64 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='frstApatiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Forestry:resources' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Apatite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Apatite. -->
+            <ConfigSection>
+                <IfCondition condition=':= frstApatiteDist = "Vanilla"'>
+                    <StandardGen name='frstApatiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Forestry:resources' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 36 * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * frstApatiteFreq ' range=':=  _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 120 ' range=':=  64 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Apatite is complete. -->
+
+            <!-- End Apatite Generation -->
+
+
+            <!-- Begin Copper Generation -->
+
+            <!-- Starting LayeredVeins Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= frstCopperDist = "LayeredVeins"'>
+                    <Veins name='frstCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Forestry:resources:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.297 * _default_ * frstCopperFreq ' range=':=  _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.091 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 106 ' range=':=  74 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.091 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Copper is complete. -->
+
+
+            <!-- Starting Cloud Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= frstCopperDist = "Cloud"'>
+                    <Cloud name='frstCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Forestry:resources:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.610 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.610 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.591  * _default_ * frstCopperFreq ' range=':=  _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 106 ' range=':=  74 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='frstCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Forestry:resources:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Copper is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= frstCopperDist = "Vanilla"'>
+                    <StandardGen name='frstCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Forestry:resources:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 20 * frstCopperFreq ' range=':=  _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 106 ' range=':=  74 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Copper is complete. -->
+
+            <!-- End Copper Generation -->
+
+
+            <!-- Begin Tin Generation -->
+
+            <!-- Starting LayeredVeins Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= frstTinDist = "LayeredVeins"'>
+                    <Veins name='frstTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Forestry:resources:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.231 * _default_ * frstTinFreq ' range=':=  _default_ * frstTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.072 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 98 ' range=':=  82 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.072 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.072 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Tin is complete. -->
+
+
+            <!-- Starting Cloud Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= frstTinDist = "Cloud"'>
+                    <Cloud name='frstTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Forestry:resources:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.568 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.568 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.458  * _default_ * frstTinFreq ' range=':=  _default_ * frstTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 98 ' range=':=  82 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='frstTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Forestry:resources:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Tin is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= frstTinDist = "Vanilla"'>
+                    <StandardGen name='frstTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Forestry:resources:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 18 * frstTinFreq ' range=':=  _default_ * frstTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 98 ' range=':=  82 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Tin is complete. -->
+
+            <!-- End Tin Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Forestry" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -26,10 +26,15 @@
                     Distribution options for Fossils and Archaeology Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableFossilsandArchaeology' displayName='Handle Fossils and Archaeology Setup?' default='true' displayState='shown_dynamic' displayGroup='groupFossilsandArchaeology'>
+                <Description> Should Custom Ore Generation handle Fossils and Archaeology ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Fossils and Archaeology ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Fossils and Archaeology ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Fossils Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='fsarFossilsDist'  displayState='shown' displayGroup='groupFossilsandArchaeology'>
+                <OptionChoice name='fsarFossilsDist'  displayState=':= if(?enableFossilsandArchaeology, "shown", "hidden")' displayGroup='groupFossilsandArchaeology'>
                     <Description> Controls how Fossils is generated </Description>
                     <DisplayName>Fossils and Archaeology Fossils</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -49,11 +54,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Fossils is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='fsarFossilsFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFossilsandArchaeology'>
+                <OptionNumeric name='fsarFossilsFreq' default='1'  min='0' max='5' displayState=':= if(?enableFossilsandArchaeology, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupFossilsandArchaeology'>
                     <Description> Frequency multiplier for Fossils and Archaeology Fossils distributions </Description>
                     <DisplayName>Fossils and Archaeology Fossils Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='fsarFossilsSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFossilsandArchaeology'>
+                <OptionNumeric name='fsarFossilsSize' default='1'  min='0' max='5' displayState=':= if(?enableFossilsandArchaeology, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupFossilsandArchaeology'>
                     <Description> Size multiplier for Fossils and Archaeology Fossils distributions </Description>
                     <DisplayName>Fossils and Archaeology Fossils Size</DisplayName>
                 </OptionNumeric>
@@ -63,7 +68,7 @@
 
             <!-- Permafrost Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='fsarPermafrostDist'  displayState='shown' displayGroup='groupFossilsandArchaeology'>
+                <OptionChoice name='fsarPermafrostDist'  displayState=':= if(?enableFossilsandArchaeology, "shown", "hidden")' displayGroup='groupFossilsandArchaeology'>
                     <Description> Controls how Permafrost is generated </Description>
                     <DisplayName>Fossils and Archaeology Permafrost</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -83,11 +88,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Permafrost is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='fsarPermafrostFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFossilsandArchaeology'>
+                <OptionNumeric name='fsarPermafrostFreq' default='1'  min='0' max='5' displayState=':= if(?enableFossilsandArchaeology, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupFossilsandArchaeology'>
                     <Description> Frequency multiplier for Fossils and Archaeology Permafrost distributions </Description>
                     <DisplayName>Fossils and Archaeology Permafrost Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='fsarPermafrostSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFossilsandArchaeology'>
+                <OptionNumeric name='fsarPermafrostSize' default='1'  min='0' max='5' displayState=':= if(?enableFossilsandArchaeology, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupFossilsandArchaeology'>
                     <Description> Size multiplier for Fossils and Archaeology Permafrost distributions </Description>
                     <DisplayName>Fossils and Archaeology Permafrost Size</DisplayName>
                 </OptionNumeric>
@@ -97,349 +102,360 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableFossilsandArchaeology'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='fsarOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='fossil:fossil' weight='1.0' />
-                <Replaces block='fossil:permafrost' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Fossils Generation -->
-
-            <!-- Starting SparseVeins Preset for Fossils. -->
-            <ConfigSection>
-                <IfCondition condition=':= fsarFossilsDist = "SparseVeins"'>
-                    <Veins name='fsarFossilsVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='fsarOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='fossil:fossil' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 6.104 * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.828 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Veins name='fsarFossilsPreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='fossil:fossil' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Swamp'  />
-                        <BiomeType name='desert'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 6.104 * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.828 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <!-- "Preferred" configuration complete. -->
-
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("fossil:fossil")'> <Replaces block='fossil:fossil' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <Replaces block='fossil:permafrost' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Fossils is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Fossils. -->
-            <ConfigSection>
-                <IfCondition condition=':= fsarFossilsDist = "Cloud"'>
-                    <Cloud name='fsarFossilsCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='fossil:fossil' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 4.123  * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='fsarFossilsHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Fossils Generation -->
+
+                <!-- Starting SparseVeins Preset for Fossils. -->
+                <ConfigSection>
+                    <IfCondition condition=':= fsarFossilsDist = "SparseVeins"'>
+                        <Veins name='fsarFossilsVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='fossil:fossil' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 6.104 * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.828 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
 
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Cloud name='fsarFossilsPreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='fossil:fossil' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Swamp'  />
-                        <BiomeType name='desert'  />
-                        <Setting name='CloudRadius' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 4.123  * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='fsarFossilsPreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Veins name='fsarFossilsPreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
                             <Description>
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <OreBlock block='fossil:fossil' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Swamp'  />
+                            <BiomeType name='desert'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 6.104 * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.828 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                    <!-- "Preferred" configuration complete. -->
+                        <!-- "Preferred" configuration complete. -->
 
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Fossils is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Fossils. -->
-            <ConfigSection>
-                <IfCondition condition=':= fsarFossilsDist = "Vanilla"'>
-                    <StandardGen name='fsarFossilsStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='fossil:fossil' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 38 * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Fossils is complete. -->
-
-            <!-- End Fossils Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Fossils is complete. -->
 
 
-            <!-- Begin Permafrost Generation -->
-
-            <!-- Starting SparseVeins Preset for Permafrost. -->
-            <ConfigSection>
-                <IfCondition condition=':= fsarPermafrostDist = "SparseVeins"'>
-                    <Veins name='fsarPermafrostVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='fossil:permafrost' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <BiomeType name='Frozen'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.980 * _default_ * fsarPermafrostFreq ' range=':=  _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.256 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 18 ' range=':=  12.5 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.256 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.256 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Permafrost is complete. -->
-
-
-            <!-- Starting Cloud Preset for Permafrost. -->
-            <ConfigSection>
-                <IfCondition condition=':= fsarPermafrostDist = "Cloud"'>
-                    <Cloud name='fsarPermafrostCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='fossil:permafrost' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <BiomeType name='Frozen'  />
-                        <Setting name='CloudRadius' avg=':= 1.157 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.157 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * fsarPermafrostFreq ' range=':=  _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 18 ' range=':=  12.5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='fsarPermafrostHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
+                <!-- Starting Cloud Preset for Fossils. -->
+                <ConfigSection>
+                    <IfCondition condition=':= fsarFossilsDist = "Cloud"'>
+                        <Cloud name='fsarFossilsCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='fossil:permafrost' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 4.123  * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='fsarFossilsHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='fsarFossilsPreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Swamp'  />
+                            <BiomeType name='desert'  />
+                            <Setting name='CloudRadius' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 4.123  * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='fsarFossilsPreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Fossils is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Fossils. -->
+                <ConfigSection>
+                    <IfCondition condition=':= fsarFossilsDist = "Vanilla"'>
+                        <StandardGen name='fsarFossilsStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 38 * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Fossils is complete. -->
+
+                <!-- End Fossils Generation -->
+
+
+                <!-- Begin Permafrost Generation -->
+
+                <!-- Starting SparseVeins Preset for Permafrost. -->
+                <ConfigSection>
+                    <IfCondition condition=':= fsarPermafrostDist = "SparseVeins"'>
+                        <Veins name='fsarPermafrostVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <OreBlock block='fossil:permafrost' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <BiomeType name='Frozen'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.980 * _default_ * fsarPermafrostFreq ' range=':=  _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.256 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 18 ' range=':=  12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.256 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.256 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Permafrost is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Permafrost is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Permafrost. -->
-            <ConfigSection>
-                <IfCondition condition=':= fsarPermafrostDist = "Vanilla"'>
-                    <StandardGen name='fsarPermafrostStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='fossil:permafrost' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <BiomeType name='Frozen'  />
-                        <Setting name='Size' avg=':= 4 * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 8 * fsarPermafrostFreq ' range=':=  _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 18 ' range=':=  12.5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Permafrost is complete. -->
+                <!-- Starting Cloud Preset for Permafrost. -->
+                <ConfigSection>
+                    <IfCondition condition=':= fsarPermafrostDist = "Cloud"'>
+                        <Cloud name='fsarPermafrostCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <OreBlock block='fossil:permafrost' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <BiomeType name='Frozen'  />
+                            <Setting name='CloudRadius' avg=':= 1.157 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.157 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * fsarPermafrostFreq ' range=':=  _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 18 ' range=':=  12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='fsarPermafrostHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <OreBlock block='fossil:permafrost' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Permafrost is complete. -->
 
-            <!-- End Permafrost Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Permafrost. -->
+                <ConfigSection>
+                    <IfCondition condition=':= fsarPermafrostDist = "Vanilla"'>
+                        <StandardGen name='fsarPermafrostStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <OreBlock block='fossil:permafrost' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <BiomeType name='Frozen'  />
+                            <Setting name='Size' avg=':= 4 * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * fsarPermafrostFreq ' range=':=  _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 18 ' range=':=  12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Permafrost is complete. -->
+
+                <!-- End Permafrost Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -1,432 +1,460 @@
- <!-- ================================================================
-      Custom Ore Generation "Fossils and Archaeology" Module: This
-      configuration covers fossils and permafrost.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Fossils and Archaeology" Module: This
+     configuration covers fossils and permafrost.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="fossil">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "Fossils and Archaeology" mod on the system?  Let's find
+     out! -->
+<IfModInstalled name="fossil">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupFossilsandArchaeology' displayName='Fossils and Archaeology' displayState='shown'>
+                <Description>
+                    Distribution options for Fossils and Archaeology Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Fossils Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupFossilsandArchaeology' displayName='Fossils and Archaeology' displayState='shown'> 
-                    <Description>
-                        Distribution options for Fossils and Archaeology Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Fossils Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='fsarFossilsDist'  displayState='shown' displayGroup='groupFossilsandArchaeology'> 
-                        <Description> Controls how Fossils is generated </Description> 
-                        <DisplayName>Fossils and Archaeology Fossils</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Fossils is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='fsarFossilsFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFossilsandArchaeology'>
-                        <Description> Frequency multiplier for Fossils and Archaeology Fossils distributions </Description>
-                        <DisplayName>Fossils and Archaeology Fossils Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='fsarFossilsSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFossilsandArchaeology'>
-                        <Description> Size multiplier for Fossils and Archaeology Fossils distributions </Description>
-                        <DisplayName>Fossils and Archaeology Fossils Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Fossils Configuration UI Complete -->
-                
-                
-                <!-- Permafrost Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='fsarPermafrostDist'  displayState='shown' displayGroup='groupFossilsandArchaeology'> 
-                        <Description> Controls how Permafrost is generated </Description> 
-                        <DisplayName>Fossils and Archaeology Permafrost</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Permafrost is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='fsarPermafrostFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFossilsandArchaeology'>
-                        <Description> Frequency multiplier for Fossils and Archaeology Permafrost distributions </Description>
-                        <DisplayName>Fossils and Archaeology Permafrost Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='fsarPermafrostSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFossilsandArchaeology'>
-                        <Description> Size multiplier for Fossils and Archaeology Permafrost distributions </Description>
-                        <DisplayName>Fossils and Archaeology Permafrost Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Permafrost Configuration UI Complete -->
-                
+                <OptionChoice name='fsarFossilsDist'  displayState='shown' displayGroup='groupFossilsandArchaeology'>
+                    <Description> Controls how Fossils is generated </Description>
+                    <DisplayName>Fossils and Archaeology Fossils</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
+                        <Description>
+                            Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Fossils is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='fsarFossilsFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFossilsandArchaeology'>
+                    <Description> Frequency multiplier for Fossils and Archaeology Fossils distributions </Description>
+                    <DisplayName>Fossils and Archaeology Fossils Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='fsarFossilsSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFossilsandArchaeology'>
+                    <Description> Size multiplier for Fossils and Archaeology Fossils distributions </Description>
+                    <DisplayName>Fossils and Archaeology Fossils Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Fossils Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='fsarOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='fossil:fossil' />
-                    <Replaces block='fossil:permafrost' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Fossils Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Fossils -->
-                <IfCondition condition=':= fsarFossilsDist = "sparseVeins"'>
-                
-                    <Veins name='fsarFossilsBaseVeins' block='fossil:fossil'  inherits='PresetSparseVeins' >
+            <!-- Permafrost Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='fsarPermafrostDist'  displayState='shown' displayGroup='groupFossilsandArchaeology'>
+                    <Description> Controls how Permafrost is generated </Description>
+                    <DisplayName>Fossils and Archaeology Permafrost</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFDDF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * fsarFossilsSize * _default_' range=':= 1 * 1 * fsarFossilsSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * fsarFossilsSize * _default_' range=':= 1 * 1 * fsarFossilsSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 5.3 * fsarFossilsFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Fossils Sparse Veins) Settings -->
-                    <Veins name='fsarFossilsPrefersVeins' block='fossil:fossil'  inherits='fsarFossilsBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFDDF</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='desert'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Fossils Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Fossils -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Fossils -->
-                <IfCondition condition=':= fsarFossilsDist = "smallDeposits"'>
-                
-                    <Veins name='fsarFossilsBaseVeins' block='fossil:fossil'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFDDF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * fsarFossilsSize * _default_' range=':= 1 * 1 * fsarFossilsSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * fsarFossilsSize * _default_' range=':= 1 * 1 * fsarFossilsSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 5.3 * fsarFossilsFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Fossils Deposit Veins) Settings -->
-                    <Veins name='fsarFossilsPrefersVeins' block='fossil:fossil'  inherits='fsarFossilsBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFDDF</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='desert'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Fossils Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Fossils -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Fossils -->
-                <IfCondition condition=':= fsarFossilsDist = "strategicCloud"'>
-                
-                    <Cloud name='fsarFossilsBaseCloud' block='fossil:fossil' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFDDF</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1.2 * fsarFossilsSize * _default_' range=':= 1 * 1.2 * fsarFossilsSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.2 * fsarFossilsSize * _default_' range=':= 1 * 1.2 * fsarFossilsSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.75 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1.2 * fsarFossilsSize * _default_' range=':= 1 * 1 * 1.2 * fsarFossilsSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * fsarFossilsFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Fossils Strategic Cloud Hint Veins -->
-                        <Veins name='fsarFossilsBaseHintVeins' block='fossil:fossil' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FEFDDF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Fossils Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Permafrost is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='fsarPermafrostFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFossilsandArchaeology'>
+                    <Description> Frequency multiplier for Fossils and Archaeology Permafrost distributions </Description>
+                    <DisplayName>Fossils and Archaeology Permafrost Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='fsarPermafrostSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupFossilsandArchaeology'>
+                    <Description> Size multiplier for Fossils and Archaeology Permafrost distributions </Description>
+                    <DisplayName>Fossils and Archaeology Permafrost Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Permafrost Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Fossils -->
-                
-                
-                <!-- Begin  Vanilla distribution of Fossils -->
-                <IfCondition condition=':= fsarFossilsDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='fsarFossilsBaseStandard' block='fossil:fossil' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFDDF</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 2 * fsarFossilsSize * _default_'/>
-                        <Setting name='Height' avg=':= _default_' range=':= _default_' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * fsarFossilsFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Fossils -->
-                
-                <!-- End Fossils Generation --> 
-
-                
-                <!-- Begin Permafrost Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Permafrost -->
-                <IfCondition condition=':= fsarPermafrostDist = "sparseVeins"'>
-                
-                    <Veins name='fsarPermafrostBaseVeins' block='fossil:permafrost'  inherits='PresetSparseVeins' >
-                        <Description>
-                            Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A5C3F5</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * fsarPermafrostSize * _default_' range=':= 1 * 1 * fsarPermafrostSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * fsarPermafrostSize * _default_' range=':= 1 * 1 * fsarPermafrostSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 5.3 * fsarPermafrostFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Frozen'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Permafrost -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Permafrost -->
-                <IfCondition condition=':= fsarPermafrostDist = "smallDeposits"'>
-                
-                    <Veins name='fsarPermafrostBaseVeins' block='fossil:permafrost'  inherits='PresetSmallDeposits' >
-                        <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A5C3F5</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * fsarPermafrostSize * _default_' range=':= 1 * 1 * fsarPermafrostSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * fsarPermafrostSize * _default_' range=':= 1 * 1 * fsarPermafrostSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 5.3 * fsarPermafrostFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Frozen'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Permafrost -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Permafrost -->
-                <IfCondition condition=':= fsarPermafrostDist = "strategicCloud"'>
-                
-                    <Cloud name='fsarPermafrostBaseCloud' block='fossil:permafrost' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A5C3F5</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1.2 * fsarPermafrostSize * _default_' range=':= 1 * 1.2 * fsarPermafrostSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.2 * fsarPermafrostSize * _default_' range=':= 1 * 1.2 * fsarPermafrostSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.75 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1.2 * fsarPermafrostSize * _default_' range=':= 1 * 1 * 1.2 * fsarPermafrostSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * fsarPermafrostFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Frozen'/>
-                        
-                        <!-- Begin Permafrost Strategic Cloud Hint Veins -->
-                        <Veins name='fsarPermafrostBaseHintVeins' block='fossil:permafrost' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60A5C3F5</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Frozen'/>
-                        </Veins>
-                        <!-- End Permafrost Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Permafrost -->
-                
-                
-                <!-- Begin  Vanilla distribution of Permafrost -->
-                <IfCondition condition=':= fsarPermafrostDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='fsarPermafrostBaseStandard' block='fossil:permafrost' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A5C3F5</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 2 * fsarPermafrostSize * _default_'/>
-                        <Setting name='Height' avg=':= _default_' range=':= _default_' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * fsarPermafrostFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Frozen'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Permafrost -->
-                
-                <!-- End Permafrost Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='fsarOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='fossil:fossil' weight='1.0' />
+                <Replaces block='fossil:permafrost' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Fossils Generation -->
+
+            <!-- Starting SparseVeins Preset for Fossils. -->
+            <ConfigSection>
+                <IfCondition condition=':= fsarFossilsDist = "SparseVeins"'>
+                    <Veins name='fsarFossilsVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='fossil:fossil' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 6.104 * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.828 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Veins name='fsarFossilsPreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='fossil:fossil' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Swamp'  />
+                        <BiomeType name='desert'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 6.104 * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.828 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Fossils is complete. -->
+
+
+            <!-- Starting Cloud Preset for Fossils. -->
+            <ConfigSection>
+                <IfCondition condition=':= fsarFossilsDist = "Cloud"'>
+                    <Cloud name='fsarFossilsCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='fossil:fossil' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 4.123  * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='fsarFossilsHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='fossil:fossil' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Cloud name='fsarFossilsPreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='fossil:fossil' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Swamp'  />
+                        <BiomeType name='desert'  />
+                        <Setting name='CloudRadius' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 4.123  * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='fsarFossilsPreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='fossil:fossil' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Fossils is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Fossils. -->
+            <ConfigSection>
+                <IfCondition condition=':= fsarFossilsDist = "Vanilla"'>
+                    <StandardGen name='fsarFossilsStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='fossil:fossil' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 38 * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Fossils is complete. -->
+
+            <!-- End Fossils Generation -->
+
+
+            <!-- Begin Permafrost Generation -->
+
+            <!-- Starting SparseVeins Preset for Permafrost. -->
+            <ConfigSection>
+                <IfCondition condition=':= fsarPermafrostDist = "SparseVeins"'>
+                    <Veins name='fsarPermafrostVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='fossil:permafrost' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <BiomeType name='Frozen'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.980 * _default_ * fsarPermafrostFreq ' range=':=  _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.256 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 18 ' range=':=  12.5 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.256 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.256 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Permafrost is complete. -->
+
+
+            <!-- Starting Cloud Preset for Permafrost. -->
+            <ConfigSection>
+                <IfCondition condition=':= fsarPermafrostDist = "Cloud"'>
+                    <Cloud name='fsarPermafrostCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='fossil:permafrost' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <BiomeType name='Frozen'  />
+                        <Setting name='CloudRadius' avg=':= 1.157 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.157 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * fsarPermafrostFreq ' range=':=  _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 18 ' range=':=  12.5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='fsarPermafrostHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='fossil:permafrost' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Permafrost is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Permafrost. -->
+            <ConfigSection>
+                <IfCondition condition=':= fsarPermafrostDist = "Vanilla"'>
+                    <StandardGen name='fsarPermafrostStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='fossil:permafrost' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <BiomeType name='Frozen'  />
+                        <Setting name='Size' avg=':= 4 * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 8 * fsarPermafrostFreq ' range=':=  _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 18 ' range=':=  12.5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Permafrost is complete. -->
+
+            <!-- End Permafrost Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Fossils and Archaeology" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/GeoStrata.xml
+++ b/src/main/resources/config/modules/GeoStrata.xml
@@ -27,10 +27,15 @@
                     Distribution options for GeoStrata Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableGeoStrata' displayName='Handle GeoStrata Setup?' default='true' displayState='shown_dynamic' displayGroup='groupGeoStrata'>
+                <Description> Should Custom Ore Generation handle GeoStrata ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle GeoStrata ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='GeoStrata ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Shale Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaShaleDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaShaleDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Shale is generated </Description>
                     <DisplayName>GeoStrata Shale</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -50,11 +55,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Shale is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaShaleFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaShaleFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Shale distributions </Description>
                     <DisplayName>GeoStrata Shale Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaShaleSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaShaleSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Shale distributions </Description>
                     <DisplayName>GeoStrata Shale Size</DisplayName>
                 </OptionNumeric>
@@ -64,7 +69,7 @@
 
             <!-- Sandstone Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaSandstoneDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaSandstoneDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Sandstone is generated </Description>
                     <DisplayName>GeoStrata Sandstone</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -84,11 +89,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Sandstone is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaSandstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaSandstoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Sandstone distributions </Description>
                     <DisplayName>GeoStrata Sandstone Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaSandstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaSandstoneSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Sandstone distributions </Description>
                     <DisplayName>GeoStrata Sandstone Size</DisplayName>
                 </OptionNumeric>
@@ -98,7 +103,7 @@
 
             <!-- Limestone Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaLimestoneDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaLimestoneDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Limestone is generated </Description>
                     <DisplayName>GeoStrata Limestone</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -118,11 +123,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Limestone is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaLimestoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaLimestoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Limestone distributions </Description>
                     <DisplayName>GeoStrata Limestone Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaLimestoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaLimestoneSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Limestone distributions </Description>
                     <DisplayName>GeoStrata Limestone Size</DisplayName>
                 </OptionNumeric>
@@ -132,7 +137,7 @@
 
             <!-- Pumice Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaPumiceDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaPumiceDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Pumice is generated </Description>
                     <DisplayName>GeoStrata Pumice</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -152,11 +157,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Pumice is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaPumiceFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaPumiceFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Pumice distributions </Description>
                     <DisplayName>GeoStrata Pumice Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaPumiceSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaPumiceSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Pumice distributions </Description>
                     <DisplayName>GeoStrata Pumice Size</DisplayName>
                 </OptionNumeric>
@@ -166,7 +171,7 @@
 
             <!-- Opal Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaOpalDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaOpalDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Opal is generated </Description>
                     <DisplayName>GeoStrata Opal</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -186,11 +191,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Opal is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaOpalFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaOpalFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Opal distributions </Description>
                     <DisplayName>GeoStrata Opal Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaOpalSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaOpalSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Opal distributions </Description>
                     <DisplayName>GeoStrata Opal Size</DisplayName>
                 </OptionNumeric>
@@ -200,7 +205,7 @@
 
             <!-- Slate Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaSlateDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaSlateDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Slate is generated </Description>
                     <DisplayName>GeoStrata Slate</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -220,11 +225,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Slate is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaSlateFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaSlateFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Slate distributions </Description>
                     <DisplayName>GeoStrata Slate Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaSlateSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaSlateSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Slate distributions </Description>
                     <DisplayName>GeoStrata Slate Size</DisplayName>
                 </OptionNumeric>
@@ -234,7 +239,7 @@
 
             <!-- Gneiss Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaGneissDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaGneissDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Gneiss is generated </Description>
                     <DisplayName>GeoStrata Gneiss</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -254,11 +259,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Gneiss is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaGneissFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaGneissFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Gneiss distributions </Description>
                     <DisplayName>GeoStrata Gneiss Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaGneissSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaGneissSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Gneiss distributions </Description>
                     <DisplayName>GeoStrata Gneiss Size</DisplayName>
                 </OptionNumeric>
@@ -268,7 +273,7 @@
 
             <!-- Peridotite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaPeridotiteDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaPeridotiteDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Peridotite is generated </Description>
                     <DisplayName>GeoStrata Peridotite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -288,11 +293,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Peridotite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaPeridotiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaPeridotiteFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Peridotite distributions </Description>
                     <DisplayName>GeoStrata Peridotite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaPeridotiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaPeridotiteSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Peridotite distributions </Description>
                     <DisplayName>GeoStrata Peridotite Size</DisplayName>
                 </OptionNumeric>
@@ -302,7 +307,7 @@
 
             <!-- Granulite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaGranuliteDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaGranuliteDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Granulite is generated </Description>
                     <DisplayName>GeoStrata Granulite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -322,11 +327,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Granulite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaGranuliteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaGranuliteFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Granulite distributions </Description>
                     <DisplayName>GeoStrata Granulite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaGranuliteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaGranuliteSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Granulite distributions </Description>
                     <DisplayName>GeoStrata Granulite Size</DisplayName>
                 </OptionNumeric>
@@ -336,7 +341,7 @@
 
             <!-- Migmatite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaMigmatiteDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaMigmatiteDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Migmatite is generated </Description>
                     <DisplayName>GeoStrata Migmatite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -356,11 +361,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Migmatite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaMigmatiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaMigmatiteFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Migmatite distributions </Description>
                     <DisplayName>GeoStrata Migmatite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaMigmatiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaMigmatiteSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Migmatite distributions </Description>
                     <DisplayName>GeoStrata Migmatite Size</DisplayName>
                 </OptionNumeric>
@@ -370,7 +375,7 @@
 
             <!-- Schist Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaSchistDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaSchistDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Schist is generated </Description>
                     <DisplayName>GeoStrata Schist</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -390,11 +395,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Schist is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaSchistFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaSchistFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Schist distributions </Description>
                     <DisplayName>GeoStrata Schist Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaSchistSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaSchistSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Schist distributions </Description>
                     <DisplayName>GeoStrata Schist Size</DisplayName>
                 </OptionNumeric>
@@ -404,7 +409,7 @@
 
             <!-- Basalt Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaBasaltDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaBasaltDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Basalt is generated </Description>
                     <DisplayName>GeoStrata Basalt</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -424,11 +429,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Basalt is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaBasaltFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaBasaltFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Basalt distributions </Description>
                     <DisplayName>GeoStrata Basalt Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaBasaltSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaBasaltSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Basalt distributions </Description>
                     <DisplayName>GeoStrata Basalt Size</DisplayName>
                 </OptionNumeric>
@@ -438,7 +443,7 @@
 
             <!-- Onyx Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaOnyxDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaOnyxDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Onyx is generated </Description>
                     <DisplayName>GeoStrata Onyx</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -458,11 +463,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Onyx is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaOnyxFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaOnyxFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Onyx distributions </Description>
                     <DisplayName>GeoStrata Onyx Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaOnyxSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaOnyxSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Onyx distributions </Description>
                     <DisplayName>GeoStrata Onyx Size</DisplayName>
                 </OptionNumeric>
@@ -472,7 +477,7 @@
 
             <!-- Quartz Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaQuartzDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaQuartzDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Quartz is generated </Description>
                     <DisplayName>GeoStrata Quartz</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -492,11 +497,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Quartz is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Quartz distributions </Description>
                     <DisplayName>GeoStrata Quartz Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaQuartzSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaQuartzSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Quartz distributions </Description>
                     <DisplayName>GeoStrata Quartz Size</DisplayName>
                 </OptionNumeric>
@@ -506,7 +511,7 @@
 
             <!-- Marble Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaMarbleDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaMarbleDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Marble is generated </Description>
                     <DisplayName>GeoStrata Marble</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -526,11 +531,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Marble is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaMarbleFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaMarbleFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Marble distributions </Description>
                     <DisplayName>GeoStrata Marble Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaMarbleSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaMarbleSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Marble distributions </Description>
                     <DisplayName>GeoStrata Marble Size</DisplayName>
                 </OptionNumeric>
@@ -540,7 +545,7 @@
 
             <!-- Granite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaGraniteDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaGraniteDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Granite is generated </Description>
                     <DisplayName>GeoStrata Granite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -560,11 +565,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Granite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaGraniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaGraniteFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Granite distributions </Description>
                     <DisplayName>GeoStrata Granite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaGraniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaGraniteSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Granite distributions </Description>
                     <DisplayName>GeoStrata Granite Size</DisplayName>
                 </OptionNumeric>
@@ -574,7 +579,7 @@
 
             <!-- Hornfel Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='gstaHornfelDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                <OptionChoice name='gstaHornfelDist'  displayState=':= if(?enableGeoStrata, "shown", "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Controls how Hornfel is generated </Description>
                     <DisplayName>GeoStrata Hornfel</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -594,11 +599,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Hornfel is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='gstaHornfelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaHornfelFreq' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Frequency multiplier for GeoStrata Hornfel distributions </Description>
                     <DisplayName>GeoStrata Hornfel Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='gstaHornfelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                <OptionNumeric name='gstaHornfelSize' default='1'  min='0' max='5' displayState=':= if(?enableGeoStrata, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupGeoStrata'>
                     <Description> Size multiplier for GeoStrata Hornfel distributions </Description>
                     <DisplayName>GeoStrata Hornfel Size</DisplayName>
                 </OptionNumeric>
@@ -608,2042 +613,2081 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableGeoStrata'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='gstaOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
-                <Replaces block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Shale Generation -->
-
-            <!-- Starting LayeredVeins Preset for Shale. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaShaleDist = "LayeredVeins"'>
-                    <Veins name='gstaShaleVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='gstaOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaShaleFreq ' range=':=  _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 56 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <Replaces block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <Replaces block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <Replaces block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <Replaces block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <Replaces block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <Replaces block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <Replaces block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <Replaces block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <Replaces block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <Replaces block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <Replaces block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <Replaces block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <Replaces block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <Replaces block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <Replaces block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <Replaces block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <Replaces block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Shale is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Shale. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaShaleDist = "Cloud"'>
-                    <Cloud name='gstaShaleCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaShaleFreq ' range=':=  _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 56 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaShaleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Shale Generation -->
+
+                <!-- Starting LayeredVeins Preset for Shale. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaShaleDist = "LayeredVeins"'>
+                        <Veins name='gstaShaleVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaShaleFreq ' range=':=  _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 56 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Shale is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Shale is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Shale. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaShaleDist = "Vanilla"'>
-                    <StandardGen name='gstaShaleStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 24 * gstaShaleFreq ' range=':=  _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 56 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Shale is complete. -->
-
-            <!-- End Shale Generation -->
-
-
-            <!-- Begin Sandstone Generation -->
-
-            <!-- Starting LayeredVeins Preset for Sandstone. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaSandstoneDist = "LayeredVeins"'>
-                    <Veins name='gstaSandstoneVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaSandstoneFreq ' range=':=  _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Sandstone is complete. -->
-
-
-            <!-- Starting Cloud Preset for Sandstone. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaSandstoneDist = "Cloud"'>
-                    <Cloud name='gstaSandstoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaSandstoneFreq ' range=':=  _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaSandstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
+                <!-- Starting Cloud Preset for Shale. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaShaleDist = "Cloud"'>
+                        <Cloud name='gstaShaleCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Sandstone is complete. -->
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaShaleFreq ' range=':=  _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 56 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaShaleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Shale is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Sandstone. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaSandstoneDist = "Vanilla"'>
-                    <StandardGen name='gstaSandstoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= _default_ * gstaSandstoneFreq ' range=':=  _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Sandstone is complete. -->
-
-            <!-- End Sandstone Generation -->
-
-
-            <!-- Begin Limestone Generation -->
-
-            <!-- Starting LayeredVeins Preset for Limestone. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaLimestoneDist = "LayeredVeins"'>
-                    <Veins name='gstaLimestoneVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaLimestoneFreq ' range=':=  _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Limestone is complete. -->
-
-
-            <!-- Starting Cloud Preset for Limestone. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaLimestoneDist = "Cloud"'>
-                    <Cloud name='gstaLimestoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaLimestoneFreq ' range=':=  _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaLimestoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
+                <!-- Starting Vanilla Preset for Shale. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaShaleDist = "Vanilla"'>
+                        <StandardGen name='gstaShaleStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Limestone is complete. -->
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 24 * gstaShaleFreq ' range=':=  _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 56 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Shale is complete. -->
+
+                <!-- End Shale Generation -->
 
 
-            <!-- Starting Vanilla Preset for Limestone. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaLimestoneDist = "Vanilla"'>
-                    <StandardGen name='gstaLimestoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= _default_ * gstaLimestoneFreq ' range=':=  _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Limestone is complete. -->
+                <!-- Begin Sandstone Generation -->
 
-            <!-- End Limestone Generation -->
-
-
-            <!-- Begin Pumice Generation -->
-
-            <!-- Starting LayeredVeins Preset for Pumice. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaPumiceDist = "LayeredVeins"'>
-                    <Veins name='gstaPumiceVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaPumiceFreq ' range=':=  _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Pumice is complete. -->
-
-
-            <!-- Starting Cloud Preset for Pumice. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaPumiceDist = "Cloud"'>
-                    <Cloud name='gstaPumiceCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaPumiceFreq ' range=':=  _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaPumiceHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
+                <!-- Starting LayeredVeins Preset for Sandstone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaSandstoneDist = "LayeredVeins"'>
+                        <Veins name='gstaSandstoneVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaSandstoneFreq ' range=':=  _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Pumice is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Sandstone is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Pumice. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaPumiceDist = "Vanilla"'>
-                    <StandardGen name='gstaPumiceStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 14.4 * gstaPumiceFreq ' range=':=  _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Pumice is complete. -->
-
-            <!-- End Pumice Generation -->
-
-
-            <!-- Begin Opal Generation -->
-
-            <!-- Starting LayeredVeins Preset for Opal. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaOpalDist = "LayeredVeins"'>
-                    <Veins name='gstaOpalVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.161 * _default_ * gstaOpalFreq ' range=':=  _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.051 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.051 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.051 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Opal is complete. -->
-
-
-            <!-- Starting Cloud Preset for Opal. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaOpalDist = "Cloud"'>
-                    <Cloud name='gstaOpalCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.522 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.522 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * gstaOpalFreq ' range=':=  _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaOpalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
+                <!-- Starting Cloud Preset for Sandstone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaSandstoneDist = "Cloud"'>
+                        <Cloud name='gstaSandstoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Opal is complete. -->
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaSandstoneFreq ' range=':=  _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaSandstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Sandstone is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Opal. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaOpalDist = "Vanilla"'>
-                    <StandardGen name='gstaOpalStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * gstaOpalFreq ' range=':=  _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Opal is complete. -->
-
-            <!-- End Opal Generation -->
-
-
-            <!-- Begin Slate Generation -->
-
-            <!-- Starting LayeredVeins Preset for Slate. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaSlateDist = "LayeredVeins"'>
-                    <Veins name='gstaSlateVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaSlateFreq ' range=':=  _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Slate is complete. -->
-
-
-            <!-- Starting Cloud Preset for Slate. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaSlateDist = "Cloud"'>
-                    <Cloud name='gstaSlateCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaSlateFreq ' range=':=  _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaSlateHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
+                <!-- Starting Vanilla Preset for Sandstone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaSandstoneDist = "Vanilla"'>
+                        <StandardGen name='gstaSandstoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Slate is complete. -->
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= _default_ * gstaSandstoneFreq ' range=':=  _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Sandstone is complete. -->
+
+                <!-- End Sandstone Generation -->
 
 
-            <!-- Starting Vanilla Preset for Slate. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaSlateDist = "Vanilla"'>
-                    <StandardGen name='gstaSlateStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 24 * gstaSlateFreq ' range=':=  _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 40 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Slate is complete. -->
+                <!-- Begin Limestone Generation -->
 
-            <!-- End Slate Generation -->
-
-
-            <!-- Begin Gneiss Generation -->
-
-            <!-- Starting LayeredVeins Preset for Gneiss. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaGneissDist = "LayeredVeins"'>
-                    <Veins name='gstaGneissVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaGneissFreq ' range=':=  _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Gneiss is complete. -->
-
-
-            <!-- Starting Cloud Preset for Gneiss. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaGneissDist = "Cloud"'>
-                    <Cloud name='gstaGneissCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaGneissFreq ' range=':=  _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaGneissHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
+                <!-- Starting LayeredVeins Preset for Limestone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaLimestoneDist = "LayeredVeins"'>
+                        <Veins name='gstaLimestoneVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaLimestoneFreq ' range=':=  _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Gneiss is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Limestone is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Gneiss. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaGneissDist = "Vanilla"'>
-                    <StandardGen name='gstaGneissStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 19.2 * gstaGneissFreq ' range=':=  _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Gneiss is complete. -->
-
-            <!-- End Gneiss Generation -->
-
-
-            <!-- Begin Peridotite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Peridotite. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaPeridotiteDist = "LayeredVeins"'>
-                    <Veins name='gstaPeridotiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaPeridotiteFreq ' range=':=  _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Peridotite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Peridotite. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaPeridotiteDist = "Cloud"'>
-                    <Cloud name='gstaPeridotiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaPeridotiteFreq ' range=':=  _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaPeridotiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
+                <!-- Starting Cloud Preset for Limestone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaLimestoneDist = "Cloud"'>
+                        <Cloud name='gstaLimestoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Peridotite is complete. -->
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaLimestoneFreq ' range=':=  _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaLimestoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Limestone is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Peridotite. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaPeridotiteDist = "Vanilla"'>
-                    <StandardGen name='gstaPeridotiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 14.4 * gstaPeridotiteFreq ' range=':=  _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Peridotite is complete. -->
-
-            <!-- End Peridotite Generation -->
-
-
-            <!-- Begin Granulite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Granulite. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaGranuliteDist = "LayeredVeins"'>
-                    <Veins name='gstaGranuliteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.746 * _default_ * gstaGranuliteFreq ' range=':=  _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.4 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.4 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.4 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Granulite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Granulite. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaGranuliteDist = "Cloud"'>
-                    <Cloud name='gstaGranuliteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.342 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.342 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 5.483  * _default_ * gstaGranuliteFreq ' range=':=  _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaGranuliteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
+                <!-- Starting Vanilla Preset for Limestone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaLimestoneDist = "Vanilla"'>
+                        <StandardGen name='gstaLimestoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Granulite is complete. -->
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= _default_ * gstaLimestoneFreq ' range=':=  _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Limestone is complete. -->
+
+                <!-- End Limestone Generation -->
 
 
-            <!-- Starting Vanilla Preset for Granulite. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaGranuliteDist = "Vanilla"'>
-                    <StandardGen name='gstaGranuliteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 16.8 * gstaGranuliteFreq ' range=':=  _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Granulite is complete. -->
+                <!-- Begin Pumice Generation -->
 
-            <!-- End Granulite Generation -->
-
-
-            <!-- Begin Migmatite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Migmatite. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaMigmatiteDist = "LayeredVeins"'>
-                    <Veins name='gstaMigmatiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaMigmatiteFreq ' range=':=  _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Migmatite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Migmatite. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaMigmatiteDist = "Cloud"'>
-                    <Cloud name='gstaMigmatiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaMigmatiteFreq ' range=':=  _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaMigmatiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
+                <!-- Starting LayeredVeins Preset for Pumice. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaPumiceDist = "LayeredVeins"'>
+                        <Veins name='gstaPumiceVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaPumiceFreq ' range=':=  _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Migmatite is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Pumice is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Migmatite. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaMigmatiteDist = "Vanilla"'>
-                    <StandardGen name='gstaMigmatiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 14.4 * gstaMigmatiteFreq ' range=':=  _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Migmatite is complete. -->
-
-            <!-- End Migmatite Generation -->
-
-
-            <!-- Begin Schist Generation -->
-
-            <!-- Starting LayeredVeins Preset for Schist. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaSchistDist = "LayeredVeins"'>
-                    <Veins name='gstaSchistVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaSchistFreq ' range=':=  _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Schist is complete. -->
-
-
-            <!-- Starting Cloud Preset for Schist. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaSchistDist = "Cloud"'>
-                    <Cloud name='gstaSchistCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaSchistFreq ' range=':=  _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaSchistHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
+                <!-- Starting Cloud Preset for Pumice. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaPumiceDist = "Cloud"'>
+                        <Cloud name='gstaPumiceCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Schist is complete. -->
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaPumiceFreq ' range=':=  _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaPumiceHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Pumice is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Schist. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaSchistDist = "Vanilla"'>
-                    <StandardGen name='gstaSchistStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 19.2 * gstaSchistFreq ' range=':=  _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Schist is complete. -->
-
-            <!-- End Schist Generation -->
-
-
-            <!-- Begin Basalt Generation -->
-
-            <!-- Starting LayeredVeins Preset for Basalt. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaBasaltDist = "LayeredVeins"'>
-                    <Veins name='gstaBasaltVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaBasaltFreq ' range=':=  _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Basalt is complete. -->
-
-
-            <!-- Starting Cloud Preset for Basalt. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaBasaltDist = "Cloud"'>
-                    <Cloud name='gstaBasaltCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaBasaltFreq ' range=':=  _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaBasaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
+                <!-- Starting Vanilla Preset for Pumice. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaPumiceDist = "Vanilla"'>
+                        <StandardGen name='gstaPumiceStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Basalt is complete. -->
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 14.4 * gstaPumiceFreq ' range=':=  _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Pumice is complete. -->
+
+                <!-- End Pumice Generation -->
 
 
-            <!-- Starting Vanilla Preset for Basalt. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaBasaltDist = "Vanilla"'>
-                    <StandardGen name='gstaBasaltStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 24 * gstaBasaltFreq ' range=':=  _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Basalt is complete. -->
+                <!-- Begin Opal Generation -->
 
-            <!-- End Basalt Generation -->
-
-
-            <!-- Begin Onyx Generation -->
-
-            <!-- Starting LayeredVeins Preset for Onyx. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaOnyxDist = "LayeredVeins"'>
-                    <Veins name='gstaOnyxVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaOnyxFreq ' range=':=  _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Onyx is complete. -->
-
-
-            <!-- Starting Cloud Preset for Onyx. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaOnyxDist = "Cloud"'>
-                    <Cloud name='gstaOnyxCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaOnyxFreq ' range=':=  _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaOnyxHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
+                <!-- Starting LayeredVeins Preset for Opal. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaOpalDist = "LayeredVeins"'>
+                        <Veins name='gstaOpalVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.161 * _default_ * gstaOpalFreq ' range=':=  _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.051 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.051 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.051 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Onyx is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Opal is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Onyx. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaOnyxDist = "Vanilla"'>
-                    <StandardGen name='gstaOnyxStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 24 * gstaOnyxFreq ' range=':=  _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Onyx is complete. -->
-
-            <!-- End Onyx Generation -->
-
-
-            <!-- Begin Quartz Generation -->
-
-            <!-- Starting LayeredVeins Preset for Quartz. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaQuartzDist = "LayeredVeins"'>
-                    <Veins name='gstaQuartzVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.321 * _default_ * gstaQuartzFreq ' range=':=  _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.324 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.324 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.324 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Quartz is complete. -->
-
-
-            <!-- Starting Cloud Preset for Quartz. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaQuartzDist = "Cloud"'>
-                    <Cloud name='gstaQuartzCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.153 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.153 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 4.634  * _default_ * gstaQuartzFreq ' range=':=  _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaQuartzHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
+                <!-- Starting Cloud Preset for Opal. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaOpalDist = "Cloud"'>
+                        <Cloud name='gstaOpalCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Quartz is complete. -->
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.522 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.522 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * gstaOpalFreq ' range=':=  _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaOpalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Opal is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Quartz. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaQuartzDist = "Vanilla"'>
-                    <StandardGen name='gstaQuartzStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * gstaQuartzFreq ' range=':=  _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Quartz is complete. -->
-
-            <!-- End Quartz Generation -->
-
-
-            <!-- Begin Marble Generation -->
-
-            <!-- Starting LayeredVeins Preset for Marble. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaMarbleDist = "LayeredVeins"'>
-                    <Veins name='gstaMarbleVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaMarbleFreq ' range=':=  _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  24 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Marble is complete. -->
-
-
-            <!-- Starting Cloud Preset for Marble. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaMarbleDist = "Cloud"'>
-                    <Cloud name='gstaMarbleCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaMarbleFreq ' range=':=  _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  24 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaMarbleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
+                <!-- Starting Vanilla Preset for Opal. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaOpalDist = "Vanilla"'>
+                        <StandardGen name='gstaOpalStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Marble is complete. -->
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * gstaOpalFreq ' range=':=  _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Opal is complete. -->
+
+                <!-- End Opal Generation -->
 
 
-            <!-- Starting Vanilla Preset for Marble. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaMarbleDist = "Vanilla"'>
-                    <StandardGen name='gstaMarbleStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 24 * gstaMarbleFreq ' range=':=  _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 40 ' range=':=  24 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Marble is complete. -->
+                <!-- Begin Slate Generation -->
 
-            <!-- End Marble Generation -->
-
-
-            <!-- Begin Granite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Granite. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaGraniteDist = "LayeredVeins"'>
-                    <Veins name='gstaGraniteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaGraniteFreq ' range=':=  _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Granite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Granite. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaGraniteDist = "Cloud"'>
-                    <Cloud name='gstaGraniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaGraniteFreq ' range=':=  _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaGraniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
+                <!-- Starting LayeredVeins Preset for Slate. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaSlateDist = "LayeredVeins"'>
+                        <Veins name='gstaSlateVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaSlateFreq ' range=':=  _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Granite is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Slate is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Granite. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaGraniteDist = "Vanilla"'>
-                    <StandardGen name='gstaGraniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 24 * gstaGraniteFreq ' range=':=  _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Granite is complete. -->
-
-            <!-- End Granite Generation -->
-
-
-            <!-- Begin Hornfel Generation -->
-
-            <!-- Starting LayeredVeins Preset for Hornfel. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaHornfelDist = "LayeredVeins"'>
-                    <Veins name='gstaHornfelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaHornfelFreq ' range=':=  _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Hornfel is complete. -->
-
-
-            <!-- Starting Cloud Preset for Hornfel. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaHornfelDist = "Cloud"'>
-                    <Cloud name='gstaHornfelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaHornfelFreq ' range=':=  _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='gstaHornfelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
+                <!-- Starting Cloud Preset for Slate. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaSlateDist = "Cloud"'>
+                        <Cloud name='gstaSlateCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaSlateFreq ' range=':=  _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaSlateHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Slate is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Slate. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaSlateDist = "Vanilla"'>
+                        <StandardGen name='gstaSlateStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 24 * gstaSlateFreq ' range=':=  _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Slate is complete. -->
+
+                <!-- End Slate Generation -->
+
+
+                <!-- Begin Gneiss Generation -->
+
+                <!-- Starting LayeredVeins Preset for Gneiss. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaGneissDist = "LayeredVeins"'>
+                        <Veins name='gstaGneissVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaGneissFreq ' range=':=  _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Hornfel is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Gneiss is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Hornfel. -->
-            <ConfigSection>
-                <IfCondition condition=':= gstaHornfelDist = "Vanilla"'>
-                    <StandardGen name='gstaHornfelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 32 * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 19.2 * gstaHornfelFreq ' range=':=  _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Hornfel is complete. -->
+                <!-- Starting Cloud Preset for Gneiss. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaGneissDist = "Cloud"'>
+                        <Cloud name='gstaGneissCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaGneissFreq ' range=':=  _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaGneissHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Gneiss is complete. -->
 
-            <!-- End Hornfel Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Gneiss. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaGneissDist = "Vanilla"'>
+                        <StandardGen name='gstaGneissStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 19.2 * gstaGneissFreq ' range=':=  _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Gneiss is complete. -->
+
+                <!-- End Gneiss Generation -->
+
+
+                <!-- Begin Peridotite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Peridotite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaPeridotiteDist = "LayeredVeins"'>
+                        <Veins name='gstaPeridotiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaPeridotiteFreq ' range=':=  _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Peridotite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Peridotite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaPeridotiteDist = "Cloud"'>
+                        <Cloud name='gstaPeridotiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaPeridotiteFreq ' range=':=  _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaPeridotiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Peridotite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Peridotite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaPeridotiteDist = "Vanilla"'>
+                        <StandardGen name='gstaPeridotiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 14.4 * gstaPeridotiteFreq ' range=':=  _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Peridotite is complete. -->
+
+                <!-- End Peridotite Generation -->
+
+
+                <!-- Begin Granulite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Granulite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaGranuliteDist = "LayeredVeins"'>
+                        <Veins name='gstaGranuliteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.746 * _default_ * gstaGranuliteFreq ' range=':=  _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.4 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.4 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.4 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Granulite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Granulite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaGranuliteDist = "Cloud"'>
+                        <Cloud name='gstaGranuliteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.342 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.342 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.483  * _default_ * gstaGranuliteFreq ' range=':=  _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaGranuliteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Granulite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Granulite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaGranuliteDist = "Vanilla"'>
+                        <StandardGen name='gstaGranuliteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.8 * gstaGranuliteFreq ' range=':=  _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Granulite is complete. -->
+
+                <!-- End Granulite Generation -->
+
+
+                <!-- Begin Migmatite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Migmatite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaMigmatiteDist = "LayeredVeins"'>
+                        <Veins name='gstaMigmatiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaMigmatiteFreq ' range=':=  _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Migmatite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Migmatite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaMigmatiteDist = "Cloud"'>
+                        <Cloud name='gstaMigmatiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaMigmatiteFreq ' range=':=  _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaMigmatiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Migmatite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Migmatite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaMigmatiteDist = "Vanilla"'>
+                        <StandardGen name='gstaMigmatiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 14.4 * gstaMigmatiteFreq ' range=':=  _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Migmatite is complete. -->
+
+                <!-- End Migmatite Generation -->
+
+
+                <!-- Begin Schist Generation -->
+
+                <!-- Starting LayeredVeins Preset for Schist. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaSchistDist = "LayeredVeins"'>
+                        <Veins name='gstaSchistVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaSchistFreq ' range=':=  _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Schist is complete. -->
+
+
+                <!-- Starting Cloud Preset for Schist. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaSchistDist = "Cloud"'>
+                        <Cloud name='gstaSchistCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaSchistFreq ' range=':=  _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaSchistHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Schist is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Schist. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaSchistDist = "Vanilla"'>
+                        <StandardGen name='gstaSchistStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 19.2 * gstaSchistFreq ' range=':=  _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Schist is complete. -->
+
+                <!-- End Schist Generation -->
+
+
+                <!-- Begin Basalt Generation -->
+
+                <!-- Starting LayeredVeins Preset for Basalt. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaBasaltDist = "LayeredVeins"'>
+                        <Veins name='gstaBasaltVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaBasaltFreq ' range=':=  _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Basalt is complete. -->
+
+
+                <!-- Starting Cloud Preset for Basalt. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaBasaltDist = "Cloud"'>
+                        <Cloud name='gstaBasaltCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaBasaltFreq ' range=':=  _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaBasaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Basalt is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Basalt. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaBasaltDist = "Vanilla"'>
+                        <StandardGen name='gstaBasaltStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 24 * gstaBasaltFreq ' range=':=  _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Basalt is complete. -->
+
+                <!-- End Basalt Generation -->
+
+
+                <!-- Begin Onyx Generation -->
+
+                <!-- Starting LayeredVeins Preset for Onyx. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaOnyxDist = "LayeredVeins"'>
+                        <Veins name='gstaOnyxVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaOnyxFreq ' range=':=  _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Onyx is complete. -->
+
+
+                <!-- Starting Cloud Preset for Onyx. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaOnyxDist = "Cloud"'>
+                        <Cloud name='gstaOnyxCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaOnyxFreq ' range=':=  _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaOnyxHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Onyx is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Onyx. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaOnyxDist = "Vanilla"'>
+                        <StandardGen name='gstaOnyxStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 24 * gstaOnyxFreq ' range=':=  _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Onyx is complete. -->
+
+                <!-- End Onyx Generation -->
+
+
+                <!-- Begin Quartz Generation -->
+
+                <!-- Starting LayeredVeins Preset for Quartz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaQuartzDist = "LayeredVeins"'>
+                        <Veins name='gstaQuartzVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.321 * _default_ * gstaQuartzFreq ' range=':=  _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.324 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.324 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.324 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Quartz is complete. -->
+
+
+                <!-- Starting Cloud Preset for Quartz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaQuartzDist = "Cloud"'>
+                        <Cloud name='gstaQuartzCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.153 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.153 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 4.634  * _default_ * gstaQuartzFreq ' range=':=  _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaQuartzHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Quartz is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Quartz. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaQuartzDist = "Vanilla"'>
+                        <StandardGen name='gstaQuartzStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12 * gstaQuartzFreq ' range=':=  _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Quartz is complete. -->
+
+                <!-- End Quartz Generation -->
+
+
+                <!-- Begin Marble Generation -->
+
+                <!-- Starting LayeredVeins Preset for Marble. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaMarbleDist = "LayeredVeins"'>
+                        <Veins name='gstaMarbleVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaMarbleFreq ' range=':=  _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  24 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Marble is complete. -->
+
+
+                <!-- Starting Cloud Preset for Marble. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaMarbleDist = "Cloud"'>
+                        <Cloud name='gstaMarbleCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaMarbleFreq ' range=':=  _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  24 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaMarbleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Marble is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Marble. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaMarbleDist = "Vanilla"'>
+                        <StandardGen name='gstaMarbleStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 24 * gstaMarbleFreq ' range=':=  _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':=  24 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Marble is complete. -->
+
+                <!-- End Marble Generation -->
+
+
+                <!-- Begin Granite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Granite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaGraniteDist = "LayeredVeins"'>
+                        <Veins name='gstaGraniteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaGraniteFreq ' range=':=  _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Granite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Granite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaGraniteDist = "Cloud"'>
+                        <Cloud name='gstaGraniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaGraniteFreq ' range=':=  _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaGraniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Granite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Granite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaGraniteDist = "Vanilla"'>
+                        <StandardGen name='gstaGraniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 24 * gstaGraniteFreq ' range=':=  _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Granite is complete. -->
+
+                <!-- End Granite Generation -->
+
+
+                <!-- Begin Hornfel Generation -->
+
+                <!-- Starting LayeredVeins Preset for Hornfel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaHornfelDist = "LayeredVeins"'>
+                        <Veins name='gstaHornfelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaHornfelFreq ' range=':=  _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Hornfel is complete. -->
+
+
+                <!-- Starting Cloud Preset for Hornfel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaHornfelDist = "Cloud"'>
+                        <Cloud name='gstaHornfelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaHornfelFreq ' range=':=  _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='gstaHornfelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Hornfel is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Hornfel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= gstaHornfelDist = "Vanilla"'>
+                        <StandardGen name='gstaHornfelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 32 * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 19.2 * gstaHornfelFreq ' range=':=  _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Hornfel is complete. -->
+
+                <!-- End Hornfel Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/GeoStrata.xml
+++ b/src/main/resources/config/modules/GeoStrata.xml
@@ -1,1126 +1,2664 @@
- <!-- ================================================================
-      Custom Ore Generation "GeoStrata" Module: This configuration
-      covers shale, sandstone, limestone, pumice, opal, slate, gneiss,
-      peridotite,  granulite, migmatite, schist, basalt, onyx, quartz,
-      marble, granite,  and hornfel.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "GeoStrata" Module: This configuration
+     covers shale, sandstone, limestone, pumice, opal, slate, gneiss,
+     peridotite, granulite, migmatite, schist, basalt, onyx, quartz,
+     marble, granite, and hornfel.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="GeoStrata">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "GeoStrata" mod on the system?  Let's find out! -->
+<IfModInstalled name="GeoStrata">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupGeoStrata' displayName='GeoStrata' displayState='shown'>
+                <Description>
+                    Distribution options for GeoStrata Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Shale Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupGeoStrata' displayName='GeoStrata' displayState='shown'> 
-                    <Description>
-                        Distribution options for GeoStrata Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Shale Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaShaleDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Shale is generated </Description> 
-                        <DisplayName>GeoStrata Shale</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Shale is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaShaleFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Shale distributions </Description>
-                        <DisplayName>GeoStrata Shale Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaShaleSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Shale distributions </Description>
-                        <DisplayName>GeoStrata Shale Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Shale Configuration UI Complete -->
-                
-                
-                <!-- Sandstone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaSandstoneDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Sandstone is generated </Description> 
-                        <DisplayName>GeoStrata Sandstone</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Sandstone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaSandstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Sandstone distributions </Description>
-                        <DisplayName>GeoStrata Sandstone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaSandstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Sandstone distributions </Description>
-                        <DisplayName>GeoStrata Sandstone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Sandstone Configuration UI Complete -->
-                
-                
-                <!-- Limestone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaLimestoneDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Limestone is generated </Description> 
-                        <DisplayName>GeoStrata Limestone</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Limestone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaLimestoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Limestone distributions </Description>
-                        <DisplayName>GeoStrata Limestone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaLimestoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Limestone distributions </Description>
-                        <DisplayName>GeoStrata Limestone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Limestone Configuration UI Complete -->
-                
-                
-                <!-- Pumice Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaPumiceDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Pumice is generated </Description> 
-                        <DisplayName>GeoStrata Pumice</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Pumice is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaPumiceFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Pumice distributions </Description>
-                        <DisplayName>GeoStrata Pumice Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaPumiceSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Pumice distributions </Description>
-                        <DisplayName>GeoStrata Pumice Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Pumice Configuration UI Complete -->
-                
-                
-                <!-- Opal Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaOpalDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Opal is generated </Description> 
-                        <DisplayName>GeoStrata Opal</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Opal is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaOpalFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Opal distributions </Description>
-                        <DisplayName>GeoStrata Opal Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaOpalSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Opal distributions </Description>
-                        <DisplayName>GeoStrata Opal Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Opal Configuration UI Complete -->
-                
-                
-                <!-- Slate Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaSlateDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Slate is generated </Description> 
-                        <DisplayName>GeoStrata Slate</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Slate is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaSlateFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Slate distributions </Description>
-                        <DisplayName>GeoStrata Slate Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaSlateSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Slate distributions </Description>
-                        <DisplayName>GeoStrata Slate Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Slate Configuration UI Complete -->
-                
-                
-                <!-- Gneiss Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaGneissDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Gneiss is generated </Description> 
-                        <DisplayName>GeoStrata Gneiss</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Gneiss is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaGneissFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Gneiss distributions </Description>
-                        <DisplayName>GeoStrata Gneiss Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaGneissSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Gneiss distributions </Description>
-                        <DisplayName>GeoStrata Gneiss Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Gneiss Configuration UI Complete -->
-                
-                
-                <!-- Peridotite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaPeridotiteDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Peridotite is generated </Description> 
-                        <DisplayName>GeoStrata Peridotite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Peridotite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaPeridotiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Peridotite distributions </Description>
-                        <DisplayName>GeoStrata Peridotite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaPeridotiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Peridotite distributions </Description>
-                        <DisplayName>GeoStrata Peridotite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Peridotite Configuration UI Complete -->
-                
-                
-                <!-- Granulite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaGranuliteDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Granulite is generated </Description> 
-                        <DisplayName>GeoStrata Granulite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Granulite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaGranuliteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Granulite distributions </Description>
-                        <DisplayName>GeoStrata Granulite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaGranuliteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Granulite distributions </Description>
-                        <DisplayName>GeoStrata Granulite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Granulite Configuration UI Complete -->
-                
-                
-                <!-- Migmatite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaMigmatiteDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Migmatite is generated </Description> 
-                        <DisplayName>GeoStrata Migmatite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Migmatite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaMigmatiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Migmatite distributions </Description>
-                        <DisplayName>GeoStrata Migmatite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaMigmatiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Migmatite distributions </Description>
-                        <DisplayName>GeoStrata Migmatite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Migmatite Configuration UI Complete -->
-                
-                
-                <!-- Schist Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaSchistDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Schist is generated </Description> 
-                        <DisplayName>GeoStrata Schist</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Schist is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaSchistFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Schist distributions </Description>
-                        <DisplayName>GeoStrata Schist Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaSchistSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Schist distributions </Description>
-                        <DisplayName>GeoStrata Schist Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Schist Configuration UI Complete -->
-                
-                
-                <!-- Basalt Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaBasaltDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Basalt is generated </Description> 
-                        <DisplayName>GeoStrata Basalt</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Basalt is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaBasaltFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Basalt distributions </Description>
-                        <DisplayName>GeoStrata Basalt Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaBasaltSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Basalt distributions </Description>
-                        <DisplayName>GeoStrata Basalt Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Basalt Configuration UI Complete -->
-                
-                
-                <!-- Onyx Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaOnyxDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Onyx is generated </Description> 
-                        <DisplayName>GeoStrata Onyx</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Onyx is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaOnyxFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Onyx distributions </Description>
-                        <DisplayName>GeoStrata Onyx Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaOnyxSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Onyx distributions </Description>
-                        <DisplayName>GeoStrata Onyx Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Onyx Configuration UI Complete -->
-                
-                
-                <!-- Quartz Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaQuartzDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Quartz is generated </Description> 
-                        <DisplayName>GeoStrata Quartz</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Quartz is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Quartz distributions </Description>
-                        <DisplayName>GeoStrata Quartz Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaQuartzSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Quartz distributions </Description>
-                        <DisplayName>GeoStrata Quartz Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Quartz Configuration UI Complete -->
-                
-                
-                <!-- Marble Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaMarbleDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Marble is generated </Description> 
-                        <DisplayName>GeoStrata Marble</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Marble is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaMarbleFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Marble distributions </Description>
-                        <DisplayName>GeoStrata Marble Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaMarbleSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Marble distributions </Description>
-                        <DisplayName>GeoStrata Marble Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Marble Configuration UI Complete -->
-                
-                
-                <!-- Granite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaGraniteDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Granite is generated </Description> 
-                        <DisplayName>GeoStrata Granite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Granite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaGraniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Granite distributions </Description>
-                        <DisplayName>GeoStrata Granite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaGraniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Granite distributions </Description>
-                        <DisplayName>GeoStrata Granite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Granite Configuration UI Complete -->
-                
-                
-                <!-- Hornfel Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='gstaHornfelDist'  displayState='shown' displayGroup='groupGeoStrata'> 
-                        <Description> Controls how Hornfel is generated </Description> 
-                        <DisplayName>GeoStrata Hornfel</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Hornfel is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='gstaHornfelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Frequency multiplier for GeoStrata Hornfel distributions </Description>
-                        <DisplayName>GeoStrata Hornfel Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='gstaHornfelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
-                        <Description> Size multiplier for GeoStrata Hornfel distributions </Description>
-                        <DisplayName>GeoStrata Hornfel Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Hornfel Configuration UI Complete -->
-                
+                <OptionChoice name='gstaShaleDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Shale is generated </Description>
+                    <DisplayName>GeoStrata Shale</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Shale is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaShaleFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Shale distributions </Description>
+                    <DisplayName>GeoStrata Shale Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaShaleSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Shale distributions </Description>
+                    <DisplayName>GeoStrata Shale Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Shale Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='gstaOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='GeoStrata:geostrata_rock_shale_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_sandstone_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_limestone_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_pumice_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_opal_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_slate_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_gneiss_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_peridotite_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_granulite_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_migmatite_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_schist_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_basalt_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_onyx_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_quartz_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_marble_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_granite_smooth' />
-                    <Replaces block='GeoStrata:geostrata_rock_hornfel_smooth' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Shale Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Shale -->
-                <IfCondition condition=':= gstaShaleDist = "layeredVeins"'>
-                
-                    <Veins name='gstaShaleBaseVeins' block='GeoStrata:geostrata_rock_shale_smooth'  inherits='PresetLayeredVeins' >
+            <!-- Sandstone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaSandstoneDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Sandstone is generated </Description>
+                    <DisplayName>GeoStrata Sandstone</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60676970</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaShaleSize * _default_' range=':= 1 * 1 * gstaShaleSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaShaleSize * _default_' range=':= 1 * 1 * gstaShaleSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaShaleFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Shale Layered Veins) Settings -->
-                    <Veins name='gstaShalePrefersVeins' block='GeoStrata:geostrata_rock_shale_smooth'  inherits='gstaShaleBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60676970</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Shale Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Shale -->
-                
-                <!-- End Shale Generation --> 
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Sandstone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaSandstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Sandstone distributions </Description>
+                    <DisplayName>GeoStrata Sandstone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaSandstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Sandstone distributions </Description>
+                    <DisplayName>GeoStrata Sandstone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Sandstone Configuration UI Complete -->
 
-                
-                <!-- Begin Sandstone Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Sandstone -->
-                <IfCondition condition=':= gstaSandstoneDist = "layeredVeins"'>
-                
-                    <Veins name='gstaSandstoneBaseVeins' block='GeoStrata:geostrata_rock_sandstone_smooth'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BA9D80</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaSandstoneSize * _default_' range=':= 1 * 1 * gstaSandstoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaSandstoneSize * _default_' range=':= 1 * 1 * gstaSandstoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaSandstoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Sandstone Layered Veins) Settings -->
-                    <Veins name='gstaSandstonePrefersVeins' block='GeoStrata:geostrata_rock_sandstone_smooth'  inherits='gstaSandstoneBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BA9D80</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Sandstone Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Sandstone -->
-                
-                <!-- End Sandstone Generation --> 
 
-                
-                <!-- Begin Limestone Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Limestone -->
-                <IfCondition condition=':= gstaLimestoneDist = "layeredVeins"'>
-                
-                    <Veins name='gstaLimestoneBaseVeins' block='GeoStrata:geostrata_rock_limestone_smooth'  inherits='PresetLayeredVeins' >
+            <!-- Limestone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaLimestoneDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Limestone is generated </Description>
+                    <DisplayName>GeoStrata Limestone</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CBBFAD</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaLimestoneSize * _default_' range=':= 1 * 1 * gstaLimestoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaLimestoneSize * _default_' range=':= 1 * 1 * gstaLimestoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaLimestoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Limestone Layered Veins) Settings -->
-                    <Veins name='gstaLimestonePrefersVeins' block='GeoStrata:geostrata_rock_limestone_smooth'  inherits='gstaLimestoneBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CBBFAD</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Limestone Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Limestone -->
-                
-                <!-- End Limestone Generation --> 
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Limestone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaLimestoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Limestone distributions </Description>
+                    <DisplayName>GeoStrata Limestone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaLimestoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Limestone distributions </Description>
+                    <DisplayName>GeoStrata Limestone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Limestone Configuration UI Complete -->
 
-                
-                <!-- Begin Pumice Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Pumice -->
-                <IfCondition condition=':= gstaPumiceDist = "layeredVeins"'>
-                
-                    <Veins name='gstaPumiceBaseVeins' block='GeoStrata:geostrata_rock_pumice_smooth'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C4C1BA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaPumiceSize * _default_' range=':= 1 * 1 * gstaPumiceSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaPumiceSize * _default_' range=':= 1 * 1 * gstaPumiceSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaPumiceFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Pumice Layered Veins) Settings -->
-                    <Veins name='gstaPumicePrefersVeins' block='GeoStrata:geostrata_rock_pumice_smooth'  inherits='gstaPumiceBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C4C1BA</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Pumice Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Pumice -->
-                
-                <!-- End Pumice Generation --> 
 
-                
-                <!-- Begin Opal Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Opal -->
-                <IfCondition condition=':= gstaOpalDist = "layeredVeins"'>
-                
-                    <Veins name='gstaOpalBaseVeins' block='GeoStrata:geostrata_rock_opal_smooth'  inherits='PresetLayeredVeins' >
+            <!-- Pumice Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaPumiceDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Pumice is generated </Description>
+                    <DisplayName>GeoStrata Pumice</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CAFFFF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaOpalSize * _default_' range=':= 1 * 1 * gstaOpalSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaOpalSize * _default_' range=':= 1 * 1 * gstaOpalSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaOpalFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Opal Layered Veins) Settings -->
-                    <Veins name='gstaOpalPrefersVeins' block='GeoStrata:geostrata_rock_opal_smooth'  inherits='gstaOpalBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CAFFFF</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Opal Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Opal -->
-                
-                <!-- End Opal Generation --> 
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Pumice is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaPumiceFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Pumice distributions </Description>
+                    <DisplayName>GeoStrata Pumice Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaPumiceSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Pumice distributions </Description>
+                    <DisplayName>GeoStrata Pumice Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Pumice Configuration UI Complete -->
 
-                
-                <!-- Begin Slate Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Slate -->
-                <IfCondition condition=':= gstaSlateDist = "layeredVeins"'>
-                
-                    <Veins name='gstaSlateBaseVeins' block='GeoStrata:geostrata_rock_slate_smooth'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60494B53</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaSlateSize * _default_' range=':= 1 * 1 * gstaSlateSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaSlateSize * _default_' range=':= 1 * 1 * gstaSlateSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaSlateFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Slate Layered Veins) Settings -->
-                    <Veins name='gstaSlatePrefersVeins' block='GeoStrata:geostrata_rock_slate_smooth'  inherits='gstaSlateBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60494B53</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Slate Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Slate -->
-                
-                <!-- End Slate Generation --> 
 
-                
-                <!-- Begin Gneiss Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Gneiss -->
-                <IfCondition condition=':= gstaGneissDist = "layeredVeins"'>
-                
-                    <Veins name='gstaGneissBaseVeins' block='GeoStrata:geostrata_rock_gneiss_smooth'  inherits='PresetLayeredVeins' >
+            <!-- Opal Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaOpalDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Opal is generated </Description>
+                    <DisplayName>GeoStrata Opal</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BFBDBC</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaGneissSize * _default_' range=':= 1 * 1 * gstaGneissSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaGneissSize * _default_' range=':= 1 * 1 * gstaGneissSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaGneissFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Gneiss Layered Veins) Settings -->
-                    <Veins name='gstaGneissPrefersVeins' block='GeoStrata:geostrata_rock_gneiss_smooth'  inherits='gstaGneissBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BFBDBC</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Gneiss Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Gneiss -->
-                
-                <!-- End Gneiss Generation --> 
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Opal is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaOpalFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Opal distributions </Description>
+                    <DisplayName>GeoStrata Opal Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaOpalSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Opal distributions </Description>
+                    <DisplayName>GeoStrata Opal Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Opal Configuration UI Complete -->
 
-                
-                <!-- Begin Peridotite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Peridotite -->
-                <IfCondition condition=':= gstaPeridotiteDist = "layeredVeins"'>
-                
-                    <Veins name='gstaPeridotiteBaseVeins' block='GeoStrata:geostrata_rock_peridotite_smooth'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60617361</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaPeridotiteSize * _default_' range=':= 1 * 1 * gstaPeridotiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaPeridotiteSize * _default_' range=':= 1 * 1 * gstaPeridotiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaPeridotiteFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Peridotite Layered Veins) Settings -->
-                    <Veins name='gstaPeridotitePrefersVeins' block='GeoStrata:geostrata_rock_peridotite_smooth'  inherits='gstaPeridotiteBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60617361</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Peridotite Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Peridotite -->
-                
-                <!-- End Peridotite Generation --> 
 
-                
-                <!-- Begin Granulite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Granulite -->
-                <IfCondition condition=':= gstaGranuliteDist = "layeredVeins"'>
-                
-                    <Veins name='gstaGranuliteBaseVeins' block='GeoStrata:geostrata_rock_granulite_smooth'  inherits='PresetLayeredVeins' >
+            <!-- Slate Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaSlateDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Slate is generated </Description>
+                    <DisplayName>GeoStrata Slate</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60AEB3AB</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaGranuliteSize * _default_' range=':= 1 * 1 * gstaGranuliteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaGranuliteSize * _default_' range=':= 1 * 1 * gstaGranuliteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaGranuliteFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Granulite Layered Veins) Settings -->
-                    <Veins name='gstaGranulitePrefersVeins' block='GeoStrata:geostrata_rock_granulite_smooth'  inherits='gstaGranuliteBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60AEB3AB</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Granulite Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Granulite -->
-                
-                <!-- End Granulite Generation --> 
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Slate is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaSlateFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Slate distributions </Description>
+                    <DisplayName>GeoStrata Slate Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaSlateSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Slate distributions </Description>
+                    <DisplayName>GeoStrata Slate Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Slate Configuration UI Complete -->
 
-                
-                <!-- Begin Migmatite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Migmatite -->
-                <IfCondition condition=':= gstaMigmatiteDist = "layeredVeins"'>
-                
-                    <Veins name='gstaMigmatiteBaseVeins' block='GeoStrata:geostrata_rock_migmatite_smooth'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6092958C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaMigmatiteSize * _default_' range=':= 1 * 1 * gstaMigmatiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaMigmatiteSize * _default_' range=':= 1 * 1 * gstaMigmatiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaMigmatiteFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Migmatite Layered Veins) Settings -->
-                    <Veins name='gstaMigmatitePrefersVeins' block='GeoStrata:geostrata_rock_migmatite_smooth'  inherits='gstaMigmatiteBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6092958C</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Migmatite Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Migmatite -->
-                
-                <!-- End Migmatite Generation --> 
 
-                
-                <!-- Begin Schist Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Schist -->
-                <IfCondition condition=':= gstaSchistDist = "layeredVeins"'>
-                
-                    <Veins name='gstaSchistBaseVeins' block='GeoStrata:geostrata_rock_schist_smooth'  inherits='PresetLayeredVeins' >
+            <!-- Gneiss Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaGneissDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Gneiss is generated </Description>
+                    <DisplayName>GeoStrata Gneiss</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x604B4C52</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaSchistSize * _default_' range=':= 1 * 1 * gstaSchistSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaSchistSize * _default_' range=':= 1 * 1 * gstaSchistSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaSchistFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Schist Layered Veins) Settings -->
-                    <Veins name='gstaSchistPrefersVeins' block='GeoStrata:geostrata_rock_schist_smooth'  inherits='gstaSchistBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x604B4C52</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Schist Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Schist -->
-                
-                <!-- End Schist Generation --> 
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Gneiss is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaGneissFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Gneiss distributions </Description>
+                    <DisplayName>GeoStrata Gneiss Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaGneissSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Gneiss distributions </Description>
+                    <DisplayName>GeoStrata Gneiss Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Gneiss Configuration UI Complete -->
 
-                
-                <!-- Begin Basalt Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Basalt -->
-                <IfCondition condition=':= gstaBasaltDist = "layeredVeins"'>
-                
-                    <Veins name='gstaBasaltBaseVeins' block='GeoStrata:geostrata_rock_basalt_smooth'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60383844</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaBasaltSize * _default_' range=':= 1 * 1 * gstaBasaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaBasaltSize * _default_' range=':= 1 * 1 * gstaBasaltSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaBasaltFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Basalt Layered Veins) Settings -->
-                    <Veins name='gstaBasaltPrefersVeins' block='GeoStrata:geostrata_rock_basalt_smooth'  inherits='gstaBasaltBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60383844</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Basalt Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Basalt -->
-                
-                <!-- End Basalt Generation --> 
 
-                
-                <!-- Begin Onyx Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Onyx -->
-                <IfCondition condition=':= gstaOnyxDist = "layeredVeins"'>
-                
-                    <Veins name='gstaOnyxBaseVeins' block='GeoStrata:geostrata_rock_onyx_smooth'  inherits='PresetLayeredVeins' >
+            <!-- Peridotite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaPeridotiteDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Peridotite is generated </Description>
+                    <DisplayName>GeoStrata Peridotite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60303030</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaOnyxSize * _default_' range=':= 1 * 1 * gstaOnyxSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaOnyxSize * _default_' range=':= 1 * 1 * gstaOnyxSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaOnyxFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Onyx Layered Veins) Settings -->
-                    <Veins name='gstaOnyxPrefersVeins' block='GeoStrata:geostrata_rock_onyx_smooth'  inherits='gstaOnyxBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60303030</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Onyx Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Onyx -->
-                
-                <!-- End Onyx Generation --> 
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Peridotite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaPeridotiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Peridotite distributions </Description>
+                    <DisplayName>GeoStrata Peridotite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaPeridotiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Peridotite distributions </Description>
+                    <DisplayName>GeoStrata Peridotite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Peridotite Configuration UI Complete -->
 
-                
-                <!-- Begin Quartz Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Quartz -->
-                <IfCondition condition=':= gstaQuartzDist = "layeredVeins"'>
-                
-                    <Veins name='gstaQuartzBaseVeins' block='GeoStrata:geostrata_rock_quartz_smooth'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C9D2D9</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaQuartzSize * _default_' range=':= 1 * 1 * gstaQuartzSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaQuartzSize * _default_' range=':= 1 * 1 * gstaQuartzSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaQuartzFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Quartz Layered Veins) Settings -->
-                    <Veins name='gstaQuartzPrefersVeins' block='GeoStrata:geostrata_rock_quartz_smooth'  inherits='gstaQuartzBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C9D2D9</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Quartz Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Quartz -->
-                
-                <!-- End Quartz Generation --> 
 
-                
-                <!-- Begin Marble Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Marble -->
-                <IfCondition condition=':= gstaMarbleDist = "layeredVeins"'>
-                
-                    <Veins name='gstaMarbleBaseVeins' block='GeoStrata:geostrata_rock_marble_smooth'  inherits='PresetLayeredVeins' >
+            <!-- Granulite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaGranuliteDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Granulite is generated </Description>
+                    <DisplayName>GeoStrata Granulite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B4B4BC</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaMarbleSize * _default_' range=':= 1 * 1 * gstaMarbleSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaMarbleSize * _default_' range=':= 1 * 1 * gstaMarbleSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaMarbleFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Marble Layered Veins) Settings -->
-                    <Veins name='gstaMarblePrefersVeins' block='GeoStrata:geostrata_rock_marble_smooth'  inherits='gstaMarbleBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B4B4BC</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Marble Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Marble -->
-                
-                <!-- End Marble Generation --> 
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Granulite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaGranuliteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Granulite distributions </Description>
+                    <DisplayName>GeoStrata Granulite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaGranuliteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Granulite distributions </Description>
+                    <DisplayName>GeoStrata Granulite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Granulite Configuration UI Complete -->
 
-                
-                <!-- Begin Granite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Granite -->
-                <IfCondition condition=':= gstaGraniteDist = "layeredVeins"'>
-                
-                    <Veins name='gstaGraniteBaseVeins' block='GeoStrata:geostrata_rock_granite_smooth'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CA9C7F</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaGraniteSize * _default_' range=':= 1 * 1 * gstaGraniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaGraniteSize * _default_' range=':= 1 * 1 * gstaGraniteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaGraniteFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Granite Layered Veins) Settings -->
-                    <Veins name='gstaGranitePrefersVeins' block='GeoStrata:geostrata_rock_granite_smooth'  inherits='gstaGraniteBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CA9C7F</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Granite Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Granite -->
-                
-                <!-- End Granite Generation --> 
 
-                
-                <!-- Begin Hornfel Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Hornfel -->
-                <IfCondition condition=':= gstaHornfelDist = "layeredVeins"'>
-                
-                    <Veins name='gstaHornfelBaseVeins' block='GeoStrata:geostrata_rock_hornfel_smooth'  inherits='PresetLayeredVeins' >
+            <!-- Migmatite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaMigmatiteDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Migmatite is generated </Description>
+                    <DisplayName>GeoStrata Migmatite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A4A7B0</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * gstaHornfelSize * _default_' range=':= 1 * 1 * gstaHornfelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * gstaHornfelSize * _default_' range=':= 1 * 1 * gstaHornfelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * gstaHornfelFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Hornfel Layered Veins) Settings -->
-                    <Veins name='gstaHornfelPrefersVeins' block='GeoStrata:geostrata_rock_hornfel_smooth'  inherits='gstaHornfelBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A4A7B0</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Hornfel Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Hornfel -->
-                
-                <!-- End Hornfel Generation --> 
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Migmatite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaMigmatiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Migmatite distributions </Description>
+                    <DisplayName>GeoStrata Migmatite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaMigmatiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Migmatite distributions </Description>
+                    <DisplayName>GeoStrata Migmatite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Migmatite Configuration UI Complete -->
 
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
 
-        
+            <!-- Schist Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaSchistDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Schist is generated </Description>
+                    <DisplayName>GeoStrata Schist</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Schist is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaSchistFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Schist distributions </Description>
+                    <DisplayName>GeoStrata Schist Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaSchistSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Schist distributions </Description>
+                    <DisplayName>GeoStrata Schist Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Schist Configuration UI Complete -->
+
+
+            <!-- Basalt Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaBasaltDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Basalt is generated </Description>
+                    <DisplayName>GeoStrata Basalt</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Basalt is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaBasaltFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Basalt distributions </Description>
+                    <DisplayName>GeoStrata Basalt Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaBasaltSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Basalt distributions </Description>
+                    <DisplayName>GeoStrata Basalt Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Basalt Configuration UI Complete -->
+
+
+            <!-- Onyx Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaOnyxDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Onyx is generated </Description>
+                    <DisplayName>GeoStrata Onyx</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Onyx is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaOnyxFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Onyx distributions </Description>
+                    <DisplayName>GeoStrata Onyx Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaOnyxSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Onyx distributions </Description>
+                    <DisplayName>GeoStrata Onyx Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Onyx Configuration UI Complete -->
+
+
+            <!-- Quartz Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaQuartzDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Quartz is generated </Description>
+                    <DisplayName>GeoStrata Quartz</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Quartz is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Quartz distributions </Description>
+                    <DisplayName>GeoStrata Quartz Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaQuartzSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Quartz distributions </Description>
+                    <DisplayName>GeoStrata Quartz Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Quartz Configuration UI Complete -->
+
+
+            <!-- Marble Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaMarbleDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Marble is generated </Description>
+                    <DisplayName>GeoStrata Marble</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Marble is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaMarbleFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Marble distributions </Description>
+                    <DisplayName>GeoStrata Marble Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaMarbleSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Marble distributions </Description>
+                    <DisplayName>GeoStrata Marble Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Marble Configuration UI Complete -->
+
+
+            <!-- Granite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaGraniteDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Granite is generated </Description>
+                    <DisplayName>GeoStrata Granite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Granite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaGraniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Granite distributions </Description>
+                    <DisplayName>GeoStrata Granite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaGraniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Granite distributions </Description>
+                    <DisplayName>GeoStrata Granite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Granite Configuration UI Complete -->
+
+
+            <!-- Hornfel Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='gstaHornfelDist'  displayState='shown' displayGroup='groupGeoStrata'>
+                    <Description> Controls how Hornfel is generated </Description>
+                    <DisplayName>GeoStrata Hornfel</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Hornfel is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='gstaHornfelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Frequency multiplier for GeoStrata Hornfel distributions </Description>
+                    <DisplayName>GeoStrata Hornfel Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='gstaHornfelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupGeoStrata'>
+                    <Description> Size multiplier for GeoStrata Hornfel distributions </Description>
+                    <DisplayName>GeoStrata Hornfel Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Hornfel Configuration UI Complete -->
+
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='gstaOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
+                <Replaces block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Shale Generation -->
+
+            <!-- Starting LayeredVeins Preset for Shale. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaShaleDist = "LayeredVeins"'>
+                    <Veins name='gstaShaleVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaShaleFreq ' range=':=  _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 56 ' range=':=  8 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Shale is complete. -->
+
+
+            <!-- Starting Cloud Preset for Shale. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaShaleDist = "Cloud"'>
+                    <Cloud name='gstaShaleCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaShaleFreq ' range=':=  _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 56 ' range=':=  8 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaShaleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Shale is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Shale. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaShaleDist = "Vanilla"'>
+                    <StandardGen name='gstaShaleStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 24 * gstaShaleFreq ' range=':=  _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 56 ' range=':=  8 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Shale is complete. -->
+
+            <!-- End Shale Generation -->
+
+
+            <!-- Begin Sandstone Generation -->
+
+            <!-- Starting LayeredVeins Preset for Sandstone. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaSandstoneDist = "LayeredVeins"'>
+                    <Veins name='gstaSandstoneVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaSandstoneFreq ' range=':=  _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Sandstone is complete. -->
+
+
+            <!-- Starting Cloud Preset for Sandstone. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaSandstoneDist = "Cloud"'>
+                    <Cloud name='gstaSandstoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaSandstoneFreq ' range=':=  _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaSandstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Sandstone is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Sandstone. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaSandstoneDist = "Vanilla"'>
+                    <StandardGen name='gstaSandstoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= _default_ * gstaSandstoneFreq ' range=':=  _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Sandstone is complete. -->
+
+            <!-- End Sandstone Generation -->
+
+
+            <!-- Begin Limestone Generation -->
+
+            <!-- Starting LayeredVeins Preset for Limestone. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaLimestoneDist = "LayeredVeins"'>
+                    <Veins name='gstaLimestoneVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaLimestoneFreq ' range=':=  _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Limestone is complete. -->
+
+
+            <!-- Starting Cloud Preset for Limestone. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaLimestoneDist = "Cloud"'>
+                    <Cloud name='gstaLimestoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaLimestoneFreq ' range=':=  _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaLimestoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Limestone is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Limestone. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaLimestoneDist = "Vanilla"'>
+                    <StandardGen name='gstaLimestoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= _default_ * gstaLimestoneFreq ' range=':=  _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Limestone is complete. -->
+
+            <!-- End Limestone Generation -->
+
+
+            <!-- Begin Pumice Generation -->
+
+            <!-- Starting LayeredVeins Preset for Pumice. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaPumiceDist = "LayeredVeins"'>
+                    <Veins name='gstaPumiceVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaPumiceFreq ' range=':=  _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Pumice is complete. -->
+
+
+            <!-- Starting Cloud Preset for Pumice. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaPumiceDist = "Cloud"'>
+                    <Cloud name='gstaPumiceCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaPumiceFreq ' range=':=  _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaPumiceHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Pumice is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Pumice. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaPumiceDist = "Vanilla"'>
+                    <StandardGen name='gstaPumiceStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 14.4 * gstaPumiceFreq ' range=':=  _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Pumice is complete. -->
+
+            <!-- End Pumice Generation -->
+
+
+            <!-- Begin Opal Generation -->
+
+            <!-- Starting LayeredVeins Preset for Opal. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaOpalDist = "LayeredVeins"'>
+                    <Veins name='gstaOpalVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.161 * _default_ * gstaOpalFreq ' range=':=  _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.051 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.051 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.051 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Opal is complete. -->
+
+
+            <!-- Starting Cloud Preset for Opal. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaOpalDist = "Cloud"'>
+                    <Cloud name='gstaOpalCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.522 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.522 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * gstaOpalFreq ' range=':=  _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaOpalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Opal is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Opal. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaOpalDist = "Vanilla"'>
+                    <StandardGen name='gstaOpalStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * gstaOpalFreq ' range=':=  _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Opal is complete. -->
+
+            <!-- End Opal Generation -->
+
+
+            <!-- Begin Slate Generation -->
+
+            <!-- Starting LayeredVeins Preset for Slate. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaSlateDist = "LayeredVeins"'>
+                    <Veins name='gstaSlateVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaSlateFreq ' range=':=  _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  8 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Slate is complete. -->
+
+
+            <!-- Starting Cloud Preset for Slate. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaSlateDist = "Cloud"'>
+                    <Cloud name='gstaSlateCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaSlateFreq ' range=':=  _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  8 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaSlateHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Slate is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Slate. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaSlateDist = "Vanilla"'>
+                    <StandardGen name='gstaSlateStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 24 * gstaSlateFreq ' range=':=  _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 40 ' range=':=  8 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Slate is complete. -->
+
+            <!-- End Slate Generation -->
+
+
+            <!-- Begin Gneiss Generation -->
+
+            <!-- Starting LayeredVeins Preset for Gneiss. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaGneissDist = "LayeredVeins"'>
+                    <Veins name='gstaGneissVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaGneissFreq ' range=':=  _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Gneiss is complete. -->
+
+
+            <!-- Starting Cloud Preset for Gneiss. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaGneissDist = "Cloud"'>
+                    <Cloud name='gstaGneissCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaGneissFreq ' range=':=  _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaGneissHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Gneiss is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Gneiss. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaGneissDist = "Vanilla"'>
+                    <StandardGen name='gstaGneissStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 19.2 * gstaGneissFreq ' range=':=  _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Gneiss is complete. -->
+
+            <!-- End Gneiss Generation -->
+
+
+            <!-- Begin Peridotite Generation -->
+
+            <!-- Starting LayeredVeins Preset for Peridotite. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaPeridotiteDist = "LayeredVeins"'>
+                    <Veins name='gstaPeridotiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaPeridotiteFreq ' range=':=  _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Peridotite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Peridotite. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaPeridotiteDist = "Cloud"'>
+                    <Cloud name='gstaPeridotiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaPeridotiteFreq ' range=':=  _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaPeridotiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Peridotite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Peridotite. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaPeridotiteDist = "Vanilla"'>
+                    <StandardGen name='gstaPeridotiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 14.4 * gstaPeridotiteFreq ' range=':=  _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Peridotite is complete. -->
+
+            <!-- End Peridotite Generation -->
+
+
+            <!-- Begin Granulite Generation -->
+
+            <!-- Starting LayeredVeins Preset for Granulite. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaGranuliteDist = "LayeredVeins"'>
+                    <Veins name='gstaGranuliteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.746 * _default_ * gstaGranuliteFreq ' range=':=  _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.4 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.4 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.4 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Granulite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Granulite. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaGranuliteDist = "Cloud"'>
+                    <Cloud name='gstaGranuliteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.342 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.342 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 5.483  * _default_ * gstaGranuliteFreq ' range=':=  _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaGranuliteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Granulite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Granulite. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaGranuliteDist = "Vanilla"'>
+                    <StandardGen name='gstaGranuliteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 16.8 * gstaGranuliteFreq ' range=':=  _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Granulite is complete. -->
+
+            <!-- End Granulite Generation -->
+
+
+            <!-- Begin Migmatite Generation -->
+
+            <!-- Starting LayeredVeins Preset for Migmatite. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaMigmatiteDist = "LayeredVeins"'>
+                    <Veins name='gstaMigmatiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaMigmatiteFreq ' range=':=  _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Migmatite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Migmatite. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaMigmatiteDist = "Cloud"'>
+                    <Cloud name='gstaMigmatiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaMigmatiteFreq ' range=':=  _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaMigmatiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Migmatite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Migmatite. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaMigmatiteDist = "Vanilla"'>
+                    <StandardGen name='gstaMigmatiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 14.4 * gstaMigmatiteFreq ' range=':=  _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Migmatite is complete. -->
+
+            <!-- End Migmatite Generation -->
+
+
+            <!-- Begin Schist Generation -->
+
+            <!-- Starting LayeredVeins Preset for Schist. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaSchistDist = "LayeredVeins"'>
+                    <Veins name='gstaSchistVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaSchistFreq ' range=':=  _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Schist is complete. -->
+
+
+            <!-- Starting Cloud Preset for Schist. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaSchistDist = "Cloud"'>
+                    <Cloud name='gstaSchistCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaSchistFreq ' range=':=  _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaSchistHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Schist is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Schist. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaSchistDist = "Vanilla"'>
+                    <StandardGen name='gstaSchistStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 19.2 * gstaSchistFreq ' range=':=  _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Schist is complete. -->
+
+            <!-- End Schist Generation -->
+
+
+            <!-- Begin Basalt Generation -->
+
+            <!-- Starting LayeredVeins Preset for Basalt. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaBasaltDist = "LayeredVeins"'>
+                    <Veins name='gstaBasaltVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaBasaltFreq ' range=':=  _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Basalt is complete. -->
+
+
+            <!-- Starting Cloud Preset for Basalt. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaBasaltDist = "Cloud"'>
+                    <Cloud name='gstaBasaltCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaBasaltFreq ' range=':=  _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaBasaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Basalt is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Basalt. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaBasaltDist = "Vanilla"'>
+                    <StandardGen name='gstaBasaltStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 24 * gstaBasaltFreq ' range=':=  _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Basalt is complete. -->
+
+            <!-- End Basalt Generation -->
+
+
+            <!-- Begin Onyx Generation -->
+
+            <!-- Starting LayeredVeins Preset for Onyx. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaOnyxDist = "LayeredVeins"'>
+                    <Veins name='gstaOnyxVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaOnyxFreq ' range=':=  _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Onyx is complete. -->
+
+
+            <!-- Starting Cloud Preset for Onyx. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaOnyxDist = "Cloud"'>
+                    <Cloud name='gstaOnyxCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaOnyxFreq ' range=':=  _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaOnyxHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Onyx is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Onyx. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaOnyxDist = "Vanilla"'>
+                    <StandardGen name='gstaOnyxStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 24 * gstaOnyxFreq ' range=':=  _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Onyx is complete. -->
+
+            <!-- End Onyx Generation -->
+
+
+            <!-- Begin Quartz Generation -->
+
+            <!-- Starting LayeredVeins Preset for Quartz. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaQuartzDist = "LayeredVeins"'>
+                    <Veins name='gstaQuartzVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.321 * _default_ * gstaQuartzFreq ' range=':=  _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.324 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.324 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.324 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Quartz is complete. -->
+
+
+            <!-- Starting Cloud Preset for Quartz. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaQuartzDist = "Cloud"'>
+                    <Cloud name='gstaQuartzCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.153 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.153 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 4.634  * _default_ * gstaQuartzFreq ' range=':=  _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaQuartzHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Quartz is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Quartz. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaQuartzDist = "Vanilla"'>
+                    <StandardGen name='gstaQuartzStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 12 * gstaQuartzFreq ' range=':=  _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Quartz is complete. -->
+
+            <!-- End Quartz Generation -->
+
+
+            <!-- Begin Marble Generation -->
+
+            <!-- Starting LayeredVeins Preset for Marble. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaMarbleDist = "LayeredVeins"'>
+                    <Veins name='gstaMarbleVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaMarbleFreq ' range=':=  _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  24 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Marble is complete. -->
+
+
+            <!-- Starting Cloud Preset for Marble. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaMarbleDist = "Cloud"'>
+                    <Cloud name='gstaMarbleCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaMarbleFreq ' range=':=  _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  24 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaMarbleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Marble is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Marble. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaMarbleDist = "Vanilla"'>
+                    <StandardGen name='gstaMarbleStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 24 * gstaMarbleFreq ' range=':=  _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 40 ' range=':=  24 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Marble is complete. -->
+
+            <!-- End Marble Generation -->
+
+
+            <!-- Begin Granite Generation -->
+
+            <!-- Starting LayeredVeins Preset for Granite. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaGraniteDist = "LayeredVeins"'>
+                    <Veins name='gstaGraniteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaGraniteFreq ' range=':=  _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Granite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Granite. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaGraniteDist = "Cloud"'>
+                    <Cloud name='gstaGraniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaGraniteFreq ' range=':=  _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaGraniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Granite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Granite. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaGraniteDist = "Vanilla"'>
+                    <StandardGen name='gstaGraniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 24 * gstaGraniteFreq ' range=':=  _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Granite is complete. -->
+
+            <!-- End Granite Generation -->
+
+
+            <!-- Begin Hornfel Generation -->
+
+            <!-- Starting LayeredVeins Preset for Hornfel. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaHornfelDist = "LayeredVeins"'>
+                    <Veins name='gstaHornfelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaHornfelFreq ' range=':=  _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Hornfel is complete. -->
+
+
+            <!-- Starting Cloud Preset for Hornfel. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaHornfelDist = "Cloud"'>
+                    <Cloud name='gstaHornfelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaHornfelFreq ' range=':=  _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='gstaHornfelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Hornfel is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Hornfel. -->
+            <ConfigSection>
+                <IfCondition condition=':= gstaHornfelDist = "Vanilla"'>
+                    <StandardGen name='gstaHornfelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 32 * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 19.2 * gstaHornfelFreq ' range=':=  _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Hornfel is complete. -->
+
+            <!-- End Hornfel Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "GeoStrata" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/Mekanism.xml
+++ b/src/main/resources/config/modules/Mekanism.xml
@@ -25,10 +25,15 @@
                     Distribution options for Mekanism Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableMekanism' displayName='Handle Mekanism Setup?' default='true' displayState='shown_dynamic' displayGroup='groupMekanism'>
+                <Description> Should Custom Ore Generation handle Mekanism ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Mekanism ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Mekanism ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Osmium Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mknsOsmiumDist'  displayState='shown' displayGroup='groupMekanism'>
+                <OptionChoice name='mknsOsmiumDist'  displayState=':= if(?enableMekanism, "shown", "hidden")' displayGroup='groupMekanism'>
                     <Description> Controls how Osmium is generated </Description>
                     <DisplayName>Mekanism Osmium</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -48,11 +53,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Osmium is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mknsOsmiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMekanism'>
+                <OptionNumeric name='mknsOsmiumFreq' default='1'  min='0' max='5' displayState=':= if(?enableMekanism, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMekanism'>
                     <Description> Frequency multiplier for Mekanism Osmium distributions </Description>
                     <DisplayName>Mekanism Osmium Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mknsOsmiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMekanism'>
+                <OptionNumeric name='mknsOsmiumSize' default='1'  min='0' max='5' displayState=':= if(?enableMekanism, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMekanism'>
                     <Description> Size multiplier for Mekanism Osmium distributions </Description>
                     <DisplayName>Mekanism Osmium Size</DisplayName>
                 </OptionNumeric>
@@ -62,7 +67,7 @@
 
             <!-- Copper Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mknsCopperDist'  displayState='shown' displayGroup='groupMekanism'>
+                <OptionChoice name='mknsCopperDist'  displayState=':= if(?enableMekanism, "shown", "hidden")' displayGroup='groupMekanism'>
                     <Description> Controls how Copper is generated </Description>
                     <DisplayName>Mekanism Copper</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -82,11 +87,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mknsCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMekanism'>
+                <OptionNumeric name='mknsCopperFreq' default='1'  min='0' max='5' displayState=':= if(?enableMekanism, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMekanism'>
                     <Description> Frequency multiplier for Mekanism Copper distributions </Description>
                     <DisplayName>Mekanism Copper Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mknsCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMekanism'>
+                <OptionNumeric name='mknsCopperSize' default='1'  min='0' max='5' displayState=':= if(?enableMekanism, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMekanism'>
                     <Description> Size multiplier for Mekanism Copper distributions </Description>
                     <DisplayName>Mekanism Copper Size</DisplayName>
                 </OptionNumeric>
@@ -96,7 +101,7 @@
 
             <!-- Tin Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mknsTinDist'  displayState='shown' displayGroup='groupMekanism'>
+                <OptionChoice name='mknsTinDist'  displayState=':= if(?enableMekanism, "shown", "hidden")' displayGroup='groupMekanism'>
                     <Description> Controls how Tin is generated </Description>
                     <DisplayName>Mekanism Tin</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -116,11 +121,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mknsTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMekanism'>
+                <OptionNumeric name='mknsTinFreq' default='1'  min='0' max='5' displayState=':= if(?enableMekanism, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMekanism'>
                     <Description> Frequency multiplier for Mekanism Tin distributions </Description>
                     <DisplayName>Mekanism Tin Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mknsTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMekanism'>
+                <OptionNumeric name='mknsTinSize' default='1'  min='0' max='5' displayState=':= if(?enableMekanism, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMekanism'>
                     <Description> Size multiplier for Mekanism Tin distributions </Description>
                     <DisplayName>Mekanism Tin Size</DisplayName>
                 </OptionNumeric>
@@ -130,390 +135,401 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableMekanism'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='mknsOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='Mekanism:OreBlock' weight='1.0' />
-                <Replaces block='Mekanism:OreBlock:1' weight='1.0' />
-                <Replaces block='Mekanism:OreBlock:2' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Osmium Generation -->
-
-            <!-- Starting LayeredVeins Preset for Osmium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mknsOsmiumDist = "LayeredVeins"'>
-                    <Veins name='mknsOsmiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='mknsOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='Mekanism:OreBlock' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.161 * _default_ * mknsOsmiumFreq ' range=':=  _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.051 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.051 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.051 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <Replaces block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <Replaces block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <Replaces block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Osmium is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Osmium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mknsOsmiumDist = "Cloud"'>
-                    <Cloud name='mknsOsmiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Mekanism:OreBlock' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.522 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.522 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * mknsOsmiumFreq ' range=':=  _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mknsOsmiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Osmium Generation -->
+
+                <!-- Starting LayeredVeins Preset for Osmium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mknsOsmiumDist = "LayeredVeins"'>
+                        <Veins name='mknsOsmiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='Mekanism:OreBlock' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.161 * _default_ * mknsOsmiumFreq ' range=':=  _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.051 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.051 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.051 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Osmium is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Osmium is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Osmium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mknsOsmiumDist = "Vanilla"'>
-                    <StandardGen name='mknsOsmiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Mekanism:OreBlock' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * mknsOsmiumFreq ' range=':=  _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Osmium is complete. -->
-
-            <!-- End Osmium Generation -->
-
-
-            <!-- Begin Copper Generation -->
-
-            <!-- Starting LayeredVeins Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= mknsCopperDist = "LayeredVeins"'>
-                    <Veins name='mknsCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * mknsCopperFreq ' range=':=  _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Copper is complete. -->
-
-
-            <!-- Starting Cloud Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= mknsCopperDist = "Cloud"'>
-                    <Cloud name='mknsCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.636 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.636 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * mknsCopperFreq ' range=':=  _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mknsCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
+                <!-- Starting Cloud Preset for Osmium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mknsOsmiumDist = "Cloud"'>
+                        <Cloud name='mknsOsmiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Copper is complete. -->
+                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.522 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.522 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * mknsOsmiumFreq ' range=':=  _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mknsOsmiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Osmium is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= mknsCopperDist = "Vanilla"'>
-                    <StandardGen name='mknsCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 16 * mknsCopperFreq ' range=':=  _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Copper is complete. -->
-
-            <!-- End Copper Generation -->
-
-
-            <!-- Begin Tin Generation -->
-
-            <!-- Starting LayeredVeins Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= mknsTinDist = "LayeredVeins"'>
-                    <Veins name='mknsTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.254 * _default_ * mknsTinFreq ' range=':=  _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.078 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.078 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.078 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Tin is complete. -->
-
-
-            <!-- Starting Cloud Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= mknsTinDist = "Cloud"'>
-                    <Cloud name='mknsTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.582 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.582 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.503  * _default_ * mknsTinFreq ' range=':=  _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mknsTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
+                <!-- Starting Vanilla Preset for Osmium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mknsOsmiumDist = "Vanilla"'>
+                        <StandardGen name='mknsOsmiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12 * mknsOsmiumFreq ' range=':=  _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Osmium is complete. -->
+
+                <!-- End Osmium Generation -->
+
+
+                <!-- Begin Copper Generation -->
+
+                <!-- Starting LayeredVeins Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mknsCopperDist = "LayeredVeins"'>
+                        <Veins name='mknsCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * mknsCopperFreq ' range=':=  _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Tin is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= mknsTinDist = "Vanilla"'>
-                    <StandardGen name='mknsTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 14 * mknsTinFreq ' range=':=  _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Tin is complete. -->
+                <!-- Starting Cloud Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mknsCopperDist = "Cloud"'>
+                        <Cloud name='mknsCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * mknsCopperFreq ' range=':=  _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mknsCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Copper is complete. -->
 
-            <!-- End Tin Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mknsCopperDist = "Vanilla"'>
+                        <StandardGen name='mknsCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16 * mknsCopperFreq ' range=':=  _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Copper is complete. -->
+
+                <!-- End Copper Generation -->
+
+
+                <!-- Begin Tin Generation -->
+
+                <!-- Starting LayeredVeins Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mknsTinDist = "LayeredVeins"'>
+                        <Veins name='mknsTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.254 * _default_ * mknsTinFreq ' range=':=  _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.078 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.078 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.078 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Tin is complete. -->
+
+
+                <!-- Starting Cloud Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mknsTinDist = "Cloud"'>
+                        <Cloud name='mknsTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.582 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.582 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.503  * _default_ * mknsTinFreq ' range=':=  _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mknsTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tin is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mknsTinDist = "Vanilla"'>
+                        <StandardGen name='mknsTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 14 * mknsTinFreq ' range=':=  _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tin is complete. -->
+
+                <!-- End Tin Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/Mekanism.xml
+++ b/src/main/resources/config/modules/Mekanism.xml
@@ -1,333 +1,534 @@
-<!--*********************  CustomOreGen ThermalExpansion Ores Module ******************************
-*
-*   This file contains settings for the Mekanism (Mek) ores:
-*       Copper, Osmium, Tin
-*
-***********************************************************************************************-->
+<!-- =================================================================
+     Custom Ore Generation "Mekanism" Module: This configuration
+     covers osmium, copper, and tin.
+     ================================================================= -->
+
+
+
+
+
+
+<!-- Is the "Mekanism" mod on the system?  Let's find out! -->
 <IfModInstalled name="Mekanism">
 
-    <!--***************************   Options + Symbols   ***********************************
-    *
-    *   Below are options and symbols for each ore, similar to those for the standard ores.
-    *
-    *************************************************************************************-->
-    <ConfigSection>                
-    
-        <OptionDisplayGroup name="groupMek" displayName="Mekanism" displayState="shown">
-            <Description> 
-                Distribution options for the Mek ores.
-            </Description>
-        </OptionDisplayGroup>
-       
-        <!--*******************   Osmium   *********************-->
-        <ConfigSection>
-            
-            <OptionChoice name="mekOsmiumDist" displayState="shown" displayGroup="groupMek">
-                <Description> Controls how Mek Osmium is generated </Description>
-                <DisplayName>Mek Osmium Type</DisplayName>
-                <Default>layeredVeins</Default>
-                <Choice value="layeredVeins" displayValue="Veins">
-                    <Description> 
-                        Long, narrow groups of veins found about one third of the way down to bedrock.  More common in jungles and mountains.  
-                    </Description>
-                </Choice>
-                <Choice value="strategicClouds" displayValue="Clouds">
-                    <Description> 
-                        Rare, sparsely populated clouds of ore extending over several chunks.  Found only in jungles and mountains.
-                    </Description>
-                </Choice>
-                <Choice value="vanillaStdGen" displayValue="Clusters">
-                    <Description> 
-                        Small clusters of ore scattered below sea level.  This is the default Mek Osmium generation.
-                    </Description>
-                </Choice>
-                <Choice value="none" displayValue="None" description="No Osmium is generated at all."/>
-            </OptionChoice>
-            
-            <OptionNumeric name="mekOsmiumFreq" default="1" min="0" max="5" displayState=":= if(?advOptions,&quot;shown&quot;,&quot;hidden&quot;)" displayGroup="groupMek">
-                <Description> Frequency multiplier for Mek Osmium distributions </Description>
-                <DisplayName>Mek Osmium Freq.</DisplayName>
-            </OptionNumeric>
-            
-            <OptionNumeric name="mekOsmiumSize" default="1" min="0" max="5" displayState=":= if(?advOptions,&quot;shown&quot;,&quot;hidden&quot;)" displayGroup="groupMek">
-                <Description> Size multiplier for Mek Osmium distributions </Description>
-                <DisplayName>Mek Osmium Size</DisplayName>
-            </OptionNumeric>
-            
-        </ConfigSection>           
-	   
-        <!--*******************   Copper   *********************-->
-        <ConfigSection>
-            
-            <OptionChoice name="mekCopperDist" displayState="shown" displayGroup="groupMek">
-                <Description> Controls how Mek Copper is generated </Description>
-                <DisplayName>Mek Copper Type</DisplayName>
-                <Default>layeredVeins</Default>
-                <Choice value="layeredVeins" displayValue="Veins">
-                    <Description> 
-                        Groups of long narrow veins found about one third of the way down to bedrock.  Especially common in jungles.  
-                    </Description>
-                </Choice>
-                <Choice value="strategicClouds" displayValue="Clouds">
-                    <Description> 
-                        Rare, sparsely populated clouds of ore extending over several chunks.  Found only in jungles.
-                    </Description>
-                </Choice>
-                <Choice value="vanillaStdGen" displayValue="Clusters">
-                    <Description> 
-                        Small clusters of ore scattered below sea level.  This is the default Mek copper generation.
-                    </Description>
-                </Choice>
-                <Choice value="none" displayValue="None" description="No copper is generated at all."/>
-            </OptionChoice>
-            
-            <OptionNumeric name="mekCopperFreq" default="1" min="0" max="5" displayState=":= if(?advOptions,&quot;shown&quot;,&quot;hidden&quot;)" displayGroup="groupMek">
-                <Description> Frequency multiplier for Mek Copper distributions </Description>
-                <DisplayName>Mek Copper Freq.</DisplayName>
-            </OptionNumeric>
-            
-            <OptionNumeric name="mekCopperSize" default="1" min="0" max="5" displayState=":= if(?advOptions,&quot;shown&quot;,&quot;hidden&quot;)" displayGroup="groupMek">
-                <Description> Size multiplier for Mek Copper distributions </Description>
-                <DisplayName>Mek Copper Size</DisplayName>
-            </OptionNumeric>
-            
-        </ConfigSection>           
-        
-        <!--********************   Tin   ***********************-->
-        <ConfigSection>
-            
-            <OptionChoice name="mekTinDist" displayState="shown" displayGroup="groupMek">
-                <Description> Controls how Mek Tin is generated </Description>
-                <DisplayName>Mek Tin Type</DisplayName>
-                <Default>layeredVeins</Default>
-                <Choice value="layeredVeins" displayValue="Veins">
-                    <Description> 
-                        Groups of long narrow veins found about halfway down to bedrock.  More frequent in grassy plains.  
-                    </Description>
-                </Choice>
-                <Choice value="strategicClouds" displayValue="Clouds">
-                    <Description> 
-                        Rare, sparsely populated clouds of ore extending over several chunks.  Found only in grassy plains.
-                    </Description>
-                </Choice>
-                <Choice value="vanillaStdGen" displayValue="Clusters">
-                    <Description> 
-                        Small clusters of ore scattered below sea level.  This is the default Mek tin generation.
-                    </Description>
-                </Choice>
-                <Choice value="none" displayValue="None" description="No tin is generated at all."/>
-            </OptionChoice>
-            
-            <OptionNumeric name="mekTinFreq" default="1" min="0" max="5" displayState=":= if(?advOptions,&quot;shown&quot;,&quot;hidden&quot;)" displayGroup="groupMek">
-                <Description> Frequency multiplier for Mek Tin distributions </Description>
-                <DisplayName>Mek Tin Freq.</DisplayName>
-            </OptionNumeric>
-            
-            <OptionNumeric name="mekTinSize" default="1" min="0" max="5" displayState=":= if(?advOptions,&quot;shown&quot;,&quot;hidden&quot;)" displayGroup="groupMek">
-                <Description> Size multiplier for Mek Tin distributions </Description>
-                <DisplayName>Mek Tin Size</DisplayName>
-            </OptionNumeric>  
-            
-        </ConfigSection>           
-        
-     </ConfigSection>    
-   
-    <!--*****************************   Distributions   *************************************
-    *   
-    *   Below are the actual distributions for the overworld and mystcraft ages.
-    *
-    *************************************************************************************-->
-    <IfCondition condition=":= ?COGActive">
-        
-        <Substitute name="MekSubstitute" block="minecraft:stone">
-            <Description> 
-                Replace Mekanism-generated ore clusters with stone.   
-            </Description>
-            <Comment>  
-                The global option deferredPopulationRange must be large enough to catch all ore clusters (&gt;= 32).
-            </Comment>
-            <Replaces block="Mekanism:OreBlock"/> 
-        </Substitute>
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
 
-        
-        <!--*******************   Osmium Distribution   *********************-->            
-        <ConfigSection>
-        
-            <IfCondition condition=":= if(age, age.mekOsmiumClusters &gt; 0, mekOsmiumDist = &quot;vanillaStdGen&quot;)">
-                <StandardGen name="MekOsmiumStandard" block="Mekanism:OreBlock:0" inherits="PresetStandardGen"> 
-                    <Description> Equivalent to regular Mekanism Osmium distribution </Description>
-                    <DrawWireframe>:=drawWireframes</DrawWireframe>
-                    <WireframeColor>0x400099FF</WireframeColor> 
-                    <Setting name="Size" avg=":= mekOsmiumSize * _default_"/> 
-                    <Setting name="Frequency" avg=":= 2/5 * mekOsmiumFreq * if(age,age.mekOsmiumClusters,1) * _default_" range=":= 3 * mekOsmiumFreq * if(age,age.mekOsmiumClusters,1)"/>
-                    <Setting name="Height" avg=":= 57/64 * dimension.groundLevel" range=":= 17/64 * dimension.groundLevel" type="uniform"/> 
-                </StandardGen>
-            </IfCondition>   
-            
-            <IfCondition condition=":= if(age, age.mekOsmiumVeins &gt; 0, mekOsmiumDist = &quot;layeredVeins&quot;)">             
-                <Veins name="MekOsmiumVeins" block="Mekanism:OreBlock:0" inherits="PresetLayeredVeins">
-                    <Description>  Average veins in the 25-85 range. </Description> 
-                    <DrawWireframe>:=drawWireframes</DrawWireframe>
-                    <WireframeColor>0x400099FF</WireframeColor> 
-                    <Setting name="MotherlodeFrequency" avg=":= 0.9 * mekOsmiumFreq * if(age,age.mekOsmiumVeins,1) * _default_"/>
-                    <Setting name="MotherlodeSize" avg=":= 0.9 * mekOsmiumSize * _default_" range=":= 0.9 * mekOsmiumSize * _default_"/>
-                    <Setting name="MotherlodeHeight" avg=":= 45/64 * dimension.groundLevel" range=":= 50/64 * dimension.groundLevel" type="normal"/>
-                    <Setting name="BranchFrequency" avg=":= 0.95 * _default_" range=":= 0.95 * _default_"/>
-                    <Setting name="BranchLength" avg=":= 0.95 * mekOsmiumSize * _default_"/>
-                    <Setting name="BranchHeightLimit" avg="12"/>
-                    <Setting name="SegmentRadius" avg=":= 0.95 * mekOsmiumSize * _default_" range=":= 0.95 * mekOsmiumSize * _default_"/>
-                </Veins>                
-                <Veins name="MekOsmiumBiomeVeins" inherits="MekOsmiumVeins">
-                    <Description> This roughly triples the chance of finding Osmium in jungle and mountain biomes. </Description> 
-                    <Setting name="MotherlodeFrequency" avg=":= 2 * _default_"/>
-                    <Setting name="MotherlodeHeight" avg=":=_default_" range=":= 2 * _default_"/>
-                    <Setting name="BranchHeightLimit" avg=":= 2 * _default_"/>  
-                    <BiomeType name="Jungle"/>
-					<BiomeType name="Mountain"/>
-                </Veins>   
-            </IfCondition>     
-            
-            <IfCondition condition=":= if(age, age.mekOsmiumClouds &gt; 0, mekOsmiumDist = &quot;strategicClouds&quot;)">
-                <Cloud name="MekOsmiumBiomeCloud" block="Mekanism:OreBlock:0" inherits="PresetStrategicCloud">
-                    <Description>  
-                        Diffuse Osmium cloud surrounded by single-block "hint" veins, found in jungle and mountain biomes.
-                    </Description> 
-                    <DrawWireframe>:=drawWireframes</DrawWireframe>
-                    <WireframeColor>0x400099FF</WireframeColor> 
-                    <Setting name="DistributionFrequency" avg=":= 2.5 * mekOsmiumFreq * if(age,age.mekOsmiumClouds,1) * _default_"/>
-                    <Setting name="CloudRadius" avg=":= 0.95 * mekOsmiumSize * _default_" range=":= 0.95 * mekOsmiumSize * _default_"/>
-                    <Setting name="CloudThickness" avg=":= 0.95 * mekOsmiumSize * _default_" range=":= mekOsmiumSize * _default_"/> 
-                    <BiomeType name="Jungle"/>
-					<BiomeType name="Mountain"/>
-                    <Veins name="MekOsmiumHintVeins" block="Mekanism:OreBlock:0" inherits="PresetHintVeins">
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x400099FF</WireframeColor> 
-                        <Setting name="MotherlodeFrequency" avg=":= _default_" range=":= _default_"/>   
-                        <Setting name="MotherlodeRangeLimit" avg=":= mekOsmiumSize * _default_" range=":= mekOsmiumSize * _default_"/>
-                    </Veins>
-                </Cloud>
-            </IfCondition>  
-            
-        </ConfigSection>
 
-        <!--*******************   Copper Distribution   *********************-->            
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            <IfCondition condition=":= if(age, age.mekCopperClusters &gt; 0, mekCopperDist = &quot;vanillaStdGen&quot;)">
-                <StandardGen name="MekCopperStandard" block="Mekanism:OreBlock:1" inherits="PresetStandardGen"> 
-                    <Description> Equivalent to regular Mekanism copper distribution </Description>
-                    <DrawWireframe>:=drawWireframes</DrawWireframe>
-                    <WireframeColor>0x40773300</WireframeColor> 
-                    <Setting name="Size" avg=":= mekCopperSize * _default_"/> 
-                    <Setting name="Frequency" avg=":= 2/5 * mekCopperFreq * if(age,age.mekCopperClusters,1) * _default_" range=":= 3 * mekCopperFreq * if(age,age.mekCopperClusters,1)"/>
-                    <Setting name="Height" avg=":= 57/64 * dimension.groundLevel" range=":= 17/64 * dimension.groundLevel" type="uniform"/> 
-                </StandardGen>
-            </IfCondition>   
-            
-            <IfCondition condition=":= if(age, age.mekCopperVeins &gt; 0, mekCopperDist = &quot;layeredVeins&quot;)">             
-                <Veins name="MekCopperVeins" block="Mekanism:OreBlock:1" inherits="PresetLayeredVeins">
-                    <Description>  Average veins in the 25-85 range. </Description> 
-                    <DrawWireframe>:=drawWireframes</DrawWireframe>
-                    <WireframeColor>0x40773300</WireframeColor> 
-                    <Setting name="MotherlodeFrequency" avg=":= 0.9 * mekCopperFreq * if(age,age.mekCopperVeins,1) * _default_"/>
-                    <Setting name="MotherlodeSize" avg=":= 0.9 * mekCopperSize * _default_" range=":= 0.9 * mekCopperSize * _default_"/>
-                    <Setting name="MotherlodeHeight" avg=":= 45/64 * dimension.groundLevel" range=":= 10/64 * dimension.groundLevel" type="normal"/>
-                    <Setting name="BranchFrequency" avg=":= 0.95 * _default_" range=":= 0.95 * _default_"/>
-                    <Setting name="BranchLength" avg=":= 0.95 * mekCopperSize * _default_"/>
-                    <Setting name="BranchHeightLimit" avg="12"/>
-                    <Setting name="SegmentRadius" avg=":= 0.95 * mekCopperSize * _default_" range=":= 0.95 * mekCopperSize * _default_"/>
-                </Veins>                
-                <Veins name="MekCopperVeinsJungle" inherits="MekCopperVeins">
-                    <Description> This roughly triples the chance of finding Copper in jungle biomes. </Description> 
-                    <Setting name="MotherlodeFrequency" avg=":= 2 * _default_"/>
-                    <Setting name="MotherlodeHeight" avg=":=_default_" range=":= 2 * _default_"/>
-                    <Setting name="BranchHeightLimit" avg=":= 2 * _default_"/>  
-                    <BiomeType name="Jungle"/>
-                </Veins>   
-            </IfCondition>     
-            
-            <IfCondition condition=":= if(age, age.mekCopperClouds &gt; 0, mekCopperDist = &quot;strategicClouds&quot;)">
-                <Cloud name="MekCopperCloud" block="Mekanism:OreBlock:1" inherits="PresetStrategicCloud">
-                    <Description>  
-                        Diffuse copper cloud surrounded by single-block "hint" veins, found in jungle biomes.
-                    </Description> 
-                    <DrawWireframe>:=drawWireframes</DrawWireframe>
-                    <WireframeColor>0x40773300</WireframeColor> 
-                    <Setting name="DistributionFrequency" avg=":= 2.5 * mekCopperFreq * if(age,age.mekCopperClouds,1) * _default_"/>
-                    <Setting name="CloudRadius" avg=":= 0.95 * mekCopperSize * _default_" range=":= 0.95 * mekCopperSize * _default_"/>
-                    <Setting name="CloudThickness" avg=":= 0.95 * mekCopperSize * _default_" range=":= mekCopperSize * _default_"/> 
-                    <BiomeType name="Jungle"/>
-                    <Veins name="MekCopperHintVeins" block="Mekanism:OreBlock:1" inherits="PresetHintVeins">
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x40773300</WireframeColor> 
-                        <Setting name="MotherlodeFrequency" avg=":= _default_" range=":= _default_"/>   
-                        <Setting name="MotherlodeRangeLimit" avg=":= mekCopperSize * _default_" range=":= mekCopperSize * _default_"/>
-                    </Veins>
-                </Cloud>
-            </IfCondition>  
-            
+            <OptionDisplayGroup name='groupMekanism' displayName='Mekanism' displayState='shown'>
+                <Description>
+                    Distribution options for Mekanism Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Osmium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mknsOsmiumDist'  displayState='shown' displayGroup='groupMekanism'>
+                    <Description> Controls how Osmium is generated </Description>
+                    <DisplayName>Mekanism Osmium</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Osmium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mknsOsmiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMekanism'>
+                    <Description> Frequency multiplier for Mekanism Osmium distributions </Description>
+                    <DisplayName>Mekanism Osmium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mknsOsmiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMekanism'>
+                    <Description> Size multiplier for Mekanism Osmium distributions </Description>
+                    <DisplayName>Mekanism Osmium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Osmium Configuration UI Complete -->
+
+
+            <!-- Copper Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mknsCopperDist'  displayState='shown' displayGroup='groupMekanism'>
+                    <Description> Controls how Copper is generated </Description>
+                    <DisplayName>Mekanism Copper</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mknsCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMekanism'>
+                    <Description> Frequency multiplier for Mekanism Copper distributions </Description>
+                    <DisplayName>Mekanism Copper Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mknsCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMekanism'>
+                    <Description> Size multiplier for Mekanism Copper distributions </Description>
+                    <DisplayName>Mekanism Copper Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Copper Configuration UI Complete -->
+
+
+            <!-- Tin Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mknsTinDist'  displayState='shown' displayGroup='groupMekanism'>
+                    <Description> Controls how Tin is generated </Description>
+                    <DisplayName>Mekanism Tin</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mknsTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMekanism'>
+                    <Description> Frequency multiplier for Mekanism Tin distributions </Description>
+                    <DisplayName>Mekanism Tin Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mknsTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMekanism'>
+                    <Description> Size multiplier for Mekanism Tin distributions </Description>
+                    <DisplayName>Mekanism Tin Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Tin Configuration UI Complete -->
+
         </ConfigSection>
-        
-        <!--********************   Tin Distribution   ***********************-->            
-        <ConfigSection>
-        
-            <IfCondition condition=":= if(age, age.mekTinClusters &gt; 0, mekTinDist = &quot;vanillaStdGen&quot;)">            
-                <StandardGen name="MekTinStandard" block="Mekanism:OreBlock:2" inherits="PresetStandardGen"> 
-                    <Description> Equivalent to regular Mekanism tin distribution </Description>
-                    <DrawWireframe>:=drawWireframes</DrawWireframe>
-                    <WireframeColor>0x40FFFFFF</WireframeColor> 
-                    <Setting name="Size" avg=":= mekTinSize * _default_"/> 
-                    <Setting name="Frequency" avg=":= 0.3 * mekTinFreq * if(age,age.mekTinClusters,1) * _default_" range=":= 2.5 * mekTinFreq * if(age,age.mekTinClusters,1)"/>
-                    <Setting name="Height" avg=":= 37/64 * dimension.groundLevel" range=":= 17/64 * dimension.groundLevel" type="uniform"/> 
-                </StandardGen>
-            </IfCondition>   
-            
-            <IfCondition condition=":= if(age, age.mekTinVeins &gt; 0, mekTinDist = &quot;layeredVeins&quot;)">    
-                <Veins name="MekTinVeins" block="Mekanism:OreBlock:2" inherits="PresetLayeredVeins">
-                    <Description> 
-                        Average veins in the 20-60 range.
-                    </Description> 
-                    <DrawWireframe>:=drawWireframes</DrawWireframe>
-                    <WireframeColor>0x40FFFFFF</WireframeColor> 
-                    <Setting name="MotherlodeFrequency" avg=":= 0.85 * mekTinFreq * if(age,age.mekTinVeins,1) * _default_"/>
-                    <Setting name="MotherlodeSize" avg=":= 0.85 * mekTinSize * _default_" range=":= 0.85 * mekTinSize * _default_"/>
-                    <Setting name="MotherlodeHeight" avg=":= 30/64 * dimension.groundLevel" range=":= 11/64 * dimension.groundLevel" type="normal"/>
-                    <Setting name="BranchHeightLimit" avg="11"/>
-                    <Setting name="BranchFrequency" avg=":= 0.9 * _default_"/>
-                    <Setting name="BranchLength" avg=":= 0.9 * _default_"/>
-                    <Setting name="SegmentRadius" avg=":= 0.9 * mekTinSize * _default_" range=":= 0.9 * mekTinSize * _default_"/>
-                </Veins>
-                <Veins name="MekTinVeinsPlains" inherits="MekTinVeins">
-                    <Description> This roughly triples the chance of finding tin in grassy plains. </Description> 
-                    <Setting name="MotherlodeFrequency" avg=":= 2 * _default_"/>
-                    <Setting name="MotherlodeHeight" avg=":=_default_" range=":= 2 * _default_"/>
-                    <Setting name="BranchHeightLimit" avg=":= 2 * _default_"/>  
-                    <BiomeType name="Plains"/>
-                </Veins>
-            </IfCondition>     
-            
-            <IfCondition condition=":= if(age, age.mekTinClouds &gt; 0, mekTinDist = &quot;strategicClouds&quot;)">
-                <Cloud name="MekTinCloud" block="Mekanism:OreBlock:2" inherits="PresetStrategicCloud">
-                    <Description>  
-                        Diffuse tin cloud surrounded by single-block "hint" veins, found in grassy plains.
-                    </Description> 
-                    <DrawWireframe>:=drawWireframes</DrawWireframe>
-                    <WireframeColor>0x40FFFFFF</WireframeColor> 
-                    <Setting name="DistributionFrequency" avg=":= 2.5 * mekTinFreq * if(age,age.mekTinClouds,1) * _default_"/>
-                    <Setting name="CloudRadius" avg=":= 0.9 * mekTinSize * _default_" range=":= 0.9 * mekTinSize * _default_"/>
-                    <Setting name="CloudThickness" avg=":= 0.9 * mekTinSize * _default_" range=":= mekTinSize * _default_"/> 
-                    <BiomeType name="Plains"/>
-                    <Veins name="MekTinHintVeins" block="Mekanism:OreBlock:2" inherits="PresetHintVeins">
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x40FFFFFF</WireframeColor> 
-                        <Setting name="MotherlodeFrequency" avg=":= 0.8 * _default_" range=":= _default_"/>
-                        <Setting name="MotherlodeRangeLimit" avg=":= 0.95 * mekTinSize * _default_" range=":= 0.9 * mekTinSize * _default_"/>
+        <!-- Setup Screen Complete -->
+
+
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='mknsOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='Mekanism:OreBlock' weight='1.0' />
+                <Replaces block='Mekanism:OreBlock:1' weight='1.0' />
+                <Replaces block='Mekanism:OreBlock:2' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Osmium Generation -->
+
+            <!-- Starting LayeredVeins Preset for Osmium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mknsOsmiumDist = "LayeredVeins"'>
+                    <Veins name='mknsOsmiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Mekanism:OreBlock' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.161 * _default_ * mknsOsmiumFreq ' range=':=  _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.051 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.051 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.051 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-                </Cloud>
-            </IfCondition>  
-            
-        </ConfigSection>
-        
-    </IfCondition>
-    
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Osmium is complete. -->
+
+
+            <!-- Starting Cloud Preset for Osmium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mknsOsmiumDist = "Cloud"'>
+                    <Cloud name='mknsOsmiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Mekanism:OreBlock' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.522 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.522 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * mknsOsmiumFreq ' range=':=  _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mknsOsmiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Mekanism:OreBlock' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Osmium is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Osmium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mknsOsmiumDist = "Vanilla"'>
+                    <StandardGen name='mknsOsmiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Mekanism:OreBlock' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 12 * mknsOsmiumFreq ' range=':=  _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Osmium is complete. -->
+
+            <!-- End Osmium Generation -->
+
+
+            <!-- Begin Copper Generation -->
+
+            <!-- Starting LayeredVeins Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= mknsCopperDist = "LayeredVeins"'>
+                    <Veins name='mknsCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * mknsCopperFreq ' range=':=  _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Copper is complete. -->
+
+
+            <!-- Starting Cloud Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= mknsCopperDist = "Cloud"'>
+                    <Cloud name='mknsCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.636 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.636 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * mknsCopperFreq ' range=':=  _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mknsCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Copper is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= mknsCopperDist = "Vanilla"'>
+                    <StandardGen name='mknsCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 16 * mknsCopperFreq ' range=':=  _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Copper is complete. -->
+
+            <!-- End Copper Generation -->
+
+
+            <!-- Begin Tin Generation -->
+
+            <!-- Starting LayeredVeins Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= mknsTinDist = "LayeredVeins"'>
+                    <Veins name='mknsTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.254 * _default_ * mknsTinFreq ' range=':=  _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.078 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.078 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.078 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Tin is complete. -->
+
+
+            <!-- Starting Cloud Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= mknsTinDist = "Cloud"'>
+                    <Cloud name='mknsTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.582 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.582 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.503  * _default_ * mknsTinFreq ' range=':=  _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mknsTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Tin is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= mknsTinDist = "Vanilla"'>
+                    <StandardGen name='mknsTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 14 * mknsTinFreq ' range=':=  _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Tin is complete. -->
+
+            <!-- End Tin Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
 </IfModInstalled>
+<!-- The "Mekanism" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -33,10 +33,15 @@
                     Distribution options for Metallurgy 4 Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableMetallurgy4' displayName='Handle Metallurgy 4 Setup?' default='true' displayState='shown_dynamic' displayGroup='groupMetallurgy4'>
+                <Description> Should Custom Ore Generation handle Metallurgy 4 ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Metallurgy 4 ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Metallurgy 4 ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Sulfur Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgSulfurDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgSulfurDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Sulfur is generated </Description>
                     <DisplayName>Metallurgy 4 Sulfur</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -56,11 +61,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Sulfur is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgSulfurFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgSulfurFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Sulfur distributions </Description>
                     <DisplayName>Metallurgy 4 Sulfur Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgSulfurSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgSulfurSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Sulfur distributions </Description>
                     <DisplayName>Metallurgy 4 Sulfur Size</DisplayName>
                 </OptionNumeric>
@@ -70,7 +75,7 @@
 
             <!-- Phosphorite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgPhosphoriteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgPhosphoriteDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Phosphorite is generated </Description>
                     <DisplayName>Metallurgy 4 Phosphorite</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -90,11 +95,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Phosphorite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgPhosphoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgPhosphoriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Phosphorite distributions </Description>
                     <DisplayName>Metallurgy 4 Phosphorite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgPhosphoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgPhosphoriteSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Phosphorite distributions </Description>
                     <DisplayName>Metallurgy 4 Phosphorite Size</DisplayName>
                 </OptionNumeric>
@@ -104,7 +109,7 @@
 
             <!-- Saltpeter Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgSaltpeterDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgSaltpeterDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Saltpeter is generated </Description>
                     <DisplayName>Metallurgy 4 Saltpeter</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -124,11 +129,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Saltpeter is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgSaltpeterFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgSaltpeterFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Saltpeter distributions </Description>
                     <DisplayName>Metallurgy 4 Saltpeter Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgSaltpeterSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgSaltpeterSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Saltpeter distributions </Description>
                     <DisplayName>Metallurgy 4 Saltpeter Size</DisplayName>
                 </OptionNumeric>
@@ -138,7 +143,7 @@
 
             <!-- Magnesium Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgMagnesiumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgMagnesiumDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Magnesium is generated </Description>
                     <DisplayName>Metallurgy 4 Magnesium</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -158,11 +163,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Magnesium is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgMagnesiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgMagnesiumFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Magnesium distributions </Description>
                     <DisplayName>Metallurgy 4 Magnesium Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgMagnesiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgMagnesiumSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Magnesium distributions </Description>
                     <DisplayName>Metallurgy 4 Magnesium Size</DisplayName>
                 </OptionNumeric>
@@ -172,7 +177,7 @@
 
             <!-- Bitumen Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgBitumenDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgBitumenDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Bitumen is generated </Description>
                     <DisplayName>Metallurgy 4 Bitumen</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -192,11 +197,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Bitumen is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgBitumenFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgBitumenFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Bitumen distributions </Description>
                     <DisplayName>Metallurgy 4 Bitumen Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgBitumenSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgBitumenSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Bitumen distributions </Description>
                     <DisplayName>Metallurgy 4 Bitumen Size</DisplayName>
                 </OptionNumeric>
@@ -206,7 +211,7 @@
 
             <!-- Potash Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgPotashDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgPotashDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Potash is generated </Description>
                     <DisplayName>Metallurgy 4 Potash</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -226,11 +231,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Potash is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgPotashFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgPotashFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Potash distributions </Description>
                     <DisplayName>Metallurgy 4 Potash Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgPotashSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgPotashSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Potash distributions </Description>
                     <DisplayName>Metallurgy 4 Potash Size</DisplayName>
                 </OptionNumeric>
@@ -240,7 +245,7 @@
 
             <!-- Copper Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgCopperDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgCopperDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Copper is generated </Description>
                     <DisplayName>Metallurgy 4 Copper</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -260,11 +265,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgCopperFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Copper distributions </Description>
                     <DisplayName>Metallurgy 4 Copper Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgCopperSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Copper distributions </Description>
                     <DisplayName>Metallurgy 4 Copper Size</DisplayName>
                 </OptionNumeric>
@@ -274,7 +279,7 @@
 
             <!-- Tin Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgTinDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgTinDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Tin is generated </Description>
                     <DisplayName>Metallurgy 4 Tin</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -294,11 +299,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgTinFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Tin distributions </Description>
                     <DisplayName>Metallurgy 4 Tin Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgTinSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Tin distributions </Description>
                     <DisplayName>Metallurgy 4 Tin Size</DisplayName>
                 </OptionNumeric>
@@ -308,7 +313,7 @@
 
             <!-- Manganese Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgManganeseDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgManganeseDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Manganese is generated </Description>
                     <DisplayName>Metallurgy 4 Manganese</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -328,11 +333,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Manganese is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgManganeseFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgManganeseFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Manganese distributions </Description>
                     <DisplayName>Metallurgy 4 Manganese Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgManganeseSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgManganeseSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Manganese distributions </Description>
                     <DisplayName>Metallurgy 4 Manganese Size</DisplayName>
                 </OptionNumeric>
@@ -342,7 +347,7 @@
 
             <!-- Zinc Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgZincDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgZincDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Zinc is generated </Description>
                     <DisplayName>Metallurgy 4 Zinc</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -362,11 +367,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Zinc is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgZincFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgZincFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Zinc distributions </Description>
                     <DisplayName>Metallurgy 4 Zinc Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgZincSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgZincSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Zinc distributions </Description>
                     <DisplayName>Metallurgy 4 Zinc Size</DisplayName>
                 </OptionNumeric>
@@ -376,7 +381,7 @@
 
             <!-- Silver Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgSilverDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgSilverDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Silver is generated </Description>
                     <DisplayName>Metallurgy 4 Silver</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -396,11 +401,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgSilverFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Silver distributions </Description>
                     <DisplayName>Metallurgy 4 Silver Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgSilverSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Silver distributions </Description>
                     <DisplayName>Metallurgy 4 Silver Size</DisplayName>
                 </OptionNumeric>
@@ -410,7 +415,7 @@
 
             <!-- Platinum Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgPlatinumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgPlatinumDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Platinum is generated </Description>
                     <DisplayName>Metallurgy 4 Platinum</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -430,11 +435,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Platinum is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgPlatinumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgPlatinumFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Platinum distributions </Description>
                     <DisplayName>Metallurgy 4 Platinum Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgPlatinumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgPlatinumSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Platinum distributions </Description>
                     <DisplayName>Metallurgy 4 Platinum Size</DisplayName>
                 </OptionNumeric>
@@ -444,7 +449,7 @@
 
             <!-- Promethium Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgPromethiumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgPromethiumDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Promethium is generated </Description>
                     <DisplayName>Metallurgy 4 Promethium</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -464,11 +469,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Promethium is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgPromethiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgPromethiumFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Promethium distributions </Description>
                     <DisplayName>Metallurgy 4 Promethium Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgPromethiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgPromethiumSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Promethium distributions </Description>
                     <DisplayName>Metallurgy 4 Promethium Size</DisplayName>
                 </OptionNumeric>
@@ -478,7 +483,7 @@
 
             <!-- Deep Iron Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgDeepIronDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgDeepIronDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Deep Iron is generated </Description>
                     <DisplayName>Metallurgy 4 Deep Iron</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -498,11 +503,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Deep Iron is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgDeepIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgDeepIronFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Deep Iron distributions </Description>
                     <DisplayName>Metallurgy 4 Deep Iron Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgDeepIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgDeepIronSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Deep Iron distributions </Description>
                     <DisplayName>Metallurgy 4 Deep Iron Size</DisplayName>
                 </OptionNumeric>
@@ -512,7 +517,7 @@
 
             <!-- Infuscolium Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgInfuscoliumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgInfuscoliumDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Infuscolium is generated </Description>
                     <DisplayName>Metallurgy 4 Infuscolium</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -532,11 +537,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Infuscolium is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgInfuscoliumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgInfuscoliumFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Infuscolium distributions </Description>
                     <DisplayName>Metallurgy 4 Infuscolium Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgInfuscoliumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgInfuscoliumSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Infuscolium distributions </Description>
                     <DisplayName>Metallurgy 4 Infuscolium Size</DisplayName>
                 </OptionNumeric>
@@ -546,7 +551,7 @@
 
             <!-- Oureclase Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgOureclaseDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgOureclaseDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Oureclase is generated </Description>
                     <DisplayName>Metallurgy 4 Oureclase</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -566,11 +571,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Oureclase is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgOureclaseFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgOureclaseFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Oureclase distributions </Description>
                     <DisplayName>Metallurgy 4 Oureclase Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgOureclaseSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgOureclaseSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Oureclase distributions </Description>
                     <DisplayName>Metallurgy 4 Oureclase Size</DisplayName>
                 </OptionNumeric>
@@ -580,7 +585,7 @@
 
             <!-- Astral Silver Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgAstralSilverDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgAstralSilverDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Astral Silver is generated </Description>
                     <DisplayName>Metallurgy 4 Astral Silver</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -600,11 +605,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Astral Silver is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgAstralSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgAstralSilverFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Astral Silver distributions </Description>
                     <DisplayName>Metallurgy 4 Astral Silver Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgAstralSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgAstralSilverSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Astral Silver distributions </Description>
                     <DisplayName>Metallurgy 4 Astral Silver Size</DisplayName>
                 </OptionNumeric>
@@ -614,7 +619,7 @@
 
             <!-- Carmot Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgCarmotDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgCarmotDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Carmot is generated </Description>
                     <DisplayName>Metallurgy 4 Carmot</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -634,11 +639,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Carmot is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgCarmotFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgCarmotFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Carmot distributions </Description>
                     <DisplayName>Metallurgy 4 Carmot Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgCarmotSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgCarmotSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Carmot distributions </Description>
                     <DisplayName>Metallurgy 4 Carmot Size</DisplayName>
                 </OptionNumeric>
@@ -648,7 +653,7 @@
 
             <!-- Mithril Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgMithrilDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgMithrilDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Mithril is generated </Description>
                     <DisplayName>Metallurgy 4 Mithril</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -668,11 +673,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Mithril is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgMithrilFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgMithrilFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Mithril distributions </Description>
                     <DisplayName>Metallurgy 4 Mithril Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgMithrilSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgMithrilSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Mithril distributions </Description>
                     <DisplayName>Metallurgy 4 Mithril Size</DisplayName>
                 </OptionNumeric>
@@ -682,7 +687,7 @@
 
             <!-- Rubracium Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgRubraciumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgRubraciumDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Rubracium is generated </Description>
                     <DisplayName>Metallurgy 4 Rubracium</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -702,11 +707,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Rubracium is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgRubraciumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgRubraciumFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Rubracium distributions </Description>
                     <DisplayName>Metallurgy 4 Rubracium Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgRubraciumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgRubraciumSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Rubracium distributions </Description>
                     <DisplayName>Metallurgy 4 Rubracium Size</DisplayName>
                 </OptionNumeric>
@@ -716,7 +721,7 @@
 
             <!-- Orichalcum Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgOrichalcumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgOrichalcumDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Orichalcum is generated </Description>
                     <DisplayName>Metallurgy 4 Orichalcum</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -736,11 +741,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Orichalcum is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgOrichalcumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgOrichalcumFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Orichalcum distributions </Description>
                     <DisplayName>Metallurgy 4 Orichalcum Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgOrichalcumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgOrichalcumSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Orichalcum distributions </Description>
                     <DisplayName>Metallurgy 4 Orichalcum Size</DisplayName>
                 </OptionNumeric>
@@ -750,7 +755,7 @@
 
             <!-- Adamantine Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgAdamantineDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgAdamantineDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Adamantine is generated </Description>
                     <DisplayName>Metallurgy 4 Adamantine</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -770,11 +775,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Adamantine is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgAdamantineFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgAdamantineFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Adamantine distributions </Description>
                     <DisplayName>Metallurgy 4 Adamantine Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgAdamantineSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgAdamantineSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Adamantine distributions </Description>
                     <DisplayName>Metallurgy 4 Adamantine Size</DisplayName>
                 </OptionNumeric>
@@ -784,7 +789,7 @@
 
             <!-- Atlarus Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgAtlarusDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgAtlarusDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Atlarus is generated </Description>
                     <DisplayName>Metallurgy 4 Atlarus</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -804,11 +809,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Atlarus is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgAtlarusFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgAtlarusFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Atlarus distributions </Description>
                     <DisplayName>Metallurgy 4 Atlarus Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgAtlarusSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgAtlarusSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Atlarus distributions </Description>
                     <DisplayName>Metallurgy 4 Atlarus Size</DisplayName>
                 </OptionNumeric>
@@ -818,7 +823,7 @@
 
             <!-- Ignatius Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgIgnatiusDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgIgnatiusDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Ignatius is generated </Description>
                     <DisplayName>Metallurgy 4 Ignatius</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -838,11 +843,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Ignatius is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgIgnatiusFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgIgnatiusFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Ignatius distributions </Description>
                     <DisplayName>Metallurgy 4 Ignatius Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgIgnatiusSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgIgnatiusSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Ignatius distributions </Description>
                     <DisplayName>Metallurgy 4 Ignatius Size</DisplayName>
                 </OptionNumeric>
@@ -852,7 +857,7 @@
 
             <!-- Shadow Iron Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgShadowIronDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgShadowIronDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Shadow Iron is generated </Description>
                     <DisplayName>Metallurgy 4 Shadow Iron</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -872,11 +877,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Shadow Iron is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgShadowIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgShadowIronFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Shadow Iron distributions </Description>
                     <DisplayName>Metallurgy 4 Shadow Iron Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgShadowIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgShadowIronSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Shadow Iron distributions </Description>
                     <DisplayName>Metallurgy 4 Shadow Iron Size</DisplayName>
                 </OptionNumeric>
@@ -886,7 +891,7 @@
 
             <!-- Lemurite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgLemuriteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgLemuriteDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Lemurite is generated </Description>
                     <DisplayName>Metallurgy 4 Lemurite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -906,11 +911,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Lemurite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgLemuriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgLemuriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Lemurite distributions </Description>
                     <DisplayName>Metallurgy 4 Lemurite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgLemuriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgLemuriteSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Lemurite distributions </Description>
                     <DisplayName>Metallurgy 4 Lemurite Size</DisplayName>
                 </OptionNumeric>
@@ -920,7 +925,7 @@
 
             <!-- Midasium Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgMidasiumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgMidasiumDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Midasium is generated </Description>
                     <DisplayName>Metallurgy 4 Midasium</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -940,11 +945,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Midasium is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgMidasiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgMidasiumFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Midasium distributions </Description>
                     <DisplayName>Metallurgy 4 Midasium Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgMidasiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgMidasiumSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Midasium distributions </Description>
                     <DisplayName>Metallurgy 4 Midasium Size</DisplayName>
                 </OptionNumeric>
@@ -954,7 +959,7 @@
 
             <!-- Vyroxeres Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgVyroxeresDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgVyroxeresDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Vyroxeres is generated </Description>
                     <DisplayName>Metallurgy 4 Vyroxeres</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -974,11 +979,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Vyroxeres is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgVyroxeresFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgVyroxeresFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Vyroxeres distributions </Description>
                     <DisplayName>Metallurgy 4 Vyroxeres Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgVyroxeresSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgVyroxeresSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Vyroxeres distributions </Description>
                     <DisplayName>Metallurgy 4 Vyroxeres Size</DisplayName>
                 </OptionNumeric>
@@ -988,7 +993,7 @@
 
             <!-- Ceruclase Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgCeruclaseDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgCeruclaseDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Ceruclase is generated </Description>
                     <DisplayName>Metallurgy 4 Ceruclase</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -1008,11 +1013,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Ceruclase is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgCeruclaseFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgCeruclaseFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Ceruclase distributions </Description>
                     <DisplayName>Metallurgy 4 Ceruclase Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgCeruclaseSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgCeruclaseSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Ceruclase distributions </Description>
                     <DisplayName>Metallurgy 4 Ceruclase Size</DisplayName>
                 </OptionNumeric>
@@ -1022,7 +1027,7 @@
 
             <!-- Alduorite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgAlduoriteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgAlduoriteDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Alduorite is generated </Description>
                     <DisplayName>Metallurgy 4 Alduorite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -1042,11 +1047,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Alduorite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgAlduoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgAlduoriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Alduorite distributions </Description>
                     <DisplayName>Metallurgy 4 Alduorite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgAlduoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgAlduoriteSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Alduorite distributions </Description>
                     <DisplayName>Metallurgy 4 Alduorite Size</DisplayName>
                 </OptionNumeric>
@@ -1056,7 +1061,7 @@
 
             <!-- Kalendrite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgKalendriteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgKalendriteDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Kalendrite is generated </Description>
                     <DisplayName>Metallurgy 4 Kalendrite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -1076,11 +1081,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Kalendrite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgKalendriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgKalendriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Kalendrite distributions </Description>
                     <DisplayName>Metallurgy 4 Kalendrite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgKalendriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgKalendriteSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Kalendrite distributions </Description>
                     <DisplayName>Metallurgy 4 Kalendrite Size</DisplayName>
                 </OptionNumeric>
@@ -1090,7 +1095,7 @@
 
             <!-- Vulcanite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgVulcaniteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgVulcaniteDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Vulcanite is generated </Description>
                     <DisplayName>Metallurgy 4 Vulcanite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -1110,11 +1115,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Vulcanite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgVulcaniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgVulcaniteFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Vulcanite distributions </Description>
                     <DisplayName>Metallurgy 4 Vulcanite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgVulcaniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgVulcaniteSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Vulcanite distributions </Description>
                     <DisplayName>Metallurgy 4 Vulcanite Size</DisplayName>
                 </OptionNumeric>
@@ -1124,7 +1129,7 @@
 
             <!-- Sanguinite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgSanguiniteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgSanguiniteDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Sanguinite is generated </Description>
                     <DisplayName>Metallurgy 4 Sanguinite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -1144,11 +1149,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Sanguinite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgSanguiniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgSanguiniteFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Sanguinite distributions </Description>
                     <DisplayName>Metallurgy 4 Sanguinite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgSanguiniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgSanguiniteSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Sanguinite distributions </Description>
                     <DisplayName>Metallurgy 4 Sanguinite Size</DisplayName>
                 </OptionNumeric>
@@ -1158,7 +1163,7 @@
 
             <!-- Eximite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgEximiteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgEximiteDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Eximite is generated </Description>
                     <DisplayName>Metallurgy 4 Eximite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -1178,11 +1183,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Eximite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgEximiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgEximiteFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Eximite distributions </Description>
                     <DisplayName>Metallurgy 4 Eximite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgEximiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgEximiteSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Eximite distributions </Description>
                     <DisplayName>Metallurgy 4 Eximite Size</DisplayName>
                 </OptionNumeric>
@@ -1192,7 +1197,7 @@
 
             <!-- Meutoite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mtlgMeutoiteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                <OptionChoice name='mtlgMeutoiteDist'  displayState=':= if(?enableMetallurgy4, "shown", "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Controls how Meutoite is generated </Description>
                     <DisplayName>Metallurgy 4 Meutoite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -1212,11 +1217,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Meutoite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mtlgMeutoiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgMeutoiteFreq' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Frequency multiplier for Metallurgy 4 Meutoite distributions </Description>
                     <DisplayName>Metallurgy 4 Meutoite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mtlgMeutoiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                <OptionNumeric name='mtlgMeutoiteSize' default='1'  min='0' max='5' displayState=':= if(?enableMetallurgy4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMetallurgy4'>
                     <Description> Size multiplier for Metallurgy 4 Meutoite distributions </Description>
                     <DisplayName>Metallurgy 4 Meutoite Size</DisplayName>
                 </OptionNumeric>
@@ -1226,4246 +1231,4334 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableMetallurgy4'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='mtlgOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='Metallurgy:base.ore' weight='1.0' />
-                <Replaces block='Metallurgy:base.ore:1' weight='1.0' />
-                <Replaces block='Metallurgy:base.ore:2' weight='1.0' />
-                <Replaces block='Metallurgy:fantasy.ore' weight='1.0' />
-                <Replaces block='Metallurgy:fantasy.ore:1' weight='1.0' />
-                <Replaces block='Metallurgy:fantasy.ore:11' weight='1.0' />
-                <Replaces block='Metallurgy:fantasy.ore:13' weight='1.0' />
-                <Replaces block='Metallurgy:fantasy.ore:14' weight='1.0' />
-                <Replaces block='Metallurgy:fantasy.ore:2' weight='1.0' />
-                <Replaces block='Metallurgy:fantasy.ore:4' weight='1.0' />
-                <Replaces block='Metallurgy:fantasy.ore:5' weight='1.0' />
-                <Replaces block='Metallurgy:fantasy.ore:6' weight='1.0' />
-                <Replaces block='Metallurgy:fantasy.ore:7' weight='1.0' />
-                <Replaces block='Metallurgy:fantasy.ore:8' weight='1.0' />
-                <Replaces block='Metallurgy:precious.ore' weight='1.0' />
-                <Replaces block='Metallurgy:precious.ore:1' weight='1.0' />
-                <Replaces block='Metallurgy:precious.ore:2' weight='1.0' />
-                <Replaces block='Metallurgy:utility.ore' weight='1.0' />
-                <Replaces block='Metallurgy:utility.ore:1' weight='1.0' />
-                <Replaces block='Metallurgy:utility.ore:2' weight='1.0' />
-                <Replaces block='Metallurgy:utility.ore:3' weight='1.0' />
-                <Replaces block='Metallurgy:utility.ore:4' weight='1.0' />
-                <Replaces block='Metallurgy:utility.ore:5' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Sulfur Generation -->
-
-            <!-- Starting SparseVeins Preset for Sulfur. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgSulfurDist = "SparseVeins"'>
-                    <Veins name='mtlgSulfurVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='mtlgOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgSulfurFreq ' range=':=  _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <Replaces block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <Replaces block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <Replaces block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <Replaces block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <Replaces block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <Replaces block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <Replaces block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <Replaces block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <Replaces block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <Replaces block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <Replaces block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <Replaces block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <Replaces block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <Replaces block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <Replaces block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <Replaces block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <Replaces block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <Replaces block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <Replaces block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <Replaces block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <Replaces block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <Replaces block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <Replaces block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Sulfur is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Sulfur. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgSulfurDist = "Cloud"'>
-                    <Cloud name='mtlgSulfurCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgSulfurFreq ' range=':=  _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgSulfurHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Sulfur Generation -->
+
+                <!-- Starting SparseVeins Preset for Sulfur. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgSulfurDist = "SparseVeins"'>
+                        <Veins name='mtlgSulfurVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgSulfurFreq ' range=':=  _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Sulfur is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Sulfur is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Sulfur. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgSulfurDist = "Vanilla"'>
-                    <StandardGen name='mtlgSulfurStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * mtlgSulfurFreq ' range=':=  _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Sulfur is complete. -->
-
-            <!-- End Sulfur Generation -->
-
-
-            <!-- Begin Phosphorite Generation -->
-
-            <!-- Starting SparseVeins Preset for Phosphorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgPhosphoriteDist = "SparseVeins"'>
-                    <Veins name='mtlgPhosphoriteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgPhosphoriteFreq ' range=':=  _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Phosphorite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Phosphorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgPhosphoriteDist = "Cloud"'>
-                    <Cloud name='mtlgPhosphoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgPhosphoriteFreq ' range=':=  _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgPhosphoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
+                <!-- Starting Cloud Preset for Sulfur. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgSulfurDist = "Cloud"'>
+                        <Cloud name='mtlgSulfurCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Phosphorite is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgSulfurFreq ' range=':=  _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgSulfurHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Sulfur is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Phosphorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgPhosphoriteDist = "Vanilla"'>
-                    <StandardGen name='mtlgPhosphoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * mtlgPhosphoriteFreq ' range=':=  _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Phosphorite is complete. -->
-
-            <!-- End Phosphorite Generation -->
-
-
-            <!-- Begin Saltpeter Generation -->
-
-            <!-- Starting SparseVeins Preset for Saltpeter. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgSaltpeterDist = "SparseVeins"'>
-                    <Veins name='mtlgSaltpeterVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgSaltpeterFreq ' range=':=  _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Saltpeter is complete. -->
-
-
-            <!-- Starting Cloud Preset for Saltpeter. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgSaltpeterDist = "Cloud"'>
-                    <Cloud name='mtlgSaltpeterCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgSaltpeterFreq ' range=':=  _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgSaltpeterHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
+                <!-- Starting Vanilla Preset for Sulfur. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgSulfurDist = "Vanilla"'>
+                        <StandardGen name='mtlgSulfurStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Saltpeter is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgSulfurFreq ' range=':=  _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Sulfur is complete. -->
+
+                <!-- End Sulfur Generation -->
 
 
-            <!-- Starting Vanilla Preset for Saltpeter. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgSaltpeterDist = "Vanilla"'>
-                    <StandardGen name='mtlgSaltpeterStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * mtlgSaltpeterFreq ' range=':=  _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Saltpeter is complete. -->
+                <!-- Begin Phosphorite Generation -->
 
-            <!-- End Saltpeter Generation -->
-
-
-            <!-- Begin Magnesium Generation -->
-
-            <!-- Starting SparseVeins Preset for Magnesium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgMagnesiumDist = "SparseVeins"'>
-                    <Veins name='mtlgMagnesiumVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgMagnesiumFreq ' range=':=  _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Magnesium is complete. -->
-
-
-            <!-- Starting Cloud Preset for Magnesium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgMagnesiumDist = "Cloud"'>
-                    <Cloud name='mtlgMagnesiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgMagnesiumFreq ' range=':=  _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgMagnesiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
+                <!-- Starting SparseVeins Preset for Phosphorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgPhosphoriteDist = "SparseVeins"'>
+                        <Veins name='mtlgPhosphoriteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgPhosphoriteFreq ' range=':=  _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Magnesium is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Phosphorite is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Magnesium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgMagnesiumDist = "Vanilla"'>
-                    <StandardGen name='mtlgMagnesiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * mtlgMagnesiumFreq ' range=':=  _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Magnesium is complete. -->
-
-            <!-- End Magnesium Generation -->
-
-
-            <!-- Begin Bitumen Generation -->
-
-            <!-- Starting SparseVeins Preset for Bitumen. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgBitumenDist = "SparseVeins"'>
-                    <Veins name='mtlgBitumenVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgBitumenFreq ' range=':=  _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Bitumen is complete. -->
-
-
-            <!-- Starting Cloud Preset for Bitumen. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgBitumenDist = "Cloud"'>
-                    <Cloud name='mtlgBitumenCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgBitumenFreq ' range=':=  _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgBitumenHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                <!-- Starting Cloud Preset for Phosphorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgPhosphoriteDist = "Cloud"'>
+                        <Cloud name='mtlgPhosphoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Bitumen is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgPhosphoriteFreq ' range=':=  _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgPhosphoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Phosphorite is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Bitumen. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgBitumenDist = "Vanilla"'>
-                    <StandardGen name='mtlgBitumenStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * mtlgBitumenFreq ' range=':=  _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Bitumen is complete. -->
-
-            <!-- End Bitumen Generation -->
-
-
-            <!-- Begin Potash Generation -->
-
-            <!-- Starting SparseVeins Preset for Potash. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgPotashDist = "SparseVeins"'>
-                    <Veins name='mtlgPotashVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgPotashFreq ' range=':=  _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Potash is complete. -->
-
-
-            <!-- Starting Cloud Preset for Potash. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgPotashDist = "Cloud"'>
-                    <Cloud name='mtlgPotashCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgPotashFreq ' range=':=  _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgPotashHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
+                <!-- Starting Vanilla Preset for Phosphorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgPhosphoriteDist = "Vanilla"'>
+                        <StandardGen name='mtlgPhosphoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Potash is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgPhosphoriteFreq ' range=':=  _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Phosphorite is complete. -->
+
+                <!-- End Phosphorite Generation -->
 
 
-            <!-- Starting Vanilla Preset for Potash. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgPotashDist = "Vanilla"'>
-                    <StandardGen name='mtlgPotashStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * mtlgPotashFreq ' range=':=  _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Potash is complete. -->
+                <!-- Begin Saltpeter Generation -->
 
-            <!-- End Potash Generation -->
-
-
-            <!-- Begin Copper Generation -->
-
-            <!-- Starting LayeredVeins Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgCopperDist = "LayeredVeins"'>
-                    <Veins name='mtlgCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:base.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.005 * _default_ * mtlgCopperFreq ' range=':=  _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.002 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.002 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.002 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Copper is complete. -->
-
-
-            <!-- Starting Cloud Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgCopperDist = "Cloud"'>
-                    <Cloud name='mtlgCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:base.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.417 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.417 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.007  * _default_ * mtlgCopperFreq ' range=':=  _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
+                <!-- Starting SparseVeins Preset for Saltpeter. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgSaltpeterDist = "SparseVeins"'>
+                        <Veins name='mtlgSaltpeterVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='Metallurgy:base.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgSaltpeterFreq ' range=':=  _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Copper is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Saltpeter is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgCopperDist = "Vanilla"'>
-                    <StandardGen name='mtlgCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:base.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * mtlgCopperFreq ' range=':=  _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Copper is complete. -->
-
-            <!-- End Copper Generation -->
-
-
-            <!-- Begin Tin Generation -->
-
-            <!-- Starting LayeredVeins Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgTinDist = "LayeredVeins"'>
-                    <Veins name='mtlgTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.991 * _default_ * mtlgTinFreq ' range=':=  _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.997 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.997 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.997 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Tin is complete. -->
-
-
-            <!-- Starting Cloud Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgTinDist = "Cloud"'>
-                    <Cloud name='mtlgTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.407 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.407 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.979  * _default_ * mtlgTinFreq ' range=':=  _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
+                <!-- Starting Cloud Preset for Saltpeter. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgSaltpeterDist = "Cloud"'>
+                        <Cloud name='mtlgSaltpeterCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Tin is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgSaltpeterFreq ' range=':=  _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgSaltpeterHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Saltpeter is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgTinDist = "Vanilla"'>
-                    <StandardGen name='mtlgTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 10 * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 7 * mtlgTinFreq ' range=':=  _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Tin is complete. -->
-
-            <!-- End Tin Generation -->
-
-
-            <!-- Begin Manganese Generation -->
-
-            <!-- Starting LayeredVeins Preset for Manganese. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgManganeseDist = "LayeredVeins"'>
-                    <Veins name='mtlgManganeseVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgManganeseFreq ' range=':=  _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Manganese is complete. -->
-
-
-            <!-- Starting Cloud Preset for Manganese. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgManganeseDist = "Cloud"'>
-                    <Cloud name='mtlgManganeseCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgManganeseFreq ' range=':=  _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgManganeseHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
+                <!-- Starting Vanilla Preset for Saltpeter. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgSaltpeterDist = "Vanilla"'>
+                        <StandardGen name='mtlgSaltpeterStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Manganese is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgSaltpeterFreq ' range=':=  _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Saltpeter is complete. -->
+
+                <!-- End Saltpeter Generation -->
 
 
-            <!-- Starting Vanilla Preset for Manganese. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgManganeseDist = "Vanilla"'>
-                    <StandardGen name='mtlgManganeseStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 5 * mtlgManganeseFreq ' range=':=  _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Manganese is complete. -->
+                <!-- Begin Magnesium Generation -->
 
-            <!-- End Manganese Generation -->
-
-
-            <!-- Begin Zinc Generation -->
-
-            <!-- Starting LayeredVeins Preset for Zinc. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgZincDist = "LayeredVeins"'>
-                    <Veins name='mtlgZincVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgZincFreq ' range=':=  _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Zinc is complete. -->
-
-
-            <!-- Starting Cloud Preset for Zinc. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgZincDist = "Cloud"'>
-                    <Cloud name='mtlgZincCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgZincFreq ' range=':=  _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgZincHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
+                <!-- Starting SparseVeins Preset for Magnesium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgMagnesiumDist = "SparseVeins"'>
+                        <Veins name='mtlgMagnesiumVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgMagnesiumFreq ' range=':=  _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Zinc is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Magnesium is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Zinc. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgZincDist = "Vanilla"'>
-                    <StandardGen name='mtlgZincStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 5 * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 6 * mtlgZincFreq ' range=':=  _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Zinc is complete. -->
-
-            <!-- End Zinc Generation -->
-
-
-            <!-- Begin Silver Generation -->
-
-            <!-- Starting LayeredVeins Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgSilverDist = "LayeredVeins"'>
-                    <Veins name='mtlgSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgSilverFreq ' range=':=  _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Silver is complete. -->
-
-
-            <!-- Starting Cloud Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgSilverDist = "Cloud"'>
-                    <Cloud name='mtlgSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgSilverFreq ' range=':=  _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
+                <!-- Starting Cloud Preset for Magnesium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgMagnesiumDist = "Cloud"'>
+                        <Cloud name='mtlgMagnesiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Silver is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgMagnesiumFreq ' range=':=  _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgMagnesiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Magnesium is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgSilverDist = "Vanilla"'>
-                    <StandardGen name='mtlgSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 5 * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 6 * mtlgSilverFreq ' range=':=  _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Silver is complete. -->
-
-            <!-- End Silver Generation -->
-
-
-            <!-- Begin Platinum Generation -->
-
-            <!-- Starting LayeredVeins Preset for Platinum. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgPlatinumDist = "LayeredVeins"'>
-                    <Veins name='mtlgPlatinumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgPlatinumFreq ' range=':=  _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Platinum is complete. -->
-
-
-            <!-- Starting Cloud Preset for Platinum. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgPlatinumDist = "Cloud"'>
-                    <Cloud name='mtlgPlatinumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgPlatinumFreq ' range=':=  _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgPlatinumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
+                <!-- Starting Vanilla Preset for Magnesium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgMagnesiumDist = "Vanilla"'>
+                        <StandardGen name='mtlgMagnesiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Platinum is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgMagnesiumFreq ' range=':=  _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Magnesium is complete. -->
+
+                <!-- End Magnesium Generation -->
 
 
-            <!-- Starting Vanilla Preset for Platinum. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgPlatinumDist = "Vanilla"'>
-                    <StandardGen name='mtlgPlatinumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * mtlgPlatinumFreq ' range=':=  _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Platinum is complete. -->
+                <!-- Begin Bitumen Generation -->
 
-            <!-- End Platinum Generation -->
-
-
-            <!-- Begin Promethium Generation -->
-
-            <!-- Starting LayeredVeins Preset for Promethium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgPromethiumDist = "LayeredVeins"'>
-                    <Veins name='mtlgPromethiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgPromethiumFreq ' range=':=  _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Promethium is complete. -->
-
-
-            <!-- Starting Cloud Preset for Promethium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgPromethiumDist = "Cloud"'>
-                    <Cloud name='mtlgPromethiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgPromethiumFreq ' range=':=  _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgPromethiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
+                <!-- Starting SparseVeins Preset for Bitumen. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgBitumenDist = "SparseVeins"'>
+                        <Veins name='mtlgBitumenVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgBitumenFreq ' range=':=  _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Promethium is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Bitumen is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Promethium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgPromethiumDist = "Vanilla"'>
-                    <StandardGen name='mtlgPromethiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 5 * mtlgPromethiumFreq ' range=':=  _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Promethium is complete. -->
-
-            <!-- End Promethium Generation -->
-
-
-            <!-- Begin Deep Iron Generation -->
-
-            <!-- Starting LayeredVeins Preset for Deep Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgDeepIronDist = "LayeredVeins"'>
-                    <Veins name='mtlgDeepIronVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgDeepIronFreq ' range=':=  _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Deep Iron is complete. -->
-
-
-            <!-- Starting Cloud Preset for Deep Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgDeepIronDist = "Cloud"'>
-                    <Cloud name='mtlgDeepIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgDeepIronFreq ' range=':=  _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgDeepIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
+                <!-- Starting Cloud Preset for Bitumen. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgBitumenDist = "Cloud"'>
+                        <Cloud name='mtlgBitumenCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Deep Iron is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgBitumenFreq ' range=':=  _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgBitumenHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Bitumen is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Deep Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgDeepIronDist = "Vanilla"'>
-                    <StandardGen name='mtlgDeepIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 5 * mtlgDeepIronFreq ' range=':=  _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Deep Iron is complete. -->
-
-            <!-- End Deep Iron Generation -->
-
-
-            <!-- Begin Infuscolium Generation -->
-
-            <!-- Starting LayeredVeins Preset for Infuscolium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgInfuscoliumDist = "LayeredVeins"'>
-                    <Veins name='mtlgInfuscoliumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgInfuscoliumFreq ' range=':=  _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Infuscolium is complete. -->
-
-
-            <!-- Starting Cloud Preset for Infuscolium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgInfuscoliumDist = "Cloud"'>
-                    <Cloud name='mtlgInfuscoliumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgInfuscoliumFreq ' range=':=  _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgInfuscoliumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
+                <!-- Starting Vanilla Preset for Bitumen. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgBitumenDist = "Vanilla"'>
+                        <StandardGen name='mtlgBitumenStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Infuscolium is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgBitumenFreq ' range=':=  _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Bitumen is complete. -->
+
+                <!-- End Bitumen Generation -->
 
 
-            <!-- Starting Vanilla Preset for Infuscolium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgInfuscoliumDist = "Vanilla"'>
-                    <StandardGen name='mtlgInfuscoliumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 5 * mtlgInfuscoliumFreq ' range=':=  _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Infuscolium is complete. -->
+                <!-- Begin Potash Generation -->
 
-            <!-- End Infuscolium Generation -->
-
-
-            <!-- Begin Oureclase Generation -->
-
-            <!-- Starting LayeredVeins Preset for Oureclase. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgOureclaseDist = "LayeredVeins"'>
-                    <Veins name='mtlgOureclaseVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgOureclaseFreq ' range=':=  _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Oureclase is complete. -->
-
-
-            <!-- Starting Cloud Preset for Oureclase. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgOureclaseDist = "Cloud"'>
-                    <Cloud name='mtlgOureclaseCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgOureclaseFreq ' range=':=  _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgOureclaseHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
+                <!-- Starting SparseVeins Preset for Potash. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgPotashDist = "SparseVeins"'>
+                        <Veins name='mtlgPotashVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgPotashFreq ' range=':=  _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Oureclase is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Potash is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Oureclase. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgOureclaseDist = "Vanilla"'>
-                    <StandardGen name='mtlgOureclaseStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * mtlgOureclaseFreq ' range=':=  _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Oureclase is complete. -->
-
-            <!-- End Oureclase Generation -->
-
-
-            <!-- Begin Astral Silver Generation -->
-
-            <!-- Starting LayeredVeins Preset for Astral Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgAstralSilverDist = "LayeredVeins"'>
-                    <Veins name='mtlgAstralSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgAstralSilverFreq ' range=':=  _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Astral Silver is complete. -->
-
-
-            <!-- Starting Cloud Preset for Astral Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgAstralSilverDist = "Cloud"'>
-                    <Cloud name='mtlgAstralSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgAstralSilverFreq ' range=':=  _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgAstralSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
+                <!-- Starting Cloud Preset for Potash. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgPotashDist = "Cloud"'>
+                        <Cloud name='mtlgPotashCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Astral Silver is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgPotashFreq ' range=':=  _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgPotashHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Potash is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Astral Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgAstralSilverDist = "Vanilla"'>
-                    <StandardGen name='mtlgAstralSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * mtlgAstralSilverFreq ' range=':=  _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Astral Silver is complete. -->
-
-            <!-- End Astral Silver Generation -->
-
-
-            <!-- Begin Carmot Generation -->
-
-            <!-- Starting LayeredVeins Preset for Carmot. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgCarmotDist = "LayeredVeins"'>
-                    <Veins name='mtlgCarmotVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgCarmotFreq ' range=':=  _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Carmot is complete. -->
-
-
-            <!-- Starting Cloud Preset for Carmot. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgCarmotDist = "Cloud"'>
-                    <Cloud name='mtlgCarmotCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgCarmotFreq ' range=':=  _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgCarmotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
+                <!-- Starting Vanilla Preset for Potash. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgPotashDist = "Vanilla"'>
+                        <StandardGen name='mtlgPotashStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Carmot is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgPotashFreq ' range=':=  _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Potash is complete. -->
+
+                <!-- End Potash Generation -->
 
 
-            <!-- Starting Vanilla Preset for Carmot. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgCarmotDist = "Vanilla"'>
-                    <StandardGen name='mtlgCarmotStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * mtlgCarmotFreq ' range=':=  _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Carmot is complete. -->
+                <!-- Begin Copper Generation -->
 
-            <!-- End Carmot Generation -->
-
-
-            <!-- Begin Mithril Generation -->
-
-            <!-- Starting LayeredVeins Preset for Mithril. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgMithrilDist = "LayeredVeins"'>
-                    <Veins name='mtlgMithrilVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgMithrilFreq ' range=':=  _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Mithril is complete. -->
-
-
-            <!-- Starting Cloud Preset for Mithril. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgMithrilDist = "Cloud"'>
-                    <Cloud name='mtlgMithrilCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgMithrilFreq ' range=':=  _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgMithrilHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
+                <!-- Starting LayeredVeins Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgCopperDist = "LayeredVeins"'>
+                        <Veins name='mtlgCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.005 * _default_ * mtlgCopperFreq ' range=':=  _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.002 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.002 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.002 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Mithril is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Mithril. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgMithrilDist = "Vanilla"'>
-                    <StandardGen name='mtlgMithrilStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * mtlgMithrilFreq ' range=':=  _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Mithril is complete. -->
-
-            <!-- End Mithril Generation -->
-
-
-            <!-- Begin Rubracium Generation -->
-
-            <!-- Starting LayeredVeins Preset for Rubracium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgRubraciumDist = "LayeredVeins"'>
-                    <Veins name='mtlgRubraciumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgRubraciumFreq ' range=':=  _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Rubracium is complete. -->
-
-
-            <!-- Starting Cloud Preset for Rubracium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgRubraciumDist = "Cloud"'>
-                    <Cloud name='mtlgRubraciumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgRubraciumFreq ' range=':=  _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgRubraciumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
+                <!-- Starting Cloud Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgCopperDist = "Cloud"'>
+                        <Cloud name='mtlgCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Rubracium is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.417 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.417 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.007  * _default_ * mtlgCopperFreq ' range=':=  _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Rubracium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgRubraciumDist = "Vanilla"'>
-                    <StandardGen name='mtlgRubraciumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * mtlgRubraciumFreq ' range=':=  _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Rubracium is complete. -->
-
-            <!-- End Rubracium Generation -->
-
-
-            <!-- Begin Orichalcum Generation -->
-
-            <!-- Starting LayeredVeins Preset for Orichalcum. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgOrichalcumDist = "LayeredVeins"'>
-                    <Veins name='mtlgOrichalcumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * mtlgOrichalcumFreq ' range=':=  _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Orichalcum is complete. -->
-
-
-            <!-- Starting Cloud Preset for Orichalcum. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgOrichalcumDist = "Cloud"'>
-                    <Cloud name='mtlgOrichalcumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.818 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.818 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * mtlgOrichalcumFreq ' range=':=  _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgOrichalcumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
+                <!-- Starting Vanilla Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgCopperDist = "Vanilla"'>
+                        <StandardGen name='mtlgCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Orichalcum is complete. -->
+                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12 * mtlgCopperFreq ' range=':=  _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Copper is complete. -->
+
+                <!-- End Copper Generation -->
 
 
-            <!-- Starting Vanilla Preset for Orichalcum. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgOrichalcumDist = "Vanilla"'>
-                    <StandardGen name='mtlgOrichalcumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * mtlgOrichalcumFreq ' range=':=  _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Orichalcum is complete. -->
+                <!-- Begin Tin Generation -->
 
-            <!-- End Orichalcum Generation -->
-
-
-            <!-- Begin Adamantine Generation -->
-
-            <!-- Starting LayeredVeins Preset for Adamantine. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgAdamantineDist = "LayeredVeins"'>
-                    <Veins name='mtlgAdamantineVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgAdamantineFreq ' range=':=  _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Adamantine is complete. -->
-
-
-            <!-- Starting Cloud Preset for Adamantine. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgAdamantineDist = "Cloud"'>
-                    <Cloud name='mtlgAdamantineCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgAdamantineFreq ' range=':=  _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgAdamantineHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
+                <!-- Starting LayeredVeins Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgTinDist = "LayeredVeins"'>
+                        <Veins name='mtlgTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.991 * _default_ * mtlgTinFreq ' range=':=  _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.997 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.997 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.997 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Adamantine is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Tin is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Adamantine. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgAdamantineDist = "Vanilla"'>
-                    <StandardGen name='mtlgAdamantineStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * mtlgAdamantineFreq ' range=':=  _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Adamantine is complete. -->
-
-            <!-- End Adamantine Generation -->
-
-
-            <!-- Begin Atlarus Generation -->
-
-            <!-- Starting LayeredVeins Preset for Atlarus. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgAtlarusDist = "LayeredVeins"'>
-                    <Veins name='mtlgAtlarusVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgAtlarusFreq ' range=':=  _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Atlarus is complete. -->
-
-
-            <!-- Starting Cloud Preset for Atlarus. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgAtlarusDist = "Cloud"'>
-                    <Cloud name='mtlgAtlarusCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgAtlarusFreq ' range=':=  _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgAtlarusHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
+                <!-- Starting Cloud Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgTinDist = "Cloud"'>
+                        <Cloud name='mtlgTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.407 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.407 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.979  * _default_ * mtlgTinFreq ' range=':=  _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tin is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgTinDist = "Vanilla"'>
+                        <StandardGen name='mtlgTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 10 * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 7 * mtlgTinFreq ' range=':=  _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tin is complete. -->
+
+                <!-- End Tin Generation -->
+
+
+                <!-- Begin Manganese Generation -->
+
+                <!-- Starting LayeredVeins Preset for Manganese. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgManganeseDist = "LayeredVeins"'>
+                        <Veins name='mtlgManganeseVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgManganeseFreq ' range=':=  _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Atlarus is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Manganese is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Atlarus. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgAtlarusDist = "Vanilla"'>
-                    <StandardGen name='mtlgAtlarusStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
+                <!-- Starting Cloud Preset for Manganese. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgManganeseDist = "Cloud"'>
+                        <Cloud name='mtlgManganeseCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgManganeseFreq ' range=':=  _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgManganeseHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Manganese is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Manganese. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgManganeseDist = "Vanilla"'>
+                        <StandardGen name='mtlgManganeseStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * mtlgManganeseFreq ' range=':=  _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Manganese is complete. -->
+
+                <!-- End Manganese Generation -->
+
+
+                <!-- Begin Zinc Generation -->
+
+                <!-- Starting LayeredVeins Preset for Zinc. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgZincDist = "LayeredVeins"'>
+                        <Veins name='mtlgZincVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgZincFreq ' range=':=  _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Zinc is complete. -->
+
+
+                <!-- Starting Cloud Preset for Zinc. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgZincDist = "Cloud"'>
+                        <Cloud name='mtlgZincCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgZincFreq ' range=':=  _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgZincHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Zinc is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Zinc. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgZincDist = "Vanilla"'>
+                        <StandardGen name='mtlgZincStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * mtlgZincFreq ' range=':=  _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Zinc is complete. -->
+
+                <!-- End Zinc Generation -->
+
+
+                <!-- Begin Silver Generation -->
+
+                <!-- Starting LayeredVeins Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgSilverDist = "LayeredVeins"'>
+                        <Veins name='mtlgSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgSilverFreq ' range=':=  _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Silver is complete. -->
+
+
+                <!-- Starting Cloud Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgSilverDist = "Cloud"'>
+                        <Cloud name='mtlgSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgSilverFreq ' range=':=  _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Silver is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgSilverDist = "Vanilla"'>
+                        <StandardGen name='mtlgSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * mtlgSilverFreq ' range=':=  _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Silver is complete. -->
+
+                <!-- End Silver Generation -->
+
+
+                <!-- Begin Platinum Generation -->
+
+                <!-- Starting LayeredVeins Preset for Platinum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgPlatinumDist = "LayeredVeins"'>
+                        <Veins name='mtlgPlatinumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgPlatinumFreq ' range=':=  _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Platinum is complete. -->
+
+
+                <!-- Starting Cloud Preset for Platinum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgPlatinumDist = "Cloud"'>
+                        <Cloud name='mtlgPlatinumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgPlatinumFreq ' range=':=  _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgPlatinumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Platinum is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Platinum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgPlatinumDist = "Vanilla"'>
+                        <StandardGen name='mtlgPlatinumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * mtlgPlatinumFreq ' range=':=  _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Platinum is complete. -->
+
+                <!-- End Platinum Generation -->
+
+
+                <!-- Begin Promethium Generation -->
+
+                <!-- Starting LayeredVeins Preset for Promethium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgPromethiumDist = "LayeredVeins"'>
+                        <Veins name='mtlgPromethiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgPromethiumFreq ' range=':=  _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Promethium is complete. -->
+
+
+                <!-- Starting Cloud Preset for Promethium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgPromethiumDist = "Cloud"'>
+                        <Cloud name='mtlgPromethiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgPromethiumFreq ' range=':=  _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgPromethiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Promethium is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Promethium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgPromethiumDist = "Vanilla"'>
+                        <StandardGen name='mtlgPromethiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * mtlgPromethiumFreq ' range=':=  _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Promethium is complete. -->
+
+                <!-- End Promethium Generation -->
+
+
+                <!-- Begin Deep Iron Generation -->
+
+                <!-- Starting LayeredVeins Preset for Deep Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgDeepIronDist = "LayeredVeins"'>
+                        <Veins name='mtlgDeepIronVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgDeepIronFreq ' range=':=  _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Deep Iron is complete. -->
+
+
+                <!-- Starting Cloud Preset for Deep Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgDeepIronDist = "Cloud"'>
+                        <Cloud name='mtlgDeepIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgDeepIronFreq ' range=':=  _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgDeepIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Deep Iron is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Deep Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgDeepIronDist = "Vanilla"'>
+                        <StandardGen name='mtlgDeepIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * mtlgDeepIronFreq ' range=':=  _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Deep Iron is complete. -->
+
+                <!-- End Deep Iron Generation -->
+
+
+                <!-- Begin Infuscolium Generation -->
+
+                <!-- Starting LayeredVeins Preset for Infuscolium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgInfuscoliumDist = "LayeredVeins"'>
+                        <Veins name='mtlgInfuscoliumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgInfuscoliumFreq ' range=':=  _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Infuscolium is complete. -->
+
+
+                <!-- Starting Cloud Preset for Infuscolium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgInfuscoliumDist = "Cloud"'>
+                        <Cloud name='mtlgInfuscoliumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgInfuscoliumFreq ' range=':=  _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgInfuscoliumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Infuscolium is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Infuscolium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgInfuscoliumDist = "Vanilla"'>
+                        <StandardGen name='mtlgInfuscoliumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * mtlgInfuscoliumFreq ' range=':=  _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Infuscolium is complete. -->
+
+                <!-- End Infuscolium Generation -->
+
+
+                <!-- Begin Oureclase Generation -->
+
+                <!-- Starting LayeredVeins Preset for Oureclase. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgOureclaseDist = "LayeredVeins"'>
+                        <Veins name='mtlgOureclaseVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgOureclaseFreq ' range=':=  _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Oureclase is complete. -->
+
+
+                <!-- Starting Cloud Preset for Oureclase. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgOureclaseDist = "Cloud"'>
+                        <Cloud name='mtlgOureclaseCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgOureclaseFreq ' range=':=  _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgOureclaseHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Oureclase is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Oureclase. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgOureclaseDist = "Vanilla"'>
+                        <StandardGen name='mtlgOureclaseStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgOureclaseFreq ' range=':=  _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Oureclase is complete. -->
+
+                <!-- End Oureclase Generation -->
+
+
+                <!-- Begin Astral Silver Generation -->
+
+                <!-- Starting LayeredVeins Preset for Astral Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgAstralSilverDist = "LayeredVeins"'>
+                        <Veins name='mtlgAstralSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgAstralSilverFreq ' range=':=  _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Astral Silver is
+                     complete. -->
+
+
+                <!-- Starting Cloud Preset for Astral Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgAstralSilverDist = "Cloud"'>
+                        <Cloud name='mtlgAstralSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgAstralSilverFreq ' range=':=  _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgAstralSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Astral Silver is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Astral Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgAstralSilverDist = "Vanilla"'>
+                        <StandardGen name='mtlgAstralSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgAstralSilverFreq ' range=':=  _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Astral Silver is complete. -->
+
+                <!-- End Astral Silver Generation -->
+
+
+                <!-- Begin Carmot Generation -->
+
+                <!-- Starting LayeredVeins Preset for Carmot. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgCarmotDist = "LayeredVeins"'>
+                        <Veins name='mtlgCarmotVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgCarmotFreq ' range=':=  _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Carmot is complete. -->
+
+
+                <!-- Starting Cloud Preset for Carmot. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgCarmotDist = "Cloud"'>
+                        <Cloud name='mtlgCarmotCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgCarmotFreq ' range=':=  _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgCarmotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Carmot is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Carmot. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgCarmotDist = "Vanilla"'>
+                        <StandardGen name='mtlgCarmotStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * mtlgCarmotFreq ' range=':=  _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Carmot is complete. -->
+
+                <!-- End Carmot Generation -->
+
+
+                <!-- Begin Mithril Generation -->
+
+                <!-- Starting LayeredVeins Preset for Mithril. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgMithrilDist = "LayeredVeins"'>
+                        <Veins name='mtlgMithrilVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgMithrilFreq ' range=':=  _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Mithril is complete. -->
+
+
+                <!-- Starting Cloud Preset for Mithril. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgMithrilDist = "Cloud"'>
+                        <Cloud name='mtlgMithrilCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgMithrilFreq ' range=':=  _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgMithrilHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Mithril is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Mithril. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgMithrilDist = "Vanilla"'>
+                        <StandardGen name='mtlgMithrilStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * mtlgMithrilFreq ' range=':=  _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Mithril is complete. -->
+
+                <!-- End Mithril Generation -->
+
+
+                <!-- Begin Rubracium Generation -->
+
+                <!-- Starting LayeredVeins Preset for Rubracium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgRubraciumDist = "LayeredVeins"'>
+                        <Veins name='mtlgRubraciumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgRubraciumFreq ' range=':=  _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Rubracium is complete. -->
+
+
+                <!-- Starting Cloud Preset for Rubracium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgRubraciumDist = "Cloud"'>
+                        <Cloud name='mtlgRubraciumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgRubraciumFreq ' range=':=  _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgRubraciumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Rubracium is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Rubracium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgRubraciumDist = "Vanilla"'>
+                        <StandardGen name='mtlgRubraciumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mtlgRubraciumFreq ' range=':=  _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Rubracium is complete. -->
+
+                <!-- End Rubracium Generation -->
+
+
+                <!-- Begin Orichalcum Generation -->
+
+                <!-- Starting LayeredVeins Preset for Orichalcum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgOrichalcumDist = "LayeredVeins"'>
+                        <Veins name='mtlgOrichalcumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * mtlgOrichalcumFreq ' range=':=  _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Orichalcum is complete. -->
+
+
+                <!-- Starting Cloud Preset for Orichalcum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgOrichalcumDist = "Cloud"'>
+                        <Cloud name='mtlgOrichalcumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.818 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.818 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * mtlgOrichalcumFreq ' range=':=  _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgOrichalcumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Orichalcum is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Orichalcum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgOrichalcumDist = "Vanilla"'>
+                        <StandardGen name='mtlgOrichalcumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mtlgOrichalcumFreq ' range=':=  _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Orichalcum is complete. -->
+
+                <!-- End Orichalcum Generation -->
+
+
+                <!-- Begin Adamantine Generation -->
+
+                <!-- Starting LayeredVeins Preset for Adamantine. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgAdamantineDist = "LayeredVeins"'>
+                        <Veins name='mtlgAdamantineVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgAdamantineFreq ' range=':=  _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Adamantine is complete. -->
+
+
+                <!-- Starting Cloud Preset for Adamantine. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgAdamantineDist = "Cloud"'>
+                        <Cloud name='mtlgAdamantineCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgAdamantineFreq ' range=':=  _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgAdamantineHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Adamantine is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Adamantine. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgAdamantineDist = "Vanilla"'>
+                        <StandardGen name='mtlgAdamantineStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mtlgAdamantineFreq ' range=':=  _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Adamantine is complete. -->
+
+                <!-- End Adamantine Generation -->
+
+
+                <!-- Begin Atlarus Generation -->
+
+                <!-- Starting LayeredVeins Preset for Atlarus. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgAtlarusDist = "LayeredVeins"'>
+                        <Veins name='mtlgAtlarusVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgAtlarusFreq ' range=':=  _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Atlarus is complete. -->
+
+
+                <!-- Starting Cloud Preset for Atlarus. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgAtlarusDist = "Cloud"'>
+                        <Cloud name='mtlgAtlarusCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgAtlarusFreq ' range=':=  _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgAtlarusHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Atlarus is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Atlarus. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgAtlarusDist = "Vanilla"'>
+                        <StandardGen name='mtlgAtlarusStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mtlgAtlarusFreq ' range=':=  _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Atlarus is complete. -->
+
+                <!-- End Atlarus Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
+
+
+
+            <!-- Nether Setup Beginning -->
+
+            <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
+
+                <!-- Starting Original "Nether" Block Removal -->
+
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='mtlgNetherBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            A master preset for standardgen ore
-                            distributions.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * mtlgAtlarusFreq ' range=':=  _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <Replaces block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Atlarus is complete. -->
 
-            <!-- End Atlarus Generation -->
+                <!-- Original "Nether" Block Removal Complete -->
 
-            <!-- Finished adding blocks -->
+                <!-- Adding blocks -->
+
+                <!-- Begin Ignatius Generation -->
+
+                <!-- Starting LayeredVeins Preset for Ignatius. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgIgnatiusDist = "LayeredVeins"'>
+                        <Veins name='mtlgIgnatiusVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.870 * _default_ * mtlgIgnatiusFreq ' range=':=  _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.955 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.955 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.955 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Ignatius is complete. -->
+
+
+                <!-- Starting Cloud Preset for Ignatius. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgIgnatiusDist = "Cloud"'>
+                        <Cloud name='mtlgIgnatiusCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.318 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.318 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.738  * _default_ * mtlgIgnatiusFreq ' range=':=  _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgIgnatiusHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Ignatius is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Ignatius. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgIgnatiusDist = "Vanilla"'>
+                        <StandardGen name='mtlgIgnatiusStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 9 * mtlgIgnatiusFreq ' range=':=  _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Ignatius is complete. -->
+
+                <!-- End Ignatius Generation -->
+
+
+                <!-- Begin Shadow Iron Generation -->
+
+                <!-- Starting LayeredVeins Preset for Shadow Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgShadowIronDist = "LayeredVeins"'>
+                        <Veins name='mtlgShadowIronVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.768 * _default_ * mtlgShadowIronFreq ' range=':=  _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.916 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.916 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.916 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Shadow Iron is complete. -->
+
+
+                <!-- Starting Cloud Preset for Shadow Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgShadowIronDist = "Cloud"'>
+                        <Cloud name='mtlgShadowIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.238 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.238 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.533  * _default_ * mtlgShadowIronFreq ' range=':=  _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgShadowIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Shadow Iron is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Shadow Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgShadowIronDist = "Vanilla"'>
+                        <StandardGen name='mtlgShadowIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 7 * mtlgShadowIronFreq ' range=':=  _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Shadow Iron is complete. -->
+
+                <!-- End Shadow Iron Generation -->
+
+
+                <!-- Begin Lemurite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Lemurite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgLemuriteDist = "LayeredVeins"'>
+                        <Veins name='mtlgLemuriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.711 * _default_ * mtlgLemuriteFreq ' range=':=  _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.892 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.892 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Lemurite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Lemurite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgLemuriteDist = "Cloud"'>
+                        <Cloud name='mtlgLemuriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.191 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.191 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * mtlgLemuriteFreq ' range=':=  _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgLemuriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Lemurite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Lemurite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgLemuriteDist = "Vanilla"'>
+                        <StandardGen name='mtlgLemuriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * mtlgLemuriteFreq ' range=':=  _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Lemurite is complete. -->
+
+                <!-- End Lemurite Generation -->
+
+
+                <!-- Begin Midasium Generation -->
+
+                <!-- Starting LayeredVeins Preset for Midasium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgMidasiumDist = "LayeredVeins"'>
+                        <Veins name='mtlgMidasiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgMidasiumFreq ' range=':=  _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Midasium is complete. -->
+
+
+                <!-- Starting Cloud Preset for Midasium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgMidasiumDist = "Cloud"'>
+                        <Cloud name='mtlgMidasiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgMidasiumFreq ' range=':=  _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgMidasiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Midasium is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Midasium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgMidasiumDist = "Vanilla"'>
+                        <StandardGen name='mtlgMidasiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * mtlgMidasiumFreq ' range=':=  _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Midasium is complete. -->
+
+                <!-- End Midasium Generation -->
+
+
+                <!-- Begin Vyroxeres Generation -->
+
+                <!-- Starting LayeredVeins Preset for Vyroxeres. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgVyroxeresDist = "LayeredVeins"'>
+                        <Veins name='mtlgVyroxeresVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.627 * _default_ * mtlgVyroxeresFreq ' range=':=  _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.856 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.856 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.856 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Vyroxeres is complete. -->
+
+
+                <!-- Starting Cloud Preset for Vyroxeres. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgVyroxeresDist = "Cloud"'>
+                        <Cloud name='mtlgVyroxeresCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.119 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.119 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.251  * _default_ * mtlgVyroxeresFreq ' range=':=  _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgVyroxeresHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Vyroxeres is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Vyroxeres. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgVyroxeresDist = "Vanilla"'>
+                        <StandardGen name='mtlgVyroxeresStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 7 * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgVyroxeresFreq ' range=':=  _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Vyroxeres is complete. -->
+
+                <!-- End Vyroxeres Generation -->
+
+
+                <!-- Begin Ceruclase Generation -->
+
+                <!-- Starting LayeredVeins Preset for Ceruclase. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgCeruclaseDist = "LayeredVeins"'>
+                        <Veins name='mtlgCeruclaseVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * mtlgCeruclaseFreq ' range=':=  _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Ceruclase is complete. -->
+
+
+                <!-- Starting Cloud Preset for Ceruclase. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgCeruclaseDist = "Cloud"'>
+                        <Cloud name='mtlgCeruclaseCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgCeruclaseFreq ' range=':=  _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgCeruclaseHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Ceruclase is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Ceruclase. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgCeruclaseDist = "Vanilla"'>
+                        <StandardGen name='mtlgCeruclaseStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgCeruclaseFreq ' range=':=  _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Ceruclase is complete. -->
+
+                <!-- End Ceruclase Generation -->
+
+
+                <!-- Begin Alduorite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Alduorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgAlduoriteDist = "LayeredVeins"'>
+                        <Veins name='mtlgAlduoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgAlduoriteFreq ' range=':=  _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Alduorite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Alduorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgAlduoriteDist = "Cloud"'>
+                        <Cloud name='mtlgAlduoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgAlduoriteFreq ' range=':=  _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgAlduoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Alduorite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Alduorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgAlduoriteDist = "Vanilla"'>
+                        <StandardGen name='mtlgAlduoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * mtlgAlduoriteFreq ' range=':=  _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Alduorite is complete. -->
+
+                <!-- End Alduorite Generation -->
+
+
+                <!-- Begin Kalendrite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Kalendrite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgKalendriteDist = "LayeredVeins"'>
+                        <Veins name='mtlgKalendriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgKalendriteFreq ' range=':=  _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Kalendrite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Kalendrite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgKalendriteDist = "Cloud"'>
+                        <Cloud name='mtlgKalendriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgKalendriteFreq ' range=':=  _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgKalendriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Kalendrite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Kalendrite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgKalendriteDist = "Vanilla"'>
+                        <StandardGen name='mtlgKalendriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * mtlgKalendriteFreq ' range=':=  _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Kalendrite is complete. -->
+
+                <!-- End Kalendrite Generation -->
+
+
+                <!-- Begin Vulcanite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Vulcanite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgVulcaniteDist = "LayeredVeins"'>
+                        <Veins name='mtlgVulcaniteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgVulcaniteFreq ' range=':=  _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Vulcanite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Vulcanite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgVulcaniteDist = "Cloud"'>
+                        <Cloud name='mtlgVulcaniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgVulcaniteFreq ' range=':=  _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgVulcaniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Vulcanite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Vulcanite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgVulcaniteDist = "Vanilla"'>
+                        <StandardGen name='mtlgVulcaniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mtlgVulcaniteFreq ' range=':=  _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Vulcanite is complete. -->
+
+                <!-- End Vulcanite Generation -->
+
+
+                <!-- Begin Sanguinite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Sanguinite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgSanguiniteDist = "LayeredVeins"'>
+                        <Veins name='mtlgSanguiniteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgSanguiniteFreq ' range=':=  _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Sanguinite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Sanguinite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgSanguiniteDist = "Cloud"'>
+                        <Cloud name='mtlgSanguiniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgSanguiniteFreq ' range=':=  _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgSanguiniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Sanguinite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Sanguinite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgSanguiniteDist = "Vanilla"'>
+                        <StandardGen name='mtlgSanguiniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mtlgSanguiniteFreq ' range=':=  _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Sanguinite is complete. -->
+
+                <!-- End Sanguinite Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Nether Setup Complete -->
+
+
+
+
+
+            <!-- End Setup Beginning -->
+
+            <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
+
+                <!-- Starting Original "End" Block Removal -->
+
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='mtlgEndBlockSubstitute0' block='minecraft:stone'>
+                        <Description>
+                            Replace vanilla-generated ore clusters.
+                        </Description>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <Replaces block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                    </Substitute>
+                </IfCondition>
+
+                <!-- Original "End" Block Removal Complete -->
+
+                <!-- Adding blocks -->
+
+                <!-- Begin Eximite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Eximite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgEximiteDist = "LayeredVeins"'>
+                        <Veins name='mtlgEximiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * mtlgEximiteFreq ' range=':=  _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Eximite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Eximite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgEximiteDist = "Cloud"'>
+                        <Cloud name='mtlgEximiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * mtlgEximiteFreq ' range=':=  _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgEximiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Eximite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Eximite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgEximiteDist = "Vanilla"'>
+                        <StandardGen name='mtlgEximiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * mtlgEximiteFreq ' range=':=  _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Eximite is complete. -->
+
+                <!-- End Eximite Generation -->
+
+
+                <!-- Begin Meutoite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Meutoite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgMeutoiteDist = "LayeredVeins"'>
+                        <Veins name='mtlgMeutoiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgMeutoiteFreq ' range=':=  _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Meutoite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Meutoite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgMeutoiteDist = "Cloud"'>
+                        <Cloud name='mtlgMeutoiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgMeutoiteFreq ' range=':=  _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mtlgMeutoiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Meutoite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Meutoite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mtlgMeutoiteDist = "Vanilla"'>
+                        <StandardGen name='mtlgMeutoiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * mtlgMeutoiteFreq ' range=':=  _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Meutoite is complete. -->
+
+                <!-- End Meutoite Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- End Setup Complete -->
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
-
-
-        <!-- Nether Setup Beginning -->
-
-        <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
-
-            <!-- Starting Original "Nether" Block Removal -->
-
-            <Substitute name='mtlgNetherBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='Metallurgy:nether.ore' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Nether" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Ignatius Generation -->
-
-            <!-- Starting LayeredVeins Preset for Ignatius. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgIgnatiusDist = "LayeredVeins"'>
-                    <Veins name='mtlgIgnatiusVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.870 * _default_ * mtlgIgnatiusFreq ' range=':=  _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.955 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.955 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.955 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Ignatius is complete. -->
-
-
-            <!-- Starting Cloud Preset for Ignatius. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgIgnatiusDist = "Cloud"'>
-                    <Cloud name='mtlgIgnatiusCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.318 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.318 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.738  * _default_ * mtlgIgnatiusFreq ' range=':=  _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgIgnatiusHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Ignatius is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Ignatius. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgIgnatiusDist = "Vanilla"'>
-                    <StandardGen name='mtlgIgnatiusStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 9 * mtlgIgnatiusFreq ' range=':=  _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Ignatius is complete. -->
-
-            <!-- End Ignatius Generation -->
-
-
-            <!-- Begin Shadow Iron Generation -->
-
-            <!-- Starting LayeredVeins Preset for Shadow Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgShadowIronDist = "LayeredVeins"'>
-                    <Veins name='mtlgShadowIronVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.768 * _default_ * mtlgShadowIronFreq ' range=':=  _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.916 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.916 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.916 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Shadow Iron is complete. -->
-
-
-            <!-- Starting Cloud Preset for Shadow Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgShadowIronDist = "Cloud"'>
-                    <Cloud name='mtlgShadowIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.238 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.238 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.533  * _default_ * mtlgShadowIronFreq ' range=':=  _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgShadowIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Shadow Iron is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Shadow Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgShadowIronDist = "Vanilla"'>
-                    <StandardGen name='mtlgShadowIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 7 * mtlgShadowIronFreq ' range=':=  _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Shadow Iron is complete. -->
-
-            <!-- End Shadow Iron Generation -->
-
-
-            <!-- Begin Lemurite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Lemurite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgLemuriteDist = "LayeredVeins"'>
-                    <Veins name='mtlgLemuriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.711 * _default_ * mtlgLemuriteFreq ' range=':=  _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.892 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.892 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Lemurite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Lemurite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgLemuriteDist = "Cloud"'>
-                    <Cloud name='mtlgLemuriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.191 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.191 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * mtlgLemuriteFreq ' range=':=  _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgLemuriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Lemurite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Lemurite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgLemuriteDist = "Vanilla"'>
-                    <StandardGen name='mtlgLemuriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 6 * mtlgLemuriteFreq ' range=':=  _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Lemurite is complete. -->
-
-            <!-- End Lemurite Generation -->
-
-
-            <!-- Begin Midasium Generation -->
-
-            <!-- Starting LayeredVeins Preset for Midasium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgMidasiumDist = "LayeredVeins"'>
-                    <Veins name='mtlgMidasiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgMidasiumFreq ' range=':=  _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Midasium is complete. -->
-
-
-            <!-- Starting Cloud Preset for Midasium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgMidasiumDist = "Cloud"'>
-                    <Cloud name='mtlgMidasiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgMidasiumFreq ' range=':=  _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgMidasiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Midasium is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Midasium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgMidasiumDist = "Vanilla"'>
-                    <StandardGen name='mtlgMidasiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 5 * mtlgMidasiumFreq ' range=':=  _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Midasium is complete. -->
-
-            <!-- End Midasium Generation -->
-
-
-            <!-- Begin Vyroxeres Generation -->
-
-            <!-- Starting LayeredVeins Preset for Vyroxeres. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgVyroxeresDist = "LayeredVeins"'>
-                    <Veins name='mtlgVyroxeresVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.627 * _default_ * mtlgVyroxeresFreq ' range=':=  _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.856 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.856 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.856 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Vyroxeres is complete. -->
-
-
-            <!-- Starting Cloud Preset for Vyroxeres. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgVyroxeresDist = "Cloud"'>
-                    <Cloud name='mtlgVyroxeresCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.119 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.119 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.251  * _default_ * mtlgVyroxeresFreq ' range=':=  _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgVyroxeresHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Vyroxeres is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Vyroxeres. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgVyroxeresDist = "Vanilla"'>
-                    <StandardGen name='mtlgVyroxeresStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 7 * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * mtlgVyroxeresFreq ' range=':=  _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Vyroxeres is complete. -->
-
-            <!-- End Vyroxeres Generation -->
-
-
-            <!-- Begin Ceruclase Generation -->
-
-            <!-- Starting LayeredVeins Preset for Ceruclase. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgCeruclaseDist = "LayeredVeins"'>
-                    <Veins name='mtlgCeruclaseVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * mtlgCeruclaseFreq ' range=':=  _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Ceruclase is complete. -->
-
-
-            <!-- Starting Cloud Preset for Ceruclase. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgCeruclaseDist = "Cloud"'>
-                    <Cloud name='mtlgCeruclaseCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgCeruclaseFreq ' range=':=  _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgCeruclaseHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Ceruclase is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Ceruclase. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgCeruclaseDist = "Vanilla"'>
-                    <StandardGen name='mtlgCeruclaseStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * mtlgCeruclaseFreq ' range=':=  _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Ceruclase is complete. -->
-
-            <!-- End Ceruclase Generation -->
-
-
-            <!-- Begin Alduorite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Alduorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgAlduoriteDist = "LayeredVeins"'>
-                    <Veins name='mtlgAlduoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgAlduoriteFreq ' range=':=  _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Alduorite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Alduorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgAlduoriteDist = "Cloud"'>
-                    <Cloud name='mtlgAlduoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgAlduoriteFreq ' range=':=  _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgAlduoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Alduorite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Alduorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgAlduoriteDist = "Vanilla"'>
-                    <StandardGen name='mtlgAlduoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * mtlgAlduoriteFreq ' range=':=  _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Alduorite is complete. -->
-
-            <!-- End Alduorite Generation -->
-
-
-            <!-- Begin Kalendrite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Kalendrite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgKalendriteDist = "LayeredVeins"'>
-                    <Veins name='mtlgKalendriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgKalendriteFreq ' range=':=  _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Kalendrite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Kalendrite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgKalendriteDist = "Cloud"'>
-                    <Cloud name='mtlgKalendriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgKalendriteFreq ' range=':=  _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgKalendriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Kalendrite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Kalendrite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgKalendriteDist = "Vanilla"'>
-                    <StandardGen name='mtlgKalendriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * mtlgKalendriteFreq ' range=':=  _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Kalendrite is complete. -->
-
-            <!-- End Kalendrite Generation -->
-
-
-            <!-- Begin Vulcanite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Vulcanite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgVulcaniteDist = "LayeredVeins"'>
-                    <Veins name='mtlgVulcaniteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgVulcaniteFreq ' range=':=  _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Vulcanite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Vulcanite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgVulcaniteDist = "Cloud"'>
-                    <Cloud name='mtlgVulcaniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgVulcaniteFreq ' range=':=  _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgVulcaniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Vulcanite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Vulcanite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgVulcaniteDist = "Vanilla"'>
-                    <StandardGen name='mtlgVulcaniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * mtlgVulcaniteFreq ' range=':=  _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Vulcanite is complete. -->
-
-            <!-- End Vulcanite Generation -->
-
-
-            <!-- Begin Sanguinite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Sanguinite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgSanguiniteDist = "LayeredVeins"'>
-                    <Veins name='mtlgSanguiniteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgSanguiniteFreq ' range=':=  _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Sanguinite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Sanguinite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgSanguiniteDist = "Cloud"'>
-                    <Cloud name='mtlgSanguiniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgSanguiniteFreq ' range=':=  _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgSanguiniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Sanguinite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Sanguinite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgSanguiniteDist = "Vanilla"'>
-                    <StandardGen name='mtlgSanguiniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * mtlgSanguiniteFreq ' range=':=  _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Sanguinite is complete. -->
-
-            <!-- End Sanguinite Generation -->
-
-            <!-- Finished adding blocks -->
-
-        </IfCondition>
-        <!-- Nether Setup Complete -->
-
-
-
-
-
-        <!-- End Setup Beginning -->
-
-        <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
-
-            <!-- Starting Original "End" Block Removal -->
-
-            <Substitute name='mtlgEndBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='Metallurgy:ender.ore' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "End" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Eximite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Eximite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgEximiteDist = "LayeredVeins"'>
-                    <Veins name='mtlgEximiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * mtlgEximiteFreq ' range=':=  _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Eximite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Eximite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgEximiteDist = "Cloud"'>
-                    <Cloud name='mtlgEximiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.076 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.076 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * mtlgEximiteFreq ' range=':=  _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgEximiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Eximite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Eximite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgEximiteDist = "Vanilla"'>
-                    <StandardGen name='mtlgEximiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 6 * mtlgEximiteFreq ' range=':=  _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Eximite is complete. -->
-
-            <!-- End Eximite Generation -->
-
-
-            <!-- Begin Meutoite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Meutoite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgMeutoiteDist = "LayeredVeins"'>
-                    <Veins name='mtlgMeutoiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgMeutoiteFreq ' range=':=  _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Meutoite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Meutoite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgMeutoiteDist = "Cloud"'>
-                    <Cloud name='mtlgMeutoiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgMeutoiteFreq ' range=':=  _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mtlgMeutoiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Meutoite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Meutoite. -->
-            <ConfigSection>
-                <IfCondition condition=':= mtlgMeutoiteDist = "Vanilla"'>
-                    <StandardGen name='mtlgMeutoiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 6 * mtlgMeutoiteFreq ' range=':=  _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Meutoite is complete. -->
-
-            <!-- End Meutoite Generation -->
-
-            <!-- Finished adding blocks -->
-
-        </IfCondition>
-        <!-- End Setup Complete -->
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -1,6964 +1,5486 @@
- <!-- ================================================================
-      Custom Ore Generation "Metallurgy 4" Module: This configuration
-      covers sulfur, phosphorite, saltpeter, magnesium, bitumen,
-      potash, copper,  tin, manganese, zinc, silver, platinum,
-      promethium, deep iron,  infuscolium, oureclase, astral silver,
-      carmot, mithril, rubracium,  orichalcum, adamantine, atlarus,
-      ignatius, shadow iron, lemurite,  midasium, vyroxeres,
-      ceruclase, alduorite, kalendrite, vulcanite,  sanguinite,
-      eximite, and meutoite.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Metallurgy 4" Module: This configuration
+     covers sulfur, phosphorite, saltpeter, magnesium, bitumen,
+     potash, copper, tin, manganese, zinc, silver, platinum,
+     promethium, deep iron, infuscolium, oureclase, astral silver,
+     carmot, mithril, rubracium, orichalcum, adamantine, atlarus,
+     ignatius, shadow iron, lemurite, midasium, vyroxeres, ceruclase,
+     alduorite, kalendrite, vulcanite, sanguinite, eximite, and
+     meutoite.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="Metallurgy">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+<!-- This mod includes a huge number of ores to make minecraft far
+     more interesting, especially when involving tool progression. -->
+
+
+
+
+<!-- Is the "Metallurgy 4" mod on the system?  Let's find out! -->
+<IfModInstalled name="Metallurgy">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupMetallurgy4' displayName='Metallurgy 4' displayState='shown'>
+                <Description>
+                    Distribution options for Metallurgy 4 Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Sulfur Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupMetallurgy4' displayName='Metallurgy 4' displayState='shown'> 
-                    <Description>
-                        Distribution options for Metallurgy 4 Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Sulfur Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgSulfurDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Sulfur is generated </Description> 
-                        <DisplayName>Metallurgy 4 Sulfur</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Sulfur is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgSulfurFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Sulfur distributions </Description>
-                        <DisplayName>Metallurgy 4 Sulfur Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgSulfurSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Sulfur distributions </Description>
-                        <DisplayName>Metallurgy 4 Sulfur Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Sulfur Configuration UI Complete -->
-                
-                
-                <!-- Phosphorite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgPhosphoriteDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Phosphorite is generated </Description> 
-                        <DisplayName>Metallurgy 4 Phosphorite</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Phosphorite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgPhosphoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Phosphorite distributions </Description>
-                        <DisplayName>Metallurgy 4 Phosphorite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgPhosphoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Phosphorite distributions </Description>
-                        <DisplayName>Metallurgy 4 Phosphorite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Phosphorite Configuration UI Complete -->
-                
-                
-                <!-- Saltpeter Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgSaltpeterDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Saltpeter is generated </Description> 
-                        <DisplayName>Metallurgy 4 Saltpeter</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Saltpeter is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgSaltpeterFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Saltpeter distributions </Description>
-                        <DisplayName>Metallurgy 4 Saltpeter Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgSaltpeterSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Saltpeter distributions </Description>
-                        <DisplayName>Metallurgy 4 Saltpeter Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Saltpeter Configuration UI Complete -->
-                
-                
-                <!-- Magnesium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgMagnesiumDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Magnesium is generated </Description> 
-                        <DisplayName>Metallurgy 4 Magnesium</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Magnesium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgMagnesiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Magnesium distributions </Description>
-                        <DisplayName>Metallurgy 4 Magnesium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgMagnesiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Magnesium distributions </Description>
-                        <DisplayName>Metallurgy 4 Magnesium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Magnesium Configuration UI Complete -->
-                
-                
-                <!-- Bitumen Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgBitumenDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Bitumen is generated </Description> 
-                        <DisplayName>Metallurgy 4 Bitumen</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Bitumen is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgBitumenFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Bitumen distributions </Description>
-                        <DisplayName>Metallurgy 4 Bitumen Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgBitumenSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Bitumen distributions </Description>
-                        <DisplayName>Metallurgy 4 Bitumen Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Bitumen Configuration UI Complete -->
-                
-                
-                <!-- Potash Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgPotashDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Potash is generated </Description> 
-                        <DisplayName>Metallurgy 4 Potash</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Potash is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgPotashFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Potash distributions </Description>
-                        <DisplayName>Metallurgy 4 Potash Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgPotashSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Potash distributions </Description>
-                        <DisplayName>Metallurgy 4 Potash Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Potash Configuration UI Complete -->
-                
-                
-                <!-- Copper Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgCopperDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Copper is generated </Description> 
-                        <DisplayName>Metallurgy 4 Copper</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Copper distributions </Description>
-                        <DisplayName>Metallurgy 4 Copper Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Copper distributions </Description>
-                        <DisplayName>Metallurgy 4 Copper Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Copper Configuration UI Complete -->
-                
-                
-                <!-- Tin Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgTinDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Tin is generated </Description> 
-                        <DisplayName>Metallurgy 4 Tin</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Tin distributions </Description>
-                        <DisplayName>Metallurgy 4 Tin Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Tin distributions </Description>
-                        <DisplayName>Metallurgy 4 Tin Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Tin Configuration UI Complete -->
-                
-                
-                <!-- Manganese Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgManganeseDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Manganese is generated </Description> 
-                        <DisplayName>Metallurgy 4 Manganese</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Manganese is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgManganeseFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Manganese distributions </Description>
-                        <DisplayName>Metallurgy 4 Manganese Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgManganeseSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Manganese distributions </Description>
-                        <DisplayName>Metallurgy 4 Manganese Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Manganese Configuration UI Complete -->
-                
-                
-                <!-- Zinc Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgZincDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Zinc is generated </Description> 
-                        <DisplayName>Metallurgy 4 Zinc</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Zinc is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgZincFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Zinc distributions </Description>
-                        <DisplayName>Metallurgy 4 Zinc Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgZincSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Zinc distributions </Description>
-                        <DisplayName>Metallurgy 4 Zinc Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Zinc Configuration UI Complete -->
-                
-                
-                <!-- Silver Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgSilverDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Silver is generated </Description> 
-                        <DisplayName>Metallurgy 4 Silver</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Silver distributions </Description>
-                        <DisplayName>Metallurgy 4 Silver Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Silver distributions </Description>
-                        <DisplayName>Metallurgy 4 Silver Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Silver Configuration UI Complete -->
-                
-                
-                <!-- Platinum Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgPlatinumDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Platinum is generated </Description> 
-                        <DisplayName>Metallurgy 4 Platinum</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Platinum is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgPlatinumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Platinum distributions </Description>
-                        <DisplayName>Metallurgy 4 Platinum Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgPlatinumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Platinum distributions </Description>
-                        <DisplayName>Metallurgy 4 Platinum Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Platinum Configuration UI Complete -->
-                
-                
-                <!-- Promethium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgPromethiumDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Promethium is generated </Description> 
-                        <DisplayName>Metallurgy 4 Promethium</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Promethium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgPromethiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Promethium distributions </Description>
-                        <DisplayName>Metallurgy 4 Promethium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgPromethiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Promethium distributions </Description>
-                        <DisplayName>Metallurgy 4 Promethium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Promethium Configuration UI Complete -->
-                
-                
-                <!-- Deep Iron Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgDeepIronDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Deep Iron is generated </Description> 
-                        <DisplayName>Metallurgy 4 Deep Iron</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Deep Iron is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgDeepIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Deep Iron distributions </Description>
-                        <DisplayName>Metallurgy 4 Deep Iron Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgDeepIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Deep Iron distributions </Description>
-                        <DisplayName>Metallurgy 4 Deep Iron Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Deep Iron Configuration UI Complete -->
-                
-                
-                <!-- Infuscolium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgInfuscoliumDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Infuscolium is generated </Description> 
-                        <DisplayName>Metallurgy 4 Infuscolium</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Infuscolium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgInfuscoliumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Infuscolium distributions </Description>
-                        <DisplayName>Metallurgy 4 Infuscolium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgInfuscoliumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Infuscolium distributions </Description>
-                        <DisplayName>Metallurgy 4 Infuscolium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Infuscolium Configuration UI Complete -->
-                
-                
-                <!-- Oureclase Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgOureclaseDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Oureclase is generated </Description> 
-                        <DisplayName>Metallurgy 4 Oureclase</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Oureclase is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgOureclaseFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Oureclase distributions </Description>
-                        <DisplayName>Metallurgy 4 Oureclase Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgOureclaseSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Oureclase distributions </Description>
-                        <DisplayName>Metallurgy 4 Oureclase Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Oureclase Configuration UI Complete -->
-                
-                
-                <!-- Astral Silver Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgAstralSilverDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Astral Silver is generated </Description> 
-                        <DisplayName>Metallurgy 4 Astral Silver</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Astral Silver is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgAstralSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Astral Silver distributions </Description>
-                        <DisplayName>Metallurgy 4 Astral Silver Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgAstralSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Astral Silver distributions </Description>
-                        <DisplayName>Metallurgy 4 Astral Silver Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Astral Silver Configuration UI Complete -->
-                
-                
-                <!-- Carmot Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgCarmotDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Carmot is generated </Description> 
-                        <DisplayName>Metallurgy 4 Carmot</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Carmot is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgCarmotFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Carmot distributions </Description>
-                        <DisplayName>Metallurgy 4 Carmot Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgCarmotSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Carmot distributions </Description>
-                        <DisplayName>Metallurgy 4 Carmot Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Carmot Configuration UI Complete -->
-                
-                
-                <!-- Mithril Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgMithrilDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Mithril is generated </Description> 
-                        <DisplayName>Metallurgy 4 Mithril</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Mithril is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgMithrilFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Mithril distributions </Description>
-                        <DisplayName>Metallurgy 4 Mithril Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgMithrilSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Mithril distributions </Description>
-                        <DisplayName>Metallurgy 4 Mithril Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Mithril Configuration UI Complete -->
-                
-                
-                <!-- Rubracium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgRubraciumDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Rubracium is generated </Description> 
-                        <DisplayName>Metallurgy 4 Rubracium</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Rubracium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgRubraciumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Rubracium distributions </Description>
-                        <DisplayName>Metallurgy 4 Rubracium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgRubraciumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Rubracium distributions </Description>
-                        <DisplayName>Metallurgy 4 Rubracium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Rubracium Configuration UI Complete -->
-                
-                
-                <!-- Orichalcum Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgOrichalcumDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Orichalcum is generated </Description> 
-                        <DisplayName>Metallurgy 4 Orichalcum</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Orichalcum is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgOrichalcumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Orichalcum distributions </Description>
-                        <DisplayName>Metallurgy 4 Orichalcum Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgOrichalcumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Orichalcum distributions </Description>
-                        <DisplayName>Metallurgy 4 Orichalcum Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Orichalcum Configuration UI Complete -->
-                
-                
-                <!-- Adamantine Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgAdamantineDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Adamantine is generated </Description> 
-                        <DisplayName>Metallurgy 4 Adamantine</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Adamantine is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgAdamantineFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Adamantine distributions </Description>
-                        <DisplayName>Metallurgy 4 Adamantine Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgAdamantineSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Adamantine distributions </Description>
-                        <DisplayName>Metallurgy 4 Adamantine Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Adamantine Configuration UI Complete -->
-                
-                
-                <!-- Atlarus Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgAtlarusDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Atlarus is generated </Description> 
-                        <DisplayName>Metallurgy 4 Atlarus</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Atlarus is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgAtlarusFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Atlarus distributions </Description>
-                        <DisplayName>Metallurgy 4 Atlarus Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgAtlarusSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Atlarus distributions </Description>
-                        <DisplayName>Metallurgy 4 Atlarus Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Atlarus Configuration UI Complete -->
-                
-                
-                <!-- Ignatius Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgIgnatiusDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Ignatius is generated </Description> 
-                        <DisplayName>Metallurgy 4 Ignatius</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Ignatius is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgIgnatiusFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Ignatius distributions </Description>
-                        <DisplayName>Metallurgy 4 Ignatius Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgIgnatiusSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Ignatius distributions </Description>
-                        <DisplayName>Metallurgy 4 Ignatius Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Ignatius Configuration UI Complete -->
-                
-                
-                <!-- Shadow Iron Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgShadowIronDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Shadow Iron is generated </Description> 
-                        <DisplayName>Metallurgy 4 Shadow Iron</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Shadow Iron is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgShadowIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Shadow Iron distributions </Description>
-                        <DisplayName>Metallurgy 4 Shadow Iron Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgShadowIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Shadow Iron distributions </Description>
-                        <DisplayName>Metallurgy 4 Shadow Iron Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Shadow Iron Configuration UI Complete -->
-                
-                
-                <!-- Lemurite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgLemuriteDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Lemurite is generated </Description> 
-                        <DisplayName>Metallurgy 4 Lemurite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Lemurite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgLemuriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Lemurite distributions </Description>
-                        <DisplayName>Metallurgy 4 Lemurite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgLemuriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Lemurite distributions </Description>
-                        <DisplayName>Metallurgy 4 Lemurite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Lemurite Configuration UI Complete -->
-                
-                
-                <!-- Midasium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgMidasiumDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Midasium is generated </Description> 
-                        <DisplayName>Metallurgy 4 Midasium</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Midasium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgMidasiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Midasium distributions </Description>
-                        <DisplayName>Metallurgy 4 Midasium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgMidasiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Midasium distributions </Description>
-                        <DisplayName>Metallurgy 4 Midasium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Midasium Configuration UI Complete -->
-                
-                
-                <!-- Vyroxeres Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgVyroxeresDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Vyroxeres is generated </Description> 
-                        <DisplayName>Metallurgy 4 Vyroxeres</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Vyroxeres is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgVyroxeresFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Vyroxeres distributions </Description>
-                        <DisplayName>Metallurgy 4 Vyroxeres Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgVyroxeresSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Vyroxeres distributions </Description>
-                        <DisplayName>Metallurgy 4 Vyroxeres Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Vyroxeres Configuration UI Complete -->
-                
-                
-                <!-- Ceruclase Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgCeruclaseDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Ceruclase is generated </Description> 
-                        <DisplayName>Metallurgy 4 Ceruclase</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Ceruclase is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgCeruclaseFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Ceruclase distributions </Description>
-                        <DisplayName>Metallurgy 4 Ceruclase Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgCeruclaseSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Ceruclase distributions </Description>
-                        <DisplayName>Metallurgy 4 Ceruclase Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Ceruclase Configuration UI Complete -->
-                
-                
-                <!-- Alduorite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgAlduoriteDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Alduorite is generated </Description> 
-                        <DisplayName>Metallurgy 4 Alduorite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Alduorite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgAlduoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Alduorite distributions </Description>
-                        <DisplayName>Metallurgy 4 Alduorite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgAlduoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Alduorite distributions </Description>
-                        <DisplayName>Metallurgy 4 Alduorite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Alduorite Configuration UI Complete -->
-                
-                
-                <!-- Kalendrite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgKalendriteDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Kalendrite is generated </Description> 
-                        <DisplayName>Metallurgy 4 Kalendrite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Kalendrite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgKalendriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Kalendrite distributions </Description>
-                        <DisplayName>Metallurgy 4 Kalendrite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgKalendriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Kalendrite distributions </Description>
-                        <DisplayName>Metallurgy 4 Kalendrite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Kalendrite Configuration UI Complete -->
-                
-                
-                <!-- Vulcanite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgVulcaniteDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Vulcanite is generated </Description> 
-                        <DisplayName>Metallurgy 4 Vulcanite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Vulcanite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgVulcaniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Vulcanite distributions </Description>
-                        <DisplayName>Metallurgy 4 Vulcanite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgVulcaniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Vulcanite distributions </Description>
-                        <DisplayName>Metallurgy 4 Vulcanite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Vulcanite Configuration UI Complete -->
-                
-                
-                <!-- Sanguinite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgSanguiniteDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Sanguinite is generated </Description> 
-                        <DisplayName>Metallurgy 4 Sanguinite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Sanguinite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgSanguiniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Sanguinite distributions </Description>
-                        <DisplayName>Metallurgy 4 Sanguinite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgSanguiniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Sanguinite distributions </Description>
-                        <DisplayName>Metallurgy 4 Sanguinite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Sanguinite Configuration UI Complete -->
-                
-                
-                <!-- Eximite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgEximiteDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Eximite is generated </Description> 
-                        <DisplayName>Metallurgy 4 Eximite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Eximite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgEximiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Eximite distributions </Description>
-                        <DisplayName>Metallurgy 4 Eximite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgEximiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Eximite distributions </Description>
-                        <DisplayName>Metallurgy 4 Eximite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Eximite Configuration UI Complete -->
-                
-                
-                <!-- Meutoite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mtlgMeutoiteDist'  displayState='shown' displayGroup='groupMetallurgy4'> 
-                        <Description> Controls how Meutoite is generated </Description> 
-                        <DisplayName>Metallurgy 4 Meutoite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Meutoite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mtlgMeutoiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Frequency multiplier for Metallurgy 4 Meutoite distributions </Description>
-                        <DisplayName>Metallurgy 4 Meutoite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mtlgMeutoiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
-                        <Description> Size multiplier for Metallurgy 4 Meutoite distributions </Description>
-                        <DisplayName>Metallurgy 4 Meutoite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Meutoite Configuration UI Complete -->
-                
+                <OptionChoice name='mtlgSulfurDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Sulfur is generated </Description>
+                    <DisplayName>Metallurgy 4 Sulfur</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
+                        <Description>
+                            Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Sulfur is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgSulfurFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Sulfur distributions </Description>
+                    <DisplayName>Metallurgy 4 Sulfur Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgSulfurSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Sulfur distributions </Description>
+                    <DisplayName>Metallurgy 4 Sulfur Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Sulfur Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='mtlgOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='Metallurgy:utility.ore' />
-                    <Replaces block='Metallurgy:utility.ore:1' />
-                    <Replaces block='Metallurgy:utility.ore:2' />
-                    <Replaces block='Metallurgy:utility.ore:3' />
-                    <Replaces block='Metallurgy:utility.ore:4' />
-                    <Replaces block='Metallurgy:utility.ore:5' />
-                    <Replaces block='Metallurgy:base.ore' />
-                    <Replaces block='Metallurgy:base.ore:1' />
-                    <Replaces block='Metallurgy:base.ore:2' />
-                    <Replaces block='Metallurgy:precious.ore' />
-                    <Replaces block='Metallurgy:precious.ore:1' />
-                    <Replaces block='Metallurgy:precious.ore:2' />
-                    <Replaces block='Metallurgy:fantasy.ore' />
-                    <Replaces block='Metallurgy:fantasy.ore:1' />
-                    <Replaces block='Metallurgy:fantasy.ore:2' />
-                    <Replaces block='Metallurgy:fantasy.ore:4' />
-                    <Replaces block='Metallurgy:fantasy.ore:5' />
-                    <Replaces block='Metallurgy:fantasy.ore:6' />
-                    <Replaces block='Metallurgy:fantasy.ore:7' />
-                    <Replaces block='Metallurgy:fantasy.ore:8' />
-                    <Replaces block='Metallurgy:fantasy.ore:11' />
-                    <Replaces block='Metallurgy:fantasy.ore:13' />
-                    <Replaces block='Metallurgy:fantasy.ore:14' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Sulfur Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Sulfur -->
-                <IfCondition condition=':= mtlgSulfurDist = "sparseVeins"'>
-                
-                    <Veins name='mtlgSulfurBaseVeins' block='Metallurgy:utility.ore'  inherits='PresetSparseVeins' >
+            <!-- Phosphorite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgPhosphoriteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Phosphorite is generated </Description>
+                    <DisplayName>Metallurgy 4 Phosphorite</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCF570</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgSulfurSize * _default_' range=':= 1 * 1 * mtlgSulfurSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgSulfurSize * _default_' range=':= 1 * 1 * mtlgSulfurSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgSulfurFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Sulfur Sparse Veins) Settings -->
-                    <Veins name='mtlgSulfurPrefersVeins' block='Metallurgy:utility.ore'  inherits='mtlgSulfurBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCF570</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Desert'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Sulfur Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Sulfur -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Sulfur -->
-                <IfCondition condition=':= mtlgSulfurDist = "smallDeposits"'>
-                
-                    <Veins name='mtlgSulfurBaseVeins' block='Metallurgy:utility.ore'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCF570</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgSulfurSize * _default_' range=':= 1 * 1 * mtlgSulfurSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgSulfurSize * _default_' range=':= 1 * 1 * mtlgSulfurSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgSulfurFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Sulfur Deposit Veins) Settings -->
-                    <Veins name='mtlgSulfurPrefersVeins' block='Metallurgy:utility.ore'  inherits='mtlgSulfurBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCF570</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Desert'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Sulfur Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Sulfur -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Sulfur -->
-                <IfCondition condition=':= mtlgSulfurDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgSulfurBaseCloud' block='Metallurgy:utility.ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCF570</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1.2 * mtlgSulfurSize * _default_' range=':= 1 * 1.2 * mtlgSulfurSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.2 * mtlgSulfurSize * _default_' range=':= 1 * 1.2 * mtlgSulfurSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.75 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1.2 * mtlgSulfurSize * _default_' range=':= 1 * 1 * 1.2 * mtlgSulfurSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 5 * mtlgSulfurFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Sulfur Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgSulfurBaseHintVeins' block='Metallurgy:utility.ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FCF570</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Sulfur Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Phosphorite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgPhosphoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Phosphorite distributions </Description>
+                    <DisplayName>Metallurgy 4 Phosphorite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgPhosphoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Phosphorite distributions </Description>
+                    <DisplayName>Metallurgy 4 Phosphorite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Phosphorite Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Sulfur -->
-                
-                
-                <!-- Begin  Vanilla distribution of Sulfur -->
-                <IfCondition condition=':= mtlgSulfurDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgSulfurBaseStandard' block='Metallurgy:utility.ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCF570</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 2 * mtlgSulfurSize * _default_'/>
-                        <Setting name='Height' avg=':= 60' range=':= 10' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/6 * mtlgSulfurFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Sulfur -->
-                
-                <!-- End Sulfur Generation --> 
 
-                
-                <!-- Begin Phosphorite Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Phosphorite -->
-                <IfCondition condition=':= mtlgPhosphoriteDist = "sparseVeins"'>
-                
-                    <Veins name='mtlgPhosphoriteBaseVeins' block='Metallurgy:utility.ore:1'  inherits='PresetSparseVeins' >
+            <!-- Saltpeter Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgSaltpeterDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Saltpeter is generated </Description>
+                    <DisplayName>Metallurgy 4 Saltpeter</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608D6161</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgPhosphoriteSize * _default_' range=':= 1 * 1 * mtlgPhosphoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgPhosphoriteSize * _default_' range=':= 1 * 1 * mtlgPhosphoriteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgPhosphoriteFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Phosphorite Sparse Veins) Settings -->
-                    <Veins name='mtlgPhosphoritePrefersVeins' block='Metallurgy:utility.ore:1'  inherits='mtlgPhosphoriteBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608D6161</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Phosphorite Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Phosphorite -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Phosphorite -->
-                <IfCondition condition=':= mtlgPhosphoriteDist = "smallDeposits"'>
-                
-                    <Veins name='mtlgPhosphoriteBaseVeins' block='Metallurgy:utility.ore:1'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608D6161</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgPhosphoriteSize * _default_' range=':= 1 * 1 * mtlgPhosphoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgPhosphoriteSize * _default_' range=':= 1 * 1 * mtlgPhosphoriteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgPhosphoriteFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Phosphorite Deposit Veins) Settings -->
-                    <Veins name='mtlgPhosphoritePrefersVeins' block='Metallurgy:utility.ore:1'  inherits='mtlgPhosphoriteBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608D6161</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Phosphorite Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Phosphorite -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Phosphorite -->
-                <IfCondition condition=':= mtlgPhosphoriteDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgPhosphoriteBaseCloud' block='Metallurgy:utility.ore:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608D6161</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1.2 * mtlgPhosphoriteSize * _default_' range=':= 1 * 1.2 * mtlgPhosphoriteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.2 * mtlgPhosphoriteSize * _default_' range=':= 1 * 1.2 * mtlgPhosphoriteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.75 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1.2 * mtlgPhosphoriteSize * _default_' range=':= 1 * 1 * 1.2 * mtlgPhosphoriteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 5 * mtlgPhosphoriteFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Phosphorite Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgPhosphoriteBaseHintVeins' block='Metallurgy:utility.ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x608D6161</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Phosphorite Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Saltpeter is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgSaltpeterFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Saltpeter distributions </Description>
+                    <DisplayName>Metallurgy 4 Saltpeter Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgSaltpeterSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Saltpeter distributions </Description>
+                    <DisplayName>Metallurgy 4 Saltpeter Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Saltpeter Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Phosphorite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Phosphorite -->
-                <IfCondition condition=':= mtlgPhosphoriteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgPhosphoriteBaseStandard' block='Metallurgy:utility.ore:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608D6161</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 2 * mtlgPhosphoriteSize * _default_'/>
-                        <Setting name='Height' avg=':= 60' range=':= 10' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/6 * mtlgPhosphoriteFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Phosphorite -->
-                
-                <!-- End Phosphorite Generation --> 
 
-                
-                <!-- Begin Saltpeter Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Saltpeter -->
-                <IfCondition condition=':= mtlgSaltpeterDist = "sparseVeins"'>
-                
-                    <Veins name='mtlgSaltpeterBaseVeins' block='Metallurgy:utility.ore:2'  inherits='PresetSparseVeins' >
+            <!-- Magnesium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgMagnesiumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Magnesium is generated </Description>
+                    <DisplayName>Metallurgy 4 Magnesium</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEAEA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgSaltpeterSize * _default_' range=':= 1 * 1 * mtlgSaltpeterSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgSaltpeterSize * _default_' range=':= 1 * 1 * mtlgSaltpeterSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgSaltpeterFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Saltpeter Sparse Veins) Settings -->
-                    <Veins name='mtlgSaltpeterPrefersVeins' block='Metallurgy:utility.ore:2'  inherits='mtlgSaltpeterBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEAEA</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Desert'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Saltpeter Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Saltpeter -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Saltpeter -->
-                <IfCondition condition=':= mtlgSaltpeterDist = "smallDeposits"'>
-                
-                    <Veins name='mtlgSaltpeterBaseVeins' block='Metallurgy:utility.ore:2'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEAEA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgSaltpeterSize * _default_' range=':= 1 * 1 * mtlgSaltpeterSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgSaltpeterSize * _default_' range=':= 1 * 1 * mtlgSaltpeterSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgSaltpeterFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Saltpeter Deposit Veins) Settings -->
-                    <Veins name='mtlgSaltpeterPrefersVeins' block='Metallurgy:utility.ore:2'  inherits='mtlgSaltpeterBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEAEA</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Desert'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Saltpeter Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Saltpeter -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Saltpeter -->
-                <IfCondition condition=':= mtlgSaltpeterDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgSaltpeterBaseCloud' block='Metallurgy:utility.ore:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEAEA</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1.2 * mtlgSaltpeterSize * _default_' range=':= 1 * 1.2 * mtlgSaltpeterSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.2 * mtlgSaltpeterSize * _default_' range=':= 1 * 1.2 * mtlgSaltpeterSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.75 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1.2 * mtlgSaltpeterSize * _default_' range=':= 1 * 1 * 1.2 * mtlgSaltpeterSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 5 * mtlgSaltpeterFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Saltpeter Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgSaltpeterBaseHintVeins' block='Metallurgy:utility.ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EAEAEA</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Saltpeter Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Magnesium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgMagnesiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Magnesium distributions </Description>
+                    <DisplayName>Metallurgy 4 Magnesium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgMagnesiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Magnesium distributions </Description>
+                    <DisplayName>Metallurgy 4 Magnesium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Magnesium Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Saltpeter -->
-                
-                
-                <!-- Begin  Vanilla distribution of Saltpeter -->
-                <IfCondition condition=':= mtlgSaltpeterDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgSaltpeterBaseStandard' block='Metallurgy:utility.ore:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEAEA</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 2 * mtlgSaltpeterSize * _default_'/>
-                        <Setting name='Height' avg=':= 60' range=':= 10' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/6 * mtlgSaltpeterFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Saltpeter -->
-                
-                <!-- End Saltpeter Generation --> 
 
-                
-                <!-- Begin Magnesium Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Magnesium -->
-                <IfCondition condition=':= mtlgMagnesiumDist = "sparseVeins"'>
-                
-                    <Veins name='mtlgMagnesiumBaseVeins' block='Metallurgy:utility.ore:3'  inherits='PresetSparseVeins' >
+            <!-- Bitumen Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgBitumenDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Bitumen is generated </Description>
+                    <DisplayName>Metallurgy 4 Bitumen</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60927C6C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgMagnesiumSize * _default_' range=':= 1 * 1 * mtlgMagnesiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgMagnesiumSize * _default_' range=':= 1 * 1 * mtlgMagnesiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgMagnesiumFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Magnesium Sparse Veins) Settings -->
-                    <Veins name='mtlgMagnesiumPrefersVeins' block='Metallurgy:utility.ore:3'  inherits='mtlgMagnesiumBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60927C6C</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Magnesium Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Magnesium -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Magnesium -->
-                <IfCondition condition=':= mtlgMagnesiumDist = "smallDeposits"'>
-                
-                    <Veins name='mtlgMagnesiumBaseVeins' block='Metallurgy:utility.ore:3'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60927C6C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgMagnesiumSize * _default_' range=':= 1 * 1 * mtlgMagnesiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgMagnesiumSize * _default_' range=':= 1 * 1 * mtlgMagnesiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgMagnesiumFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Magnesium Deposit Veins) Settings -->
-                    <Veins name='mtlgMagnesiumPrefersVeins' block='Metallurgy:utility.ore:3'  inherits='mtlgMagnesiumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60927C6C</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Magnesium Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Magnesium -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Magnesium -->
-                <IfCondition condition=':= mtlgMagnesiumDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgMagnesiumBaseCloud' block='Metallurgy:utility.ore:3' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60927C6C</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1.2 * mtlgMagnesiumSize * _default_' range=':= 1 * 1.2 * mtlgMagnesiumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.2 * mtlgMagnesiumSize * _default_' range=':= 1 * 1.2 * mtlgMagnesiumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.75 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1.2 * mtlgMagnesiumSize * _default_' range=':= 1 * 1 * 1.2 * mtlgMagnesiumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 5 * mtlgMagnesiumFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Magnesium Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgMagnesiumBaseHintVeins' block='Metallurgy:utility.ore:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60927C6C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Magnesium Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Bitumen is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgBitumenFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Bitumen distributions </Description>
+                    <DisplayName>Metallurgy 4 Bitumen Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgBitumenSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Bitumen distributions </Description>
+                    <DisplayName>Metallurgy 4 Bitumen Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Bitumen Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Magnesium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Magnesium -->
-                <IfCondition condition=':= mtlgMagnesiumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgMagnesiumBaseStandard' block='Metallurgy:utility.ore:3' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60927C6C</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 2 * mtlgMagnesiumSize * _default_'/>
-                        <Setting name='Height' avg=':= 60' range=':= 10' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/6 * mtlgMagnesiumFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Magnesium -->
-                
-                <!-- End Magnesium Generation --> 
 
-                
-                <!-- Begin Bitumen Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Bitumen -->
-                <IfCondition condition=':= mtlgBitumenDist = "sparseVeins"'>
-                
-                    <Veins name='mtlgBitumenBaseVeins' block='Metallurgy:utility.ore:4'  inherits='PresetSparseVeins' >
+            <!-- Potash Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgPotashDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Potash is generated </Description>
+                    <DisplayName>Metallurgy 4 Potash</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602A2A2A</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgBitumenSize * _default_' range=':= 1 * 1 * mtlgBitumenSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgBitumenSize * _default_' range=':= 1 * 1 * mtlgBitumenSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgBitumenFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Bitumen Sparse Veins) Settings -->
-                    <Veins name='mtlgBitumenPrefersVeins' block='Metallurgy:utility.ore:4'  inherits='mtlgBitumenBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602A2A2A</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Bitumen Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Bitumen -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Bitumen -->
-                <IfCondition condition=':= mtlgBitumenDist = "smallDeposits"'>
-                
-                    <Veins name='mtlgBitumenBaseVeins' block='Metallurgy:utility.ore:4'  inherits='PresetSmallDeposits' >
-                        <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602A2A2A</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgBitumenSize * _default_' range=':= 1 * 1 * mtlgBitumenSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgBitumenSize * _default_' range=':= 1 * 1 * mtlgBitumenSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgBitumenFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Bitumen Deposit Veins) Settings -->
-                    <Veins name='mtlgBitumenPrefersVeins' block='Metallurgy:utility.ore:4'  inherits='mtlgBitumenBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602A2A2A</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Bitumen Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Bitumen -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Bitumen -->
-                <IfCondition condition=':= mtlgBitumenDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgBitumenBaseCloud' block='Metallurgy:utility.ore:4' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602A2A2A</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1.2 * mtlgBitumenSize * _default_' range=':= 1 * 1.2 * mtlgBitumenSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.2 * mtlgBitumenSize * _default_' range=':= 1 * 1.2 * mtlgBitumenSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.75 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1.2 * mtlgBitumenSize * _default_' range=':= 1 * 1 * 1.2 * mtlgBitumenSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 5 * mtlgBitumenFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Bitumen Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgBitumenBaseHintVeins' block='Metallurgy:utility.ore:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x602A2A2A</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Bitumen Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Bitumen -->
-                
-                
-                <!-- Begin  Vanilla distribution of Bitumen -->
-                <IfCondition condition=':= mtlgBitumenDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgBitumenBaseStandard' block='Metallurgy:utility.ore:4' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602A2A2A</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 2 * mtlgBitumenSize * _default_'/>
-                        <Setting name='Height' avg=':= 60' range=':= 10' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/6 * mtlgBitumenFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Bitumen -->
-                
-                <!-- End Bitumen Generation --> 
-
-                
-                <!-- Begin Potash Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Potash -->
-                <IfCondition condition=':= mtlgPotashDist = "sparseVeins"'>
-                
-                    <Veins name='mtlgPotashBaseVeins' block='Metallurgy:utility.ore:5'  inherits='PresetSparseVeins' >
-                        <Description>
-                            Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFAA00</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgPotashSize * _default_' range=':= 1 * 1 * mtlgPotashSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgPotashSize * _default_' range=':= 1 * 1 * mtlgPotashSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgPotashFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Potash Sparse Veins) Settings -->
-                    <Veins name='mtlgPotashPrefersVeins' block='Metallurgy:utility.ore:5'  inherits='mtlgPotashBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFAA00</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Potash Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Potash -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Potash -->
-                <IfCondition condition=':= mtlgPotashDist = "smallDeposits"'>
-                
-                    <Veins name='mtlgPotashBaseVeins' block='Metallurgy:utility.ore:5'  inherits='PresetSmallDeposits' >
-                        <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFAA00</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgPotashSize * _default_' range=':= 1 * 1 * mtlgPotashSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgPotashSize * _default_' range=':= 1 * 1 * mtlgPotashSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.75 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 10.7 * mtlgPotashFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.45 * _default_' range=':= 0.45 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Potash Deposit Veins) Settings -->
-                    <Veins name='mtlgPotashPrefersVeins' block='Metallurgy:utility.ore:5'  inherits='mtlgPotashBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFAA00</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Potash Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Potash -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Potash -->
-                <IfCondition condition=':= mtlgPotashDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgPotashBaseCloud' block='Metallurgy:utility.ore:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFAA00</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1.2 * mtlgPotashSize * _default_' range=':= 1 * 1.2 * mtlgPotashSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.2 * mtlgPotashSize * _default_' range=':= 1 * 1.2 * mtlgPotashSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 60' range=':= 10' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.75 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1.2 * mtlgPotashSize * _default_' range=':= 1 * 1 * 1.2 * mtlgPotashSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 5 * mtlgPotashFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Potash Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgPotashBaseHintVeins' block='Metallurgy:utility.ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FFAA00</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Potash Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Potash -->
-                
-                
-                <!-- Begin  Vanilla distribution of Potash -->
-                <IfCondition condition=':= mtlgPotashDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgPotashBaseStandard' block='Metallurgy:utility.ore:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFAA00</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 2 * mtlgPotashSize * _default_'/>
-                        <Setting name='Height' avg=':= 60' range=':= 10' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/6 * mtlgPotashFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Potash -->
-                
-                <!-- End Potash Generation --> 
-
-                
-                <!-- Begin Copper Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Copper -->
-                <IfCondition condition=':= mtlgCopperDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgCopperBaseVeins' block='Metallurgy:base.ore'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EA6515</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgCopperSize * _default_' range=':= 1 * 1 * mtlgCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgCopperSize * _default_' range=':= 1 * 1 * mtlgCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * mtlgCopperFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='mtlgCopperPrefersVeins' block='Metallurgy:base.ore'  inherits='mtlgCopperBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EA6515</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Copper -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Copper -->
-                <IfCondition condition=':= mtlgCopperDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgCopperBaseVeins' block='Metallurgy:base.ore'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EA6515</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgCopperSize * _default_' range=':= 1 * 1 * mtlgCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgCopperSize * _default_' range=':= 1 * 1 * mtlgCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * mtlgCopperFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                    <Veins name='mtlgCopperPrefersVeins' block='Metallurgy:base.ore'  inherits='mtlgCopperBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EA6515</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Copper -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Copper -->
-                <IfCondition condition=':= mtlgCopperDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgCopperBaseCloud' block='Metallurgy:base.ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EA6515</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgCopperSize * _default_' range=':= 1 * 1 * mtlgCopperSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgCopperSize * _default_' range=':= 1 * 1 * mtlgCopperSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 36' range=':= 36' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgCopperSize * _default_' range=':= 1 * 1 * 1 * mtlgCopperSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * mtlgCopperFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Copper Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgCopperBaseHintVeins' block='Metallurgy:base.ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EA6515</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Copper Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Copper -->
-                
-                
-                <!-- Begin  Vanilla distribution of Copper -->
-                <IfCondition condition=':= mtlgCopperDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgCopperBaseStandard' block='Metallurgy:base.ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EA6515</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgCopperSize * _default_'/>
-                        <Setting name='Height' avg=':= 36' range=':= 36' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 2/3 * mtlgCopperFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Copper -->
-                
-                <!-- End Copper Generation --> 
-
-                
-                <!-- Begin Tin Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Tin -->
-                <IfCondition condition=':= mtlgTinDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgTinBaseVeins' block='Metallurgy:base.ore:1'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BDBDBD</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgTinSize * _default_' range=':= 1 * 1 * mtlgTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgTinSize * _default_' range=':= 1 * 1 * mtlgTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * mtlgTinFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='mtlgTinPrefersVeins' block='Metallurgy:base.ore:1'  inherits='mtlgTinBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BDBDBD</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Tin -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Tin -->
-                <IfCondition condition=':= mtlgTinDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgTinBaseVeins' block='Metallurgy:base.ore:1'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BDBDBD</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgTinSize * _default_' range=':= 1 * 1 * mtlgTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgTinSize * _default_' range=':= 1 * 1 * mtlgTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * mtlgTinFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                    <Veins name='mtlgTinPrefersVeins' block='Metallurgy:base.ore:1'  inherits='mtlgTinBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BDBDBD</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Tin -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Tin -->
-                <IfCondition condition=':= mtlgTinDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgTinBaseCloud' block='Metallurgy:base.ore:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BDBDBD</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgTinSize * _default_' range=':= 1 * 1 * mtlgTinSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgTinSize * _default_' range=':= 1 * 1 * mtlgTinSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 36' range=':= 36' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgTinSize * _default_' range=':= 1 * 1 * 1 * mtlgTinSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * mtlgTinFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Tin Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgTinBaseHintVeins' block='Metallurgy:base.ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BDBDBD</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Tin Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Tin -->
-                
-                
-                <!-- Begin  Vanilla distribution of Tin -->
-                <IfCondition condition=':= mtlgTinDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgTinBaseStandard' block='Metallurgy:base.ore:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BDBDBD</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgTinSize * _default_'/>
-                        <Setting name='Height' avg=':= 36' range=':= 36' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 2/3 * mtlgTinFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Tin -->
-                
-                <!-- End Tin Generation --> 
-
-                
-                <!-- Begin Manganese Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Manganese -->
-                <IfCondition condition=':= mtlgManganeseDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgManganeseBaseVeins' block='Metallurgy:base.ore:2'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCC7C7</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgManganeseSize * _default_' range=':= 1 * 1 * mtlgManganeseSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgManganeseSize * _default_' range=':= 1 * 1 * mtlgManganeseSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * mtlgManganeseFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Manganese Layered Veins) Settings -->
-                    <Veins name='mtlgManganesePrefersVeins' block='Metallurgy:base.ore:2'  inherits='mtlgManganeseBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCC7C7</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Manganese Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Manganese -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Manganese -->
-                <IfCondition condition=':= mtlgManganeseDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgManganeseBaseVeins' block='Metallurgy:base.ore:2'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCC7C7</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgManganeseSize * _default_' range=':= 1 * 1 * mtlgManganeseSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgManganeseSize * _default_' range=':= 1 * 1 * mtlgManganeseSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * mtlgManganeseFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Manganese Huge Veins) Settings -->
-                    <Veins name='mtlgManganesePrefersVeins' block='Metallurgy:base.ore:2'  inherits='mtlgManganeseBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCC7C7</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Manganese Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Manganese -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Manganese -->
-                <IfCondition condition=':= mtlgManganeseDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgManganeseBaseCloud' block='Metallurgy:base.ore:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCC7C7</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgManganeseSize * _default_' range=':= 1 * 1 * mtlgManganeseSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgManganeseSize * _default_' range=':= 1 * 1 * mtlgManganeseSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 36' range=':= 36' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgManganeseSize * _default_' range=':= 1 * 1 * 1 * mtlgManganeseSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * mtlgManganeseFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Manganese Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgManganeseBaseHintVeins' block='Metallurgy:base.ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FCC7C7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Manganese Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Manganese -->
-                
-                
-                <!-- Begin  Vanilla distribution of Manganese -->
-                <IfCondition condition=':= mtlgManganeseDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgManganeseBaseStandard' block='Metallurgy:base.ore:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCC7C7</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgManganeseSize * _default_'/>
-                        <Setting name='Height' avg=':= 36' range=':= 36' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 2/3 * mtlgManganeseFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Manganese -->
-                
-                <!-- End Manganese Generation --> 
-
-                
-                <!-- Begin Zinc Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Zinc -->
-                <IfCondition condition=':= mtlgZincDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgZincBaseVeins' block='Metallurgy:precious.ore'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BFC55C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgZincSize * _default_' range=':= 1 * 0.8 * mtlgZincSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgZincSize * _default_' range=':= 1 * 0.8 * mtlgZincSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgZincFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Zinc Layered Veins) Settings -->
-                    <Veins name='mtlgZincPrefersVeins' block='Metallurgy:precious.ore'  inherits='mtlgZincBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BFC55C</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Zinc Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Zinc -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Zinc -->
-                <IfCondition condition=':= mtlgZincDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgZincBaseVeins' block='Metallurgy:precious.ore'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BFC55C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgZincSize * _default_' range=':= 1 * 0.8 * mtlgZincSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgZincSize * _default_' range=':= 1 * 0.8 * mtlgZincSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgZincFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Zinc Huge Veins) Settings -->
-                    <Veins name='mtlgZincPrefersVeins' block='Metallurgy:precious.ore'  inherits='mtlgZincBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BFC55C</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Zinc Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Zinc -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Zinc -->
-                <IfCondition condition=':= mtlgZincDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgZincBaseCloud' block='Metallurgy:precious.ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BFC55C</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgZincSize * _default_' range=':= 1 * 0.8 * mtlgZincSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgZincSize * _default_' range=':= 1 * 0.8 * mtlgZincSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgZincSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgZincSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgZincFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Zinc Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgZincBaseHintVeins' block='Metallurgy:precious.ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BFC55C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Zinc Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Zinc -->
-                
-                
-                <!-- Begin  Vanilla distribution of Zinc -->
-                <IfCondition condition=':= mtlgZincDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgZincBaseStandard' block='Metallurgy:precious.ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BFC55C</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgZincSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgZincFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Zinc -->
-                
-                <!-- End Zinc Generation --> 
-
-                
-                <!-- Begin Silver Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Silver -->
-                <IfCondition condition=':= mtlgSilverDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgSilverBaseVeins' block='Metallurgy:precious.ore:1'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E1E1E1</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * mtlgSilverSize * _default_' range=':= 1 * 0.85 * mtlgSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * mtlgSilverSize * _default_' range=':= 1 * 0.85 * mtlgSilverSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgSilverFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                    <Veins name='mtlgSilverPrefersVeins' block='Metallurgy:precious.ore:1'  inherits='mtlgSilverBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E1E1E1</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Silver -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Silver -->
-                <IfCondition condition=':= mtlgSilverDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgSilverBaseVeins' block='Metallurgy:precious.ore:1'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E1E1E1</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * mtlgSilverSize * _default_' range=':= 1 * 0.85 * mtlgSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * mtlgSilverSize * _default_' range=':= 1 * 0.85 * mtlgSilverSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgSilverFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Silver Huge Veins) Settings -->
-                    <Veins name='mtlgSilverPrefersVeins' block='Metallurgy:precious.ore:1'  inherits='mtlgSilverBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E1E1E1</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Silver Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Silver -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Silver -->
-                <IfCondition condition=':= mtlgSilverDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgSilverBaseCloud' block='Metallurgy:precious.ore:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E1E1E1</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgSilverSize * _default_' range=':= 1 * 0.8 * mtlgSilverSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgSilverSize * _default_' range=':= 1 * 0.8 * mtlgSilverSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.5 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgSilverSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgSilverSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgSilverFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Silver Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgSilverBaseHintVeins' block='Metallurgy:precious.ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E1E1E1</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Silver Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Silver -->
-                
-                
-                <!-- Begin  Vanilla distribution of Silver -->
-                <IfCondition condition=':= mtlgSilverDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgSilverBaseStandard' block='Metallurgy:precious.ore:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E1E1E1</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgSilverSize * _default_'/>
-                        <Setting name='Height' avg=':= 18' range=':= 12' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.15 * mtlgSilverFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Silver -->
-                
-                <!-- End Silver Generation --> 
-
-                
-                <!-- Begin Platinum Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Platinum -->
-                <IfCondition condition=':= mtlgPlatinumDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgPlatinumBaseVeins' block='Metallurgy:precious.ore:2'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B8D6DB</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgPlatinumSize * _default_' range=':= 1 * 0.8 * mtlgPlatinumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgPlatinumSize * _default_' range=':= 1 * 0.8 * mtlgPlatinumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgPlatinumFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Platinum Layered Veins) Settings -->
-                    <Veins name='mtlgPlatinumPrefersVeins' block='Metallurgy:precious.ore:2'  inherits='mtlgPlatinumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B8D6DB</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Platinum Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Platinum -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Platinum -->
-                <IfCondition condition=':= mtlgPlatinumDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgPlatinumBaseVeins' block='Metallurgy:precious.ore:2'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B8D6DB</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgPlatinumSize * _default_' range=':= 1 * 0.8 * mtlgPlatinumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgPlatinumSize * _default_' range=':= 1 * 0.8 * mtlgPlatinumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgPlatinumFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Platinum Huge Veins) Settings -->
-                    <Veins name='mtlgPlatinumPrefersVeins' block='Metallurgy:precious.ore:2'  inherits='mtlgPlatinumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B8D6DB</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Platinum Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Platinum -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Platinum -->
-                <IfCondition condition=':= mtlgPlatinumDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgPlatinumBaseCloud' block='Metallurgy:precious.ore:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B8D6DB</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgPlatinumSize * _default_' range=':= 1 * 0.8 * mtlgPlatinumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgPlatinumSize * _default_' range=':= 1 * 0.8 * mtlgPlatinumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgPlatinumSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgPlatinumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgPlatinumFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Platinum Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgPlatinumBaseHintVeins' block='Metallurgy:precious.ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60B8D6DB</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Platinum Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Platinum -->
-                
-                
-                <!-- Begin  Vanilla distribution of Platinum -->
-                <IfCondition condition=':= mtlgPlatinumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgPlatinumBaseStandard' block='Metallurgy:precious.ore:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B8D6DB</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgPlatinumSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgPlatinumFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Platinum -->
-                
-                <!-- End Platinum Generation --> 
-
-                
-                <!-- Begin Promethium Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Promethium -->
-                <IfCondition condition=':= mtlgPromethiumDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgPromethiumBaseVeins' block='Metallurgy:fantasy.ore'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605D8258</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgPromethiumSize * _default_' range=':= 1 * 0.8 * mtlgPromethiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgPromethiumSize * _default_' range=':= 1 * 0.8 * mtlgPromethiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgPromethiumFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Promethium Layered Veins) Settings -->
-                    <Veins name='mtlgPromethiumPrefersVeins' block='Metallurgy:fantasy.ore'  inherits='mtlgPromethiumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605D8258</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Promethium Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Promethium -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Promethium -->
-                <IfCondition condition=':= mtlgPromethiumDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgPromethiumBaseVeins' block='Metallurgy:fantasy.ore'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605D8258</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgPromethiumSize * _default_' range=':= 1 * 0.8 * mtlgPromethiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgPromethiumSize * _default_' range=':= 1 * 0.8 * mtlgPromethiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgPromethiumFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Promethium Huge Veins) Settings -->
-                    <Veins name='mtlgPromethiumPrefersVeins' block='Metallurgy:fantasy.ore'  inherits='mtlgPromethiumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605D8258</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Promethium Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Promethium -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Promethium -->
-                <IfCondition condition=':= mtlgPromethiumDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgPromethiumBaseCloud' block='Metallurgy:fantasy.ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605D8258</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgPromethiumSize * _default_' range=':= 1 * 0.8 * mtlgPromethiumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgPromethiumSize * _default_' range=':= 1 * 0.8 * mtlgPromethiumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgPromethiumSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgPromethiumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgPromethiumFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Promethium Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgPromethiumBaseHintVeins' block='Metallurgy:fantasy.ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x605D8258</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Promethium Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Promethium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Promethium -->
-                <IfCondition condition=':= mtlgPromethiumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgPromethiumBaseStandard' block='Metallurgy:fantasy.ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605D8258</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgPromethiumSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgPromethiumFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Promethium -->
-                
-                <!-- End Promethium Generation --> 
-
-                
-                <!-- Begin Deep Iron Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Deep Iron -->
-                <IfCondition condition=':= mtlgDeepIronDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgDeepIronBaseVeins' block='Metallurgy:fantasy.ore:1'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x604C5E6C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgDeepIronSize * _default_' range=':= 1 * 0.8 * mtlgDeepIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgDeepIronSize * _default_' range=':= 1 * 0.8 * mtlgDeepIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgDeepIronFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Deep Iron Layered Veins) Settings -->
-                    <Veins name='mtlgDeepIronPrefersVeins' block='Metallurgy:fantasy.ore:1'  inherits='mtlgDeepIronBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x604C5E6C</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Deep Iron Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Deep Iron -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Deep Iron -->
-                <IfCondition condition=':= mtlgDeepIronDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgDeepIronBaseVeins' block='Metallurgy:fantasy.ore:1'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x604C5E6C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgDeepIronSize * _default_' range=':= 1 * 0.8 * mtlgDeepIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgDeepIronSize * _default_' range=':= 1 * 0.8 * mtlgDeepIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgDeepIronFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Deep Iron Huge Veins) Settings -->
-                    <Veins name='mtlgDeepIronPrefersVeins' block='Metallurgy:fantasy.ore:1'  inherits='mtlgDeepIronBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x604C5E6C</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Deep Iron Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Deep Iron -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Deep Iron -->
-                <IfCondition condition=':= mtlgDeepIronDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgDeepIronBaseCloud' block='Metallurgy:fantasy.ore:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x604C5E6C</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgDeepIronSize * _default_' range=':= 1 * 0.8 * mtlgDeepIronSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgDeepIronSize * _default_' range=':= 1 * 0.8 * mtlgDeepIronSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgDeepIronSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgDeepIronSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgDeepIronFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Deep Iron Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgDeepIronBaseHintVeins' block='Metallurgy:fantasy.ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x604C5E6C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Deep Iron Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Deep Iron -->
-                
-                
-                <!-- Begin  Vanilla distribution of Deep Iron -->
-                <IfCondition condition=':= mtlgDeepIronDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgDeepIronBaseStandard' block='Metallurgy:fantasy.ore:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x604C5E6C</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgDeepIronSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgDeepIronFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Deep Iron -->
-                
-                <!-- End Deep Iron Generation --> 
-
-                
-                <!-- Begin Infuscolium Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Infuscolium -->
-                <IfCondition condition=':= mtlgInfuscoliumDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgInfuscoliumBaseVeins' block='Metallurgy:fantasy.ore:2'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608B2656</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_' range=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_' range=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgInfuscoliumFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Infuscolium Layered Veins) Settings -->
-                    <Veins name='mtlgInfuscoliumPrefersVeins' block='Metallurgy:fantasy.ore:2'  inherits='mtlgInfuscoliumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608B2656</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Infuscolium Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Infuscolium -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Infuscolium -->
-                <IfCondition condition=':= mtlgInfuscoliumDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgInfuscoliumBaseVeins' block='Metallurgy:fantasy.ore:2'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608B2656</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_' range=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_' range=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgInfuscoliumFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Infuscolium Huge Veins) Settings -->
-                    <Veins name='mtlgInfuscoliumPrefersVeins' block='Metallurgy:fantasy.ore:2'  inherits='mtlgInfuscoliumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608B2656</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Infuscolium Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Infuscolium -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Infuscolium -->
-                <IfCondition condition=':= mtlgInfuscoliumDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgInfuscoliumBaseCloud' block='Metallurgy:fantasy.ore:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608B2656</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_' range=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_' range=':= 1 * 0.8 * mtlgInfuscoliumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgInfuscoliumSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgInfuscoliumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgInfuscoliumFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Infuscolium Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgInfuscoliumBaseHintVeins' block='Metallurgy:fantasy.ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x608B2656</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Infuscolium Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Infuscolium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Infuscolium -->
-                <IfCondition condition=':= mtlgInfuscoliumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgInfuscoliumBaseStandard' block='Metallurgy:fantasy.ore:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608B2656</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgInfuscoliumSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgInfuscoliumFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Infuscolium -->
-                
-                <!-- End Infuscolium Generation --> 
-
-                
-                <!-- Begin Oureclase Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Oureclase -->
-                <IfCondition condition=':= mtlgOureclaseDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgOureclaseBaseVeins' block='Metallurgy:fantasy.ore:4'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609A7607</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgOureclaseSize * _default_' range=':= 1 * 0.8 * mtlgOureclaseSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgOureclaseSize * _default_' range=':= 1 * 0.8 * mtlgOureclaseSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgOureclaseFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Oureclase Layered Veins) Settings -->
-                    <Veins name='mtlgOureclasePrefersVeins' block='Metallurgy:fantasy.ore:4'  inherits='mtlgOureclaseBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609A7607</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Oureclase Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Oureclase -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Oureclase -->
-                <IfCondition condition=':= mtlgOureclaseDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgOureclaseBaseVeins' block='Metallurgy:fantasy.ore:4'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609A7607</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgOureclaseSize * _default_' range=':= 1 * 0.8 * mtlgOureclaseSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgOureclaseSize * _default_' range=':= 1 * 0.8 * mtlgOureclaseSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgOureclaseFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Oureclase Huge Veins) Settings -->
-                    <Veins name='mtlgOureclasePrefersVeins' block='Metallurgy:fantasy.ore:4'  inherits='mtlgOureclaseBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609A7607</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Oureclase Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Oureclase -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Oureclase -->
-                <IfCondition condition=':= mtlgOureclaseDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgOureclaseBaseCloud' block='Metallurgy:fantasy.ore:4' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609A7607</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgOureclaseSize * _default_' range=':= 1 * 0.8 * mtlgOureclaseSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgOureclaseSize * _default_' range=':= 1 * 0.8 * mtlgOureclaseSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgOureclaseSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgOureclaseSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgOureclaseFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Oureclase Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgOureclaseBaseHintVeins' block='Metallurgy:fantasy.ore:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609A7607</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Oureclase Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Oureclase -->
-                
-                
-                <!-- Begin  Vanilla distribution of Oureclase -->
-                <IfCondition condition=':= mtlgOureclaseDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgOureclaseBaseStandard' block='Metallurgy:fantasy.ore:4' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609A7607</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgOureclaseSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgOureclaseFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Oureclase -->
-                
-                <!-- End Oureclase Generation --> 
-
-                
-                <!-- Begin Astral Silver Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Astral Silver -->
-                <IfCondition condition=':= mtlgAstralSilverDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgAstralSilverBaseVeins' block='Metallurgy:fantasy.ore:5'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ADC3C3</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgAstralSilverSize * _default_' range=':= 1 * 0.8 * mtlgAstralSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgAstralSilverSize * _default_' range=':= 1 * 0.8 * mtlgAstralSilverSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgAstralSilverFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Astral Silver Layered Veins) Settings -->
-                    <Veins name='mtlgAstralSilverPrefersVeins' block='Metallurgy:fantasy.ore:5'  inherits='mtlgAstralSilverBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ADC3C3</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Astral Silver Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Astral Silver -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Astral Silver -->
-                <IfCondition condition=':= mtlgAstralSilverDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgAstralSilverBaseVeins' block='Metallurgy:fantasy.ore:5'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ADC3C3</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgAstralSilverSize * _default_' range=':= 1 * 0.8 * mtlgAstralSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgAstralSilverSize * _default_' range=':= 1 * 0.8 * mtlgAstralSilverSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgAstralSilverFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Astral Silver Huge Veins) Settings -->
-                    <Veins name='mtlgAstralSilverPrefersVeins' block='Metallurgy:fantasy.ore:5'  inherits='mtlgAstralSilverBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ADC3C3</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Astral Silver Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Astral Silver -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Astral Silver -->
-                <IfCondition condition=':= mtlgAstralSilverDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgAstralSilverBaseCloud' block='Metallurgy:fantasy.ore:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ADC3C3</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgAstralSilverSize * _default_' range=':= 1 * 0.8 * mtlgAstralSilverSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgAstralSilverSize * _default_' range=':= 1 * 0.8 * mtlgAstralSilverSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgAstralSilverSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgAstralSilverSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgAstralSilverFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Astral Silver Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgAstralSilverBaseHintVeins' block='Metallurgy:fantasy.ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60ADC3C3</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Astral Silver Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Astral Silver -->
-                
-                
-                <!-- Begin  Vanilla distribution of Astral Silver -->
-                <IfCondition condition=':= mtlgAstralSilverDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgAstralSilverBaseStandard' block='Metallurgy:fantasy.ore:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ADC3C3</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgAstralSilverSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgAstralSilverFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Astral Silver -->
-                
-                <!-- End Astral Silver Generation --> 
-
-                
-                <!-- Begin Carmot Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Carmot -->
-                <IfCondition condition=':= mtlgCarmotDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgCarmotBaseVeins' block='Metallurgy:fantasy.ore:6'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D7C986</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgCarmotSize * _default_' range=':= 1 * 0.8 * mtlgCarmotSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgCarmotSize * _default_' range=':= 1 * 0.8 * mtlgCarmotSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgCarmotFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Carmot Layered Veins) Settings -->
-                    <Veins name='mtlgCarmotPrefersVeins' block='Metallurgy:fantasy.ore:6'  inherits='mtlgCarmotBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D7C986</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Carmot Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Carmot -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Carmot -->
-                <IfCondition condition=':= mtlgCarmotDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgCarmotBaseVeins' block='Metallurgy:fantasy.ore:6'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D7C986</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgCarmotSize * _default_' range=':= 1 * 0.8 * mtlgCarmotSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgCarmotSize * _default_' range=':= 1 * 0.8 * mtlgCarmotSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgCarmotFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Carmot Huge Veins) Settings -->
-                    <Veins name='mtlgCarmotPrefersVeins' block='Metallurgy:fantasy.ore:6'  inherits='mtlgCarmotBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D7C986</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Carmot Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Carmot -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Carmot -->
-                <IfCondition condition=':= mtlgCarmotDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgCarmotBaseCloud' block='Metallurgy:fantasy.ore:6' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D7C986</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgCarmotSize * _default_' range=':= 1 * 0.8 * mtlgCarmotSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgCarmotSize * _default_' range=':= 1 * 0.8 * mtlgCarmotSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgCarmotSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgCarmotSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgCarmotFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Carmot Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgCarmotBaseHintVeins' block='Metallurgy:fantasy.ore:6' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60D7C986</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Carmot Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Carmot -->
-                
-                
-                <!-- Begin  Vanilla distribution of Carmot -->
-                <IfCondition condition=':= mtlgCarmotDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgCarmotBaseStandard' block='Metallurgy:fantasy.ore:6' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D7C986</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgCarmotSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgCarmotFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Carmot -->
-                
-                <!-- End Carmot Generation --> 
-
-                
-                <!-- Begin Mithril Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Mithril -->
-                <IfCondition condition=':= mtlgMithrilDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgMithrilBaseVeins' block='Metallurgy:fantasy.ore:7'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609AF3F7</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgMithrilSize * _default_' range=':= 1 * 0.8 * mtlgMithrilSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgMithrilSize * _default_' range=':= 1 * 0.8 * mtlgMithrilSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgMithrilFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Mithril Layered Veins) Settings -->
-                    <Veins name='mtlgMithrilPrefersVeins' block='Metallurgy:fantasy.ore:7'  inherits='mtlgMithrilBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609AF3F7</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Mithril Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Mithril -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Mithril -->
-                <IfCondition condition=':= mtlgMithrilDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgMithrilBaseVeins' block='Metallurgy:fantasy.ore:7'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609AF3F7</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgMithrilSize * _default_' range=':= 1 * 0.8 * mtlgMithrilSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgMithrilSize * _default_' range=':= 1 * 0.8 * mtlgMithrilSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgMithrilFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Mithril Huge Veins) Settings -->
-                    <Veins name='mtlgMithrilPrefersVeins' block='Metallurgy:fantasy.ore:7'  inherits='mtlgMithrilBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609AF3F7</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Mithril Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Mithril -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Mithril -->
-                <IfCondition condition=':= mtlgMithrilDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgMithrilBaseCloud' block='Metallurgy:fantasy.ore:7' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609AF3F7</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgMithrilSize * _default_' range=':= 1 * 0.8 * mtlgMithrilSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgMithrilSize * _default_' range=':= 1 * 0.8 * mtlgMithrilSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgMithrilSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgMithrilSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgMithrilFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Mithril Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgMithrilBaseHintVeins' block='Metallurgy:fantasy.ore:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609AF3F7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Mithril Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Mithril -->
-                
-                
-                <!-- Begin  Vanilla distribution of Mithril -->
-                <IfCondition condition=':= mtlgMithrilDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgMithrilBaseStandard' block='Metallurgy:fantasy.ore:7' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609AF3F7</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgMithrilSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgMithrilFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Mithril -->
-                
-                <!-- End Mithril Generation --> 
-
-                
-                <!-- Begin Rubracium Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Rubracium -->
-                <IfCondition condition=':= mtlgRubraciumDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgRubraciumBaseVeins' block='Metallurgy:fantasy.ore:8'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A1363C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgRubraciumSize * _default_' range=':= 1 * 0.8 * mtlgRubraciumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgRubraciumSize * _default_' range=':= 1 * 0.8 * mtlgRubraciumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgRubraciumFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Rubracium Layered Veins) Settings -->
-                    <Veins name='mtlgRubraciumPrefersVeins' block='Metallurgy:fantasy.ore:8'  inherits='mtlgRubraciumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A1363C</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Rubracium Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Rubracium -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Rubracium -->
-                <IfCondition condition=':= mtlgRubraciumDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgRubraciumBaseVeins' block='Metallurgy:fantasy.ore:8'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A1363C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgRubraciumSize * _default_' range=':= 1 * 0.8 * mtlgRubraciumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgRubraciumSize * _default_' range=':= 1 * 0.8 * mtlgRubraciumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgRubraciumFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Rubracium Huge Veins) Settings -->
-                    <Veins name='mtlgRubraciumPrefersVeins' block='Metallurgy:fantasy.ore:8'  inherits='mtlgRubraciumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A1363C</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Rubracium Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Rubracium -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Rubracium -->
-                <IfCondition condition=':= mtlgRubraciumDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgRubraciumBaseCloud' block='Metallurgy:fantasy.ore:8' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A1363C</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgRubraciumSize * _default_' range=':= 1 * 0.8 * mtlgRubraciumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgRubraciumSize * _default_' range=':= 1 * 0.8 * mtlgRubraciumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgRubraciumSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgRubraciumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgRubraciumFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Rubracium Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgRubraciumBaseHintVeins' block='Metallurgy:fantasy.ore:8' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60A1363C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Rubracium Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Rubracium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Rubracium -->
-                <IfCondition condition=':= mtlgRubraciumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgRubraciumBaseStandard' block='Metallurgy:fantasy.ore:8' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A1363C</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgRubraciumSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgRubraciumFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Rubracium -->
-                
-                <!-- End Rubracium Generation --> 
-
-                
-                <!-- Begin Orichalcum Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Orichalcum -->
-                <IfCondition condition=':= mtlgOrichalcumDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgOrichalcumBaseVeins' block='Metallurgy:fantasy.ore:11'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60466432</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgOrichalcumSize * _default_' range=':= 1 * 0.8 * mtlgOrichalcumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgOrichalcumSize * _default_' range=':= 1 * 0.8 * mtlgOrichalcumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgOrichalcumFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Orichalcum Layered Veins) Settings -->
-                    <Veins name='mtlgOrichalcumPrefersVeins' block='Metallurgy:fantasy.ore:11'  inherits='mtlgOrichalcumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60466432</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Orichalcum Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Orichalcum -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Orichalcum -->
-                <IfCondition condition=':= mtlgOrichalcumDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgOrichalcumBaseVeins' block='Metallurgy:fantasy.ore:11'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60466432</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgOrichalcumSize * _default_' range=':= 1 * 0.8 * mtlgOrichalcumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgOrichalcumSize * _default_' range=':= 1 * 0.8 * mtlgOrichalcumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgOrichalcumFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Orichalcum Huge Veins) Settings -->
-                    <Veins name='mtlgOrichalcumPrefersVeins' block='Metallurgy:fantasy.ore:11'  inherits='mtlgOrichalcumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60466432</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Orichalcum Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Orichalcum -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Orichalcum -->
-                <IfCondition condition=':= mtlgOrichalcumDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgOrichalcumBaseCloud' block='Metallurgy:fantasy.ore:11' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60466432</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgOrichalcumSize * _default_' range=':= 1 * 0.8 * mtlgOrichalcumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgOrichalcumSize * _default_' range=':= 1 * 0.8 * mtlgOrichalcumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgOrichalcumSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgOrichalcumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgOrichalcumFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Orichalcum Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgOrichalcumBaseHintVeins' block='Metallurgy:fantasy.ore:11' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60466432</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Orichalcum Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Orichalcum -->
-                
-                
-                <!-- Begin  Vanilla distribution of Orichalcum -->
-                <IfCondition condition=':= mtlgOrichalcumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgOrichalcumBaseStandard' block='Metallurgy:fantasy.ore:11' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60466432</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgOrichalcumSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgOrichalcumFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Orichalcum -->
-                
-                <!-- End Orichalcum Generation --> 
-
-                
-                <!-- Begin Adamantine Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Adamantine -->
-                <IfCondition condition=':= mtlgAdamantineDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgAdamantineBaseVeins' block='Metallurgy:fantasy.ore:13'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60AC0C0D</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgAdamantineSize * _default_' range=':= 1 * 0.8 * mtlgAdamantineSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgAdamantineSize * _default_' range=':= 1 * 0.8 * mtlgAdamantineSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgAdamantineFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Adamantine Layered Veins) Settings -->
-                    <Veins name='mtlgAdamantinePrefersVeins' block='Metallurgy:fantasy.ore:13'  inherits='mtlgAdamantineBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60AC0C0D</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Adamantine Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Adamantine -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Adamantine -->
-                <IfCondition condition=':= mtlgAdamantineDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgAdamantineBaseVeins' block='Metallurgy:fantasy.ore:13'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60AC0C0D</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgAdamantineSize * _default_' range=':= 1 * 0.8 * mtlgAdamantineSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgAdamantineSize * _default_' range=':= 1 * 0.8 * mtlgAdamantineSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgAdamantineFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Adamantine Huge Veins) Settings -->
-                    <Veins name='mtlgAdamantinePrefersVeins' block='Metallurgy:fantasy.ore:13'  inherits='mtlgAdamantineBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60AC0C0D</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Adamantine Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Adamantine -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Adamantine -->
-                <IfCondition condition=':= mtlgAdamantineDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgAdamantineBaseCloud' block='Metallurgy:fantasy.ore:13' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60AC0C0D</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgAdamantineSize * _default_' range=':= 1 * 0.8 * mtlgAdamantineSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgAdamantineSize * _default_' range=':= 1 * 0.8 * mtlgAdamantineSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgAdamantineSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgAdamantineSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgAdamantineFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Adamantine Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgAdamantineBaseHintVeins' block='Metallurgy:fantasy.ore:13' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60AC0C0D</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Adamantine Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Adamantine -->
-                
-                
-                <!-- Begin  Vanilla distribution of Adamantine -->
-                <IfCondition condition=':= mtlgAdamantineDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgAdamantineBaseStandard' block='Metallurgy:fantasy.ore:13' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60AC0C0D</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgAdamantineSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgAdamantineFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Adamantine -->
-                
-                <!-- End Adamantine Generation --> 
-
-                
-                <!-- Begin Atlarus Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Atlarus -->
-                <IfCondition condition=':= mtlgAtlarusDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgAtlarusBaseVeins' block='Metallurgy:fantasy.ore:14'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C4B117</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgAtlarusSize * _default_' range=':= 1 * 0.8 * mtlgAtlarusSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgAtlarusSize * _default_' range=':= 1 * 0.8 * mtlgAtlarusSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgAtlarusFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Atlarus Layered Veins) Settings -->
-                    <Veins name='mtlgAtlarusPrefersVeins' block='Metallurgy:fantasy.ore:14'  inherits='mtlgAtlarusBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C4B117</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Atlarus Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Atlarus -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Atlarus -->
-                <IfCondition condition=':= mtlgAtlarusDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgAtlarusBaseVeins' block='Metallurgy:fantasy.ore:14'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C4B117</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mtlgAtlarusSize * _default_' range=':= 1 * 0.8 * mtlgAtlarusSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mtlgAtlarusSize * _default_' range=':= 1 * 0.8 * mtlgAtlarusSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mtlgAtlarusFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Atlarus Huge Veins) Settings -->
-                    <Veins name='mtlgAtlarusPrefersVeins' block='Metallurgy:fantasy.ore:14'  inherits='mtlgAtlarusBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C4B117</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Atlarus Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Atlarus -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Atlarus -->
-                <IfCondition condition=':= mtlgAtlarusDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgAtlarusBaseCloud' block='Metallurgy:fantasy.ore:14' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C4B117</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mtlgAtlarusSize * _default_' range=':= 1 * 0.8 * mtlgAtlarusSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mtlgAtlarusSize * _default_' range=':= 1 * 0.8 * mtlgAtlarusSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mtlgAtlarusSize * _default_' range=':= 1 * 0.8 * 0.8 * mtlgAtlarusSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mtlgAtlarusFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Atlarus Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgAtlarusBaseHintVeins' block='Metallurgy:fantasy.ore:14' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60C4B117</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Atlarus Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Atlarus -->
-                
-                
-                <!-- Begin  Vanilla distribution of Atlarus -->
-                <IfCondition condition=':= mtlgAtlarusDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgAtlarusBaseStandard' block='Metallurgy:fantasy.ore:14' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C4B117</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgAtlarusSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mtlgAtlarusFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Atlarus -->
-                
-                <!-- End Atlarus Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-            <!-- Setup Nether -->
-            <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
-                
-                <!-- Starting Original Nether Ore Removal -->
-                <Substitute name='mtlgNetherOreSubstitute0' block='minecraft:netherrack'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='Metallurgy:nether.ore' />
-                    <Replaces block='Metallurgy:nether.ore:1' />
-                    <Replaces block='Metallurgy:nether.ore:2' />
-                    <Replaces block='Metallurgy:nether.ore:3' />
-                    <Replaces block='Metallurgy:nether.ore:4' />
-                    <Replaces block='Metallurgy:nether.ore:5' />
-                    <Replaces block='Metallurgy:nether.ore:6' />
-                    <Replaces block='Metallurgy:nether.ore:7' />
-                    <Replaces block='Metallurgy:nether.ore:8' />
-                    <Replaces block='Metallurgy:nether.ore:9' />
-                </Substitute>
-                <!-- Original Nether Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Ignatius Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Ignatius -->
-                <IfCondition condition=':= mtlgIgnatiusDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgIgnatiusBaseVeins' block='Metallurgy:nether.ore'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EE810A</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgIgnatiusSize * _default_' range=':= 1 * 1 * mtlgIgnatiusSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgIgnatiusSize * _default_' range=':= 1 * 1 * mtlgIgnatiusSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgIgnatiusFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Ignatius -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Ignatius -->
-                <IfCondition condition=':= mtlgIgnatiusDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgIgnatiusBaseVeins' block='Metallurgy:nether.ore'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EE810A</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgIgnatiusSize * _default_' range=':= 1 * 1 * mtlgIgnatiusSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgIgnatiusSize * _default_' range=':= 1 * 1 * mtlgIgnatiusSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgIgnatiusFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Ignatius -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Ignatius -->
-                <IfCondition condition=':= mtlgIgnatiusDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgIgnatiusBaseCloud' block='Metallurgy:nether.ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EE810A</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgIgnatiusSize * _default_' range=':= 1 * 1 * mtlgIgnatiusSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgIgnatiusSize * _default_' range=':= 1 * 1 * mtlgIgnatiusSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgIgnatiusSize * _default_' range=':= 1 * 1 * 1 * mtlgIgnatiusSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * mtlgIgnatiusFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ignatius Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgIgnatiusBaseHintVeins' block='Metallurgy:nether.ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EE810A</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ignatius Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Ignatius -->
-                
-                
-                <!-- Begin  Vanilla distribution of Ignatius -->
-                <IfCondition condition=':= mtlgIgnatiusDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgIgnatiusBaseStandard' block='Metallurgy:nether.ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EE810A</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgIgnatiusSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * mtlgIgnatiusFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Ignatius -->
-                
-                <!-- End Ignatius Generation --> 
-
-                
-                <!-- Begin Shadow Iron Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Shadow Iron -->
-                <IfCondition condition=':= mtlgShadowIronDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgShadowIronBaseVeins' block='Metallurgy:nether.ore:1'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60634C3F</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgShadowIronSize * _default_' range=':= 1 * 1 * mtlgShadowIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgShadowIronSize * _default_' range=':= 1 * 1 * mtlgShadowIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgShadowIronFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Shadow Iron -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Shadow Iron -->
-                <IfCondition condition=':= mtlgShadowIronDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgShadowIronBaseVeins' block='Metallurgy:nether.ore:1'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60634C3F</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgShadowIronSize * _default_' range=':= 1 * 1 * mtlgShadowIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgShadowIronSize * _default_' range=':= 1 * 1 * mtlgShadowIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgShadowIronFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Shadow Iron -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Shadow Iron -->
-                <IfCondition condition=':= mtlgShadowIronDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgShadowIronBaseCloud' block='Metallurgy:nether.ore:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60634C3F</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgShadowIronSize * _default_' range=':= 1 * 1 * mtlgShadowIronSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgShadowIronSize * _default_' range=':= 1 * 1 * mtlgShadowIronSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgShadowIronSize * _default_' range=':= 1 * 1 * 1 * mtlgShadowIronSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * mtlgShadowIronFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Shadow Iron Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgShadowIronBaseHintVeins' block='Metallurgy:nether.ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60634C3F</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Shadow Iron Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Shadow Iron -->
-                
-                
-                <!-- Begin  Vanilla distribution of Shadow Iron -->
-                <IfCondition condition=':= mtlgShadowIronDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgShadowIronBaseStandard' block='Metallurgy:nether.ore:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60634C3F</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgShadowIronSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * mtlgShadowIronFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Shadow Iron -->
-                
-                <!-- End Shadow Iron Generation --> 
-
-                
-                <!-- Begin Lemurite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Lemurite -->
-                <IfCondition condition=':= mtlgLemuriteDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgLemuriteBaseVeins' block='Metallurgy:nether.ore:2'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B1B1B4</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgLemuriteSize * _default_' range=':= 1 * 1 * mtlgLemuriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgLemuriteSize * _default_' range=':= 1 * 1 * mtlgLemuriteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgLemuriteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Lemurite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Lemurite -->
-                <IfCondition condition=':= mtlgLemuriteDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgLemuriteBaseVeins' block='Metallurgy:nether.ore:2'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B1B1B4</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgLemuriteSize * _default_' range=':= 1 * 1 * mtlgLemuriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgLemuriteSize * _default_' range=':= 1 * 1 * mtlgLemuriteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgLemuriteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Lemurite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Lemurite -->
-                <IfCondition condition=':= mtlgLemuriteDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgLemuriteBaseCloud' block='Metallurgy:nether.ore:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B1B1B4</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgLemuriteSize * _default_' range=':= 1 * 1 * mtlgLemuriteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgLemuriteSize * _default_' range=':= 1 * 1 * mtlgLemuriteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgLemuriteSize * _default_' range=':= 1 * 1 * 1 * mtlgLemuriteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * mtlgLemuriteFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Lemurite Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgLemuriteBaseHintVeins' block='Metallurgy:nether.ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60B1B1B4</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Lemurite Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Lemurite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Lemurite -->
-                <IfCondition condition=':= mtlgLemuriteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgLemuriteBaseStandard' block='Metallurgy:nether.ore:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60B1B1B4</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgLemuriteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * mtlgLemuriteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Lemurite -->
-                
-                <!-- End Lemurite Generation --> 
-
-                
-                <!-- Begin Midasium Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Midasium -->
-                <IfCondition condition=':= mtlgMidasiumDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgMidasiumBaseVeins' block='Metallurgy:nether.ore:3'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60F6B237</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgMidasiumSize * _default_' range=':= 1 * 1 * mtlgMidasiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgMidasiumSize * _default_' range=':= 1 * 1 * mtlgMidasiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgMidasiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Midasium -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Midasium -->
-                <IfCondition condition=':= mtlgMidasiumDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgMidasiumBaseVeins' block='Metallurgy:nether.ore:3'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60F6B237</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgMidasiumSize * _default_' range=':= 1 * 1 * mtlgMidasiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgMidasiumSize * _default_' range=':= 1 * 1 * mtlgMidasiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgMidasiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Midasium -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Midasium -->
-                <IfCondition condition=':= mtlgMidasiumDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgMidasiumBaseCloud' block='Metallurgy:nether.ore:3' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60F6B237</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgMidasiumSize * _default_' range=':= 1 * 1 * mtlgMidasiumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgMidasiumSize * _default_' range=':= 1 * 1 * mtlgMidasiumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgMidasiumSize * _default_' range=':= 1 * 1 * 1 * mtlgMidasiumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * mtlgMidasiumFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Midasium Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgMidasiumBaseHintVeins' block='Metallurgy:nether.ore:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60F6B237</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Midasium Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Midasium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Midasium -->
-                <IfCondition condition=':= mtlgMidasiumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgMidasiumBaseStandard' block='Metallurgy:nether.ore:3' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60F6B237</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgMidasiumSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * mtlgMidasiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Midasium -->
-                
-                <!-- End Midasium Generation --> 
-
-                
-                <!-- Begin Vyroxeres Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Vyroxeres -->
-                <IfCondition condition=':= mtlgVyroxeresDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgVyroxeresBaseVeins' block='Metallurgy:nether.ore:4'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6057D411</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgVyroxeresSize * _default_' range=':= 1 * 1 * mtlgVyroxeresSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgVyroxeresSize * _default_' range=':= 1 * 1 * mtlgVyroxeresSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgVyroxeresFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Vyroxeres -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Vyroxeres -->
-                <IfCondition condition=':= mtlgVyroxeresDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgVyroxeresBaseVeins' block='Metallurgy:nether.ore:4'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6057D411</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgVyroxeresSize * _default_' range=':= 1 * 1 * mtlgVyroxeresSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgVyroxeresSize * _default_' range=':= 1 * 1 * mtlgVyroxeresSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgVyroxeresFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Vyroxeres -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Vyroxeres -->
-                <IfCondition condition=':= mtlgVyroxeresDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgVyroxeresBaseCloud' block='Metallurgy:nether.ore:4' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6057D411</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgVyroxeresSize * _default_' range=':= 1 * 1 * mtlgVyroxeresSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgVyroxeresSize * _default_' range=':= 1 * 1 * mtlgVyroxeresSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgVyroxeresSize * _default_' range=':= 1 * 1 * 1 * mtlgVyroxeresSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * mtlgVyroxeresFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Vyroxeres Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgVyroxeresBaseHintVeins' block='Metallurgy:nether.ore:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6057D411</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Vyroxeres Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Vyroxeres -->
-                
-                
-                <!-- Begin  Vanilla distribution of Vyroxeres -->
-                <IfCondition condition=':= mtlgVyroxeresDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgVyroxeresBaseStandard' block='Metallurgy:nether.ore:4' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6057D411</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgVyroxeresSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * mtlgVyroxeresFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Vyroxeres -->
-                
-                <!-- End Vyroxeres Generation --> 
-
-                
-                <!-- Begin Ceruclase Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Ceruclase -->
-                <IfCondition condition=':= mtlgCeruclaseDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgCeruclaseBaseVeins' block='Metallurgy:nether.ore:5'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x603F869C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgCeruclaseSize * _default_' range=':= 1 * 1 * mtlgCeruclaseSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgCeruclaseSize * _default_' range=':= 1 * 1 * mtlgCeruclaseSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgCeruclaseFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Ceruclase -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Ceruclase -->
-                <IfCondition condition=':= mtlgCeruclaseDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgCeruclaseBaseVeins' block='Metallurgy:nether.ore:5'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x603F869C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgCeruclaseSize * _default_' range=':= 1 * 1 * mtlgCeruclaseSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgCeruclaseSize * _default_' range=':= 1 * 1 * mtlgCeruclaseSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgCeruclaseFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Ceruclase -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Ceruclase -->
-                <IfCondition condition=':= mtlgCeruclaseDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgCeruclaseBaseCloud' block='Metallurgy:nether.ore:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x603F869C</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgCeruclaseSize * _default_' range=':= 1 * 1 * mtlgCeruclaseSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgCeruclaseSize * _default_' range=':= 1 * 1 * mtlgCeruclaseSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgCeruclaseSize * _default_' range=':= 1 * 1 * 1 * mtlgCeruclaseSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * mtlgCeruclaseFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ceruclase Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgCeruclaseBaseHintVeins' block='Metallurgy:nether.ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x603F869C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ceruclase Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Ceruclase -->
-                
-                
-                <!-- Begin  Vanilla distribution of Ceruclase -->
-                <IfCondition condition=':= mtlgCeruclaseDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgCeruclaseBaseStandard' block='Metallurgy:nether.ore:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x603F869C</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgCeruclaseSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * mtlgCeruclaseFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Ceruclase -->
-                
-                <!-- End Ceruclase Generation --> 
-
-                
-                <!-- Begin Alduorite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Alduorite -->
-                <IfCondition condition=':= mtlgAlduoriteDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgAlduoriteBaseVeins' block='Metallurgy:nether.ore:6'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609FCED2</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgAlduoriteSize * _default_' range=':= 1 * 1 * mtlgAlduoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgAlduoriteSize * _default_' range=':= 1 * 1 * mtlgAlduoriteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgAlduoriteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Alduorite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Alduorite -->
-                <IfCondition condition=':= mtlgAlduoriteDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgAlduoriteBaseVeins' block='Metallurgy:nether.ore:6'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609FCED2</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgAlduoriteSize * _default_' range=':= 1 * 1 * mtlgAlduoriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgAlduoriteSize * _default_' range=':= 1 * 1 * mtlgAlduoriteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgAlduoriteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Alduorite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Alduorite -->
-                <IfCondition condition=':= mtlgAlduoriteDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgAlduoriteBaseCloud' block='Metallurgy:nether.ore:6' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609FCED2</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgAlduoriteSize * _default_' range=':= 1 * 1 * mtlgAlduoriteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgAlduoriteSize * _default_' range=':= 1 * 1 * mtlgAlduoriteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgAlduoriteSize * _default_' range=':= 1 * 1 * 1 * mtlgAlduoriteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * mtlgAlduoriteFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Alduorite Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgAlduoriteBaseHintVeins' block='Metallurgy:nether.ore:6' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609FCED2</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Alduorite Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Alduorite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Alduorite -->
-                <IfCondition condition=':= mtlgAlduoriteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgAlduoriteBaseStandard' block='Metallurgy:nether.ore:6' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609FCED2</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgAlduoriteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * mtlgAlduoriteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Alduorite -->
-                
-                <!-- End Alduorite Generation --> 
-
-                
-                <!-- Begin Kalendrite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Kalendrite -->
-                <IfCondition condition=':= mtlgKalendriteDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgKalendriteBaseVeins' block='Metallurgy:nether.ore:7'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60AB6AB9</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgKalendriteSize * _default_' range=':= 1 * 1 * mtlgKalendriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgKalendriteSize * _default_' range=':= 1 * 1 * mtlgKalendriteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgKalendriteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Kalendrite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Kalendrite -->
-                <IfCondition condition=':= mtlgKalendriteDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgKalendriteBaseVeins' block='Metallurgy:nether.ore:7'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60AB6AB9</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgKalendriteSize * _default_' range=':= 1 * 1 * mtlgKalendriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgKalendriteSize * _default_' range=':= 1 * 1 * mtlgKalendriteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgKalendriteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Kalendrite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Kalendrite -->
-                <IfCondition condition=':= mtlgKalendriteDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgKalendriteBaseCloud' block='Metallurgy:nether.ore:7' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60AB6AB9</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgKalendriteSize * _default_' range=':= 1 * 1 * mtlgKalendriteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgKalendriteSize * _default_' range=':= 1 * 1 * mtlgKalendriteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgKalendriteSize * _default_' range=':= 1 * 1 * 1 * mtlgKalendriteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * mtlgKalendriteFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Kalendrite Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgKalendriteBaseHintVeins' block='Metallurgy:nether.ore:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60AB6AB9</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Kalendrite Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Kalendrite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Kalendrite -->
-                <IfCondition condition=':= mtlgKalendriteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgKalendriteBaseStandard' block='Metallurgy:nether.ore:7' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60AB6AB9</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgKalendriteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * mtlgKalendriteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Kalendrite -->
-                
-                <!-- End Kalendrite Generation --> 
-
-                
-                <!-- Begin Vulcanite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Vulcanite -->
-                <IfCondition condition=':= mtlgVulcaniteDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgVulcaniteBaseVeins' block='Metallurgy:nether.ore:8'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E66922</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgVulcaniteSize * _default_' range=':= 1 * 1 * mtlgVulcaniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgVulcaniteSize * _default_' range=':= 1 * 1 * mtlgVulcaniteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgVulcaniteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Vulcanite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Vulcanite -->
-                <IfCondition condition=':= mtlgVulcaniteDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgVulcaniteBaseVeins' block='Metallurgy:nether.ore:8'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E66922</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgVulcaniteSize * _default_' range=':= 1 * 1 * mtlgVulcaniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgVulcaniteSize * _default_' range=':= 1 * 1 * mtlgVulcaniteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgVulcaniteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Vulcanite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Vulcanite -->
-                <IfCondition condition=':= mtlgVulcaniteDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgVulcaniteBaseCloud' block='Metallurgy:nether.ore:8' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E66922</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgVulcaniteSize * _default_' range=':= 1 * 1 * mtlgVulcaniteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgVulcaniteSize * _default_' range=':= 1 * 1 * mtlgVulcaniteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgVulcaniteSize * _default_' range=':= 1 * 1 * 1 * mtlgVulcaniteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * mtlgVulcaniteFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Vulcanite Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgVulcaniteBaseHintVeins' block='Metallurgy:nether.ore:8' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E66922</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Vulcanite Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Vulcanite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Vulcanite -->
-                <IfCondition condition=':= mtlgVulcaniteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgVulcaniteBaseStandard' block='Metallurgy:nether.ore:8' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E66922</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgVulcaniteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * mtlgVulcaniteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Vulcanite -->
-                
-                <!-- End Vulcanite Generation --> 
-
-                
-                <!-- Begin Sanguinite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Sanguinite -->
-                <IfCondition condition=':= mtlgSanguiniteDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgSanguiniteBaseVeins' block='Metallurgy:nether.ore:9'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C30506</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgSanguiniteSize * _default_' range=':= 1 * 1 * mtlgSanguiniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgSanguiniteSize * _default_' range=':= 1 * 1 * mtlgSanguiniteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgSanguiniteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Sanguinite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Sanguinite -->
-                <IfCondition condition=':= mtlgSanguiniteDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgSanguiniteBaseVeins' block='Metallurgy:nether.ore:9'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C30506</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgSanguiniteSize * _default_' range=':= 1 * 1 * mtlgSanguiniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgSanguiniteSize * _default_' range=':= 1 * 1 * mtlgSanguiniteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgSanguiniteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Sanguinite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Sanguinite -->
-                <IfCondition condition=':= mtlgSanguiniteDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgSanguiniteBaseCloud' block='Metallurgy:nether.ore:9' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C30506</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgSanguiniteSize * _default_' range=':= 1 * 1 * mtlgSanguiniteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgSanguiniteSize * _default_' range=':= 1 * 1 * mtlgSanguiniteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgSanguiniteSize * _default_' range=':= 1 * 1 * 1 * mtlgSanguiniteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * mtlgSanguiniteFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Sanguinite Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgSanguiniteBaseHintVeins' block='Metallurgy:nether.ore:9' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60C30506</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Sanguinite Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Sanguinite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Sanguinite -->
-                <IfCondition condition=':= mtlgSanguiniteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgSanguiniteBaseStandard' block='Metallurgy:nether.ore:9' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C30506</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgSanguiniteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * mtlgSanguiniteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Sanguinite -->
-                
-                <!-- End Sanguinite Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Nether Setup Complete -->
-
-            <!-- Setup End -->
-            <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
-                
-                <!-- Starting Original End Ore Removal -->
-                <Substitute name='mtlgEndOreSubstitute0' block='minecraft:end_stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='Metallurgy:ender.ore' />
-                    <Replaces block='Metallurgy:ender.ore:1' />
-                </Substitute>
-                <!-- Original End Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Eximite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Eximite -->
-                <IfCondition condition=':= mtlgEximiteDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgEximiteBaseVeins' block='Metallurgy:ender.ore'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607B5994</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgEximiteSize * _default_' range=':= 1 * 1 * mtlgEximiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgEximiteSize * _default_' range=':= 1 * 1 * mtlgEximiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgEximiteFreq * _default_'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Eximite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Eximite -->
-                <IfCondition condition=':= mtlgEximiteDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgEximiteBaseVeins' block='Metallurgy:ender.ore'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607B5994</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgEximiteSize * _default_' range=':= 1 * 1 * mtlgEximiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgEximiteSize * _default_' range=':= 1 * 1 * mtlgEximiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgEximiteFreq * _default_'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Eximite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Eximite -->
-                <IfCondition condition=':= mtlgEximiteDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgEximiteBaseCloud' block='Metallurgy:ender.ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607B5994</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgEximiteSize * _default_' range=':= 1 * 1 * mtlgEximiteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgEximiteSize * _default_' range=':= 1 * 1 * mtlgEximiteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgEximiteSize * _default_' range=':= 1 * 1 * 1 * mtlgEximiteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * mtlgEximiteFreq *_default_'/>
-                        <Replaces block='minecraft:end_stone'/>
-                        
-                        <!-- Begin Eximite Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgEximiteBaseHintVeins' block='Metallurgy:ender.ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x607B5994</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:end_stone'/>
-                        </Veins>
-                        <!-- End Eximite Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Eximite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Eximite -->
-                <IfCondition condition=':= mtlgEximiteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgEximiteBaseStandard' block='Metallurgy:ender.ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x607B5994</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgEximiteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * mtlgEximiteFreq * _default_'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Eximite -->
-                
-                <!-- End Eximite Generation --> 
-
-                
-                <!-- Begin Meutoite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Meutoite -->
-                <IfCondition condition=':= mtlgMeutoiteDist = "layeredVeins"'>
-                
-                    <Veins name='mtlgMeutoiteBaseVeins' block='Metallurgy:ender.ore:1'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605E5168</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgMeutoiteSize * _default_' range=':= 1 * 1 * mtlgMeutoiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgMeutoiteSize * _default_' range=':= 1 * 1 * mtlgMeutoiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgMeutoiteFreq * _default_'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Meutoite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Meutoite -->
-                <IfCondition condition=':= mtlgMeutoiteDist = "hugeVeins"'>
-                
-                    <Veins name='mtlgMeutoiteBaseVeins' block='Metallurgy:ender.ore:1'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605E5168</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mtlgMeutoiteSize * _default_' range=':= 1 * 1 * mtlgMeutoiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mtlgMeutoiteSize * _default_' range=':= 1 * 1 * mtlgMeutoiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * mtlgMeutoiteFreq * _default_'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Meutoite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Meutoite -->
-                <IfCondition condition=':= mtlgMeutoiteDist = "strategicCloud"'>
-                
-                    <Cloud name='mtlgMeutoiteBaseCloud' block='Metallurgy:ender.ore:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605E5168</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mtlgMeutoiteSize * _default_' range=':= 1 * 1 * mtlgMeutoiteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mtlgMeutoiteSize * _default_' range=':= 1 * 1 * mtlgMeutoiteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mtlgMeutoiteSize * _default_' range=':= 1 * 1 * 1 * mtlgMeutoiteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * mtlgMeutoiteFreq *_default_'/>
-                        <Replaces block='minecraft:end_stone'/>
-                        
-                        <!-- Begin Meutoite Strategic Cloud Hint Veins -->
-                        <Veins name='mtlgMeutoiteBaseHintVeins' block='Metallurgy:ender.ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x605E5168</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:end_stone'/>
-                        </Veins>
-                        <!-- End Meutoite Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Meutoite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Meutoite -->
-                <IfCondition condition=':= mtlgMeutoiteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mtlgMeutoiteBaseStandard' block='Metallurgy:ender.ore:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x605E5168</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mtlgMeutoiteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * mtlgMeutoiteFreq * _default_'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Meutoite -->
-                
-                <!-- End Meutoite Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- End Setup Complete -->
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Potash is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgPotashFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Potash distributions </Description>
+                    <DisplayName>Metallurgy 4 Potash Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgPotashSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Potash distributions </Description>
+                    <DisplayName>Metallurgy 4 Potash Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Potash Configuration UI Complete -->
+
+
+            <!-- Copper Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgCopperDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Copper is generated </Description>
+                    <DisplayName>Metallurgy 4 Copper</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Copper distributions </Description>
+                    <DisplayName>Metallurgy 4 Copper Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Copper distributions </Description>
+                    <DisplayName>Metallurgy 4 Copper Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Copper Configuration UI Complete -->
+
+
+            <!-- Tin Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgTinDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Tin is generated </Description>
+                    <DisplayName>Metallurgy 4 Tin</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Tin distributions </Description>
+                    <DisplayName>Metallurgy 4 Tin Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Tin distributions </Description>
+                    <DisplayName>Metallurgy 4 Tin Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Tin Configuration UI Complete -->
+
+
+            <!-- Manganese Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgManganeseDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Manganese is generated </Description>
+                    <DisplayName>Metallurgy 4 Manganese</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Manganese is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgManganeseFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Manganese distributions </Description>
+                    <DisplayName>Metallurgy 4 Manganese Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgManganeseSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Manganese distributions </Description>
+                    <DisplayName>Metallurgy 4 Manganese Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Manganese Configuration UI Complete -->
+
+
+            <!-- Zinc Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgZincDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Zinc is generated </Description>
+                    <DisplayName>Metallurgy 4 Zinc</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Zinc is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgZincFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Zinc distributions </Description>
+                    <DisplayName>Metallurgy 4 Zinc Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgZincSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Zinc distributions </Description>
+                    <DisplayName>Metallurgy 4 Zinc Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Zinc Configuration UI Complete -->
+
+
+            <!-- Silver Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgSilverDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Silver is generated </Description>
+                    <DisplayName>Metallurgy 4 Silver</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Silver distributions </Description>
+                    <DisplayName>Metallurgy 4 Silver Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Silver distributions </Description>
+                    <DisplayName>Metallurgy 4 Silver Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Silver Configuration UI Complete -->
+
+
+            <!-- Platinum Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgPlatinumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Platinum is generated </Description>
+                    <DisplayName>Metallurgy 4 Platinum</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Platinum is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgPlatinumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Platinum distributions </Description>
+                    <DisplayName>Metallurgy 4 Platinum Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgPlatinumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Platinum distributions </Description>
+                    <DisplayName>Metallurgy 4 Platinum Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Platinum Configuration UI Complete -->
+
+
+            <!-- Promethium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgPromethiumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Promethium is generated </Description>
+                    <DisplayName>Metallurgy 4 Promethium</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Promethium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgPromethiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Promethium distributions </Description>
+                    <DisplayName>Metallurgy 4 Promethium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgPromethiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Promethium distributions </Description>
+                    <DisplayName>Metallurgy 4 Promethium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Promethium Configuration UI Complete -->
+
+
+            <!-- Deep Iron Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgDeepIronDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Deep Iron is generated </Description>
+                    <DisplayName>Metallurgy 4 Deep Iron</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Deep Iron is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgDeepIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Deep Iron distributions </Description>
+                    <DisplayName>Metallurgy 4 Deep Iron Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgDeepIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Deep Iron distributions </Description>
+                    <DisplayName>Metallurgy 4 Deep Iron Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Deep Iron Configuration UI Complete -->
+
+
+            <!-- Infuscolium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgInfuscoliumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Infuscolium is generated </Description>
+                    <DisplayName>Metallurgy 4 Infuscolium</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Infuscolium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgInfuscoliumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Infuscolium distributions </Description>
+                    <DisplayName>Metallurgy 4 Infuscolium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgInfuscoliumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Infuscolium distributions </Description>
+                    <DisplayName>Metallurgy 4 Infuscolium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Infuscolium Configuration UI Complete -->
+
+
+            <!-- Oureclase Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgOureclaseDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Oureclase is generated </Description>
+                    <DisplayName>Metallurgy 4 Oureclase</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Oureclase is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgOureclaseFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Oureclase distributions </Description>
+                    <DisplayName>Metallurgy 4 Oureclase Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgOureclaseSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Oureclase distributions </Description>
+                    <DisplayName>Metallurgy 4 Oureclase Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Oureclase Configuration UI Complete -->
+
+
+            <!-- Astral Silver Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgAstralSilverDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Astral Silver is generated </Description>
+                    <DisplayName>Metallurgy 4 Astral Silver</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Astral Silver is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgAstralSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Astral Silver distributions </Description>
+                    <DisplayName>Metallurgy 4 Astral Silver Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgAstralSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Astral Silver distributions </Description>
+                    <DisplayName>Metallurgy 4 Astral Silver Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Astral Silver Configuration UI Complete -->
+
+
+            <!-- Carmot Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgCarmotDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Carmot is generated </Description>
+                    <DisplayName>Metallurgy 4 Carmot</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Carmot is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgCarmotFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Carmot distributions </Description>
+                    <DisplayName>Metallurgy 4 Carmot Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgCarmotSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Carmot distributions </Description>
+                    <DisplayName>Metallurgy 4 Carmot Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Carmot Configuration UI Complete -->
+
+
+            <!-- Mithril Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgMithrilDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Mithril is generated </Description>
+                    <DisplayName>Metallurgy 4 Mithril</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Mithril is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgMithrilFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Mithril distributions </Description>
+                    <DisplayName>Metallurgy 4 Mithril Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgMithrilSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Mithril distributions </Description>
+                    <DisplayName>Metallurgy 4 Mithril Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Mithril Configuration UI Complete -->
+
+
+            <!-- Rubracium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgRubraciumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Rubracium is generated </Description>
+                    <DisplayName>Metallurgy 4 Rubracium</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Rubracium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgRubraciumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Rubracium distributions </Description>
+                    <DisplayName>Metallurgy 4 Rubracium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgRubraciumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Rubracium distributions </Description>
+                    <DisplayName>Metallurgy 4 Rubracium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Rubracium Configuration UI Complete -->
+
+
+            <!-- Orichalcum Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgOrichalcumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Orichalcum is generated </Description>
+                    <DisplayName>Metallurgy 4 Orichalcum</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Orichalcum is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgOrichalcumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Orichalcum distributions </Description>
+                    <DisplayName>Metallurgy 4 Orichalcum Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgOrichalcumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Orichalcum distributions </Description>
+                    <DisplayName>Metallurgy 4 Orichalcum Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Orichalcum Configuration UI Complete -->
+
+
+            <!-- Adamantine Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgAdamantineDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Adamantine is generated </Description>
+                    <DisplayName>Metallurgy 4 Adamantine</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Adamantine is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgAdamantineFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Adamantine distributions </Description>
+                    <DisplayName>Metallurgy 4 Adamantine Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgAdamantineSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Adamantine distributions </Description>
+                    <DisplayName>Metallurgy 4 Adamantine Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Adamantine Configuration UI Complete -->
+
+
+            <!-- Atlarus Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgAtlarusDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Atlarus is generated </Description>
+                    <DisplayName>Metallurgy 4 Atlarus</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Atlarus is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgAtlarusFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Atlarus distributions </Description>
+                    <DisplayName>Metallurgy 4 Atlarus Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgAtlarusSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Atlarus distributions </Description>
+                    <DisplayName>Metallurgy 4 Atlarus Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Atlarus Configuration UI Complete -->
+
+
+            <!-- Ignatius Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgIgnatiusDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Ignatius is generated </Description>
+                    <DisplayName>Metallurgy 4 Ignatius</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Ignatius is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgIgnatiusFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Ignatius distributions </Description>
+                    <DisplayName>Metallurgy 4 Ignatius Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgIgnatiusSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Ignatius distributions </Description>
+                    <DisplayName>Metallurgy 4 Ignatius Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Ignatius Configuration UI Complete -->
+
+
+            <!-- Shadow Iron Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgShadowIronDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Shadow Iron is generated </Description>
+                    <DisplayName>Metallurgy 4 Shadow Iron</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Shadow Iron is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgShadowIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Shadow Iron distributions </Description>
+                    <DisplayName>Metallurgy 4 Shadow Iron Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgShadowIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Shadow Iron distributions </Description>
+                    <DisplayName>Metallurgy 4 Shadow Iron Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Shadow Iron Configuration UI Complete -->
+
+
+            <!-- Lemurite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgLemuriteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Lemurite is generated </Description>
+                    <DisplayName>Metallurgy 4 Lemurite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Lemurite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgLemuriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Lemurite distributions </Description>
+                    <DisplayName>Metallurgy 4 Lemurite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgLemuriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Lemurite distributions </Description>
+                    <DisplayName>Metallurgy 4 Lemurite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Lemurite Configuration UI Complete -->
+
+
+            <!-- Midasium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgMidasiumDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Midasium is generated </Description>
+                    <DisplayName>Metallurgy 4 Midasium</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Midasium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgMidasiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Midasium distributions </Description>
+                    <DisplayName>Metallurgy 4 Midasium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgMidasiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Midasium distributions </Description>
+                    <DisplayName>Metallurgy 4 Midasium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Midasium Configuration UI Complete -->
+
+
+            <!-- Vyroxeres Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgVyroxeresDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Vyroxeres is generated </Description>
+                    <DisplayName>Metallurgy 4 Vyroxeres</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Vyroxeres is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgVyroxeresFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Vyroxeres distributions </Description>
+                    <DisplayName>Metallurgy 4 Vyroxeres Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgVyroxeresSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Vyroxeres distributions </Description>
+                    <DisplayName>Metallurgy 4 Vyroxeres Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Vyroxeres Configuration UI Complete -->
+
+
+            <!-- Ceruclase Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgCeruclaseDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Ceruclase is generated </Description>
+                    <DisplayName>Metallurgy 4 Ceruclase</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Ceruclase is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgCeruclaseFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Ceruclase distributions </Description>
+                    <DisplayName>Metallurgy 4 Ceruclase Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgCeruclaseSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Ceruclase distributions </Description>
+                    <DisplayName>Metallurgy 4 Ceruclase Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Ceruclase Configuration UI Complete -->
+
+
+            <!-- Alduorite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgAlduoriteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Alduorite is generated </Description>
+                    <DisplayName>Metallurgy 4 Alduorite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Alduorite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgAlduoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Alduorite distributions </Description>
+                    <DisplayName>Metallurgy 4 Alduorite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgAlduoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Alduorite distributions </Description>
+                    <DisplayName>Metallurgy 4 Alduorite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Alduorite Configuration UI Complete -->
+
+
+            <!-- Kalendrite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgKalendriteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Kalendrite is generated </Description>
+                    <DisplayName>Metallurgy 4 Kalendrite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Kalendrite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgKalendriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Kalendrite distributions </Description>
+                    <DisplayName>Metallurgy 4 Kalendrite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgKalendriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Kalendrite distributions </Description>
+                    <DisplayName>Metallurgy 4 Kalendrite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Kalendrite Configuration UI Complete -->
+
+
+            <!-- Vulcanite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgVulcaniteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Vulcanite is generated </Description>
+                    <DisplayName>Metallurgy 4 Vulcanite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Vulcanite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgVulcaniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Vulcanite distributions </Description>
+                    <DisplayName>Metallurgy 4 Vulcanite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgVulcaniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Vulcanite distributions </Description>
+                    <DisplayName>Metallurgy 4 Vulcanite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Vulcanite Configuration UI Complete -->
+
+
+            <!-- Sanguinite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgSanguiniteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Sanguinite is generated </Description>
+                    <DisplayName>Metallurgy 4 Sanguinite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Sanguinite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgSanguiniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Sanguinite distributions </Description>
+                    <DisplayName>Metallurgy 4 Sanguinite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgSanguiniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Sanguinite distributions </Description>
+                    <DisplayName>Metallurgy 4 Sanguinite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Sanguinite Configuration UI Complete -->
+
+
+            <!-- Eximite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgEximiteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Eximite is generated </Description>
+                    <DisplayName>Metallurgy 4 Eximite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Eximite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgEximiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Eximite distributions </Description>
+                    <DisplayName>Metallurgy 4 Eximite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgEximiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Eximite distributions </Description>
+                    <DisplayName>Metallurgy 4 Eximite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Eximite Configuration UI Complete -->
+
+
+            <!-- Meutoite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='mtlgMeutoiteDist'  displayState='shown' displayGroup='groupMetallurgy4'>
+                    <Description> Controls how Meutoite is generated </Description>
+                    <DisplayName>Metallurgy 4 Meutoite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Meutoite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mtlgMeutoiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Frequency multiplier for Metallurgy 4 Meutoite distributions </Description>
+                    <DisplayName>Metallurgy 4 Meutoite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mtlgMeutoiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMetallurgy4'>
+                    <Description> Size multiplier for Metallurgy 4 Meutoite distributions </Description>
+                    <DisplayName>Metallurgy 4 Meutoite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Meutoite Configuration UI Complete -->
 
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='mtlgOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='Metallurgy:base.ore' weight='1.0' />
+                <Replaces block='Metallurgy:base.ore:1' weight='1.0' />
+                <Replaces block='Metallurgy:base.ore:2' weight='1.0' />
+                <Replaces block='Metallurgy:fantasy.ore' weight='1.0' />
+                <Replaces block='Metallurgy:fantasy.ore:1' weight='1.0' />
+                <Replaces block='Metallurgy:fantasy.ore:11' weight='1.0' />
+                <Replaces block='Metallurgy:fantasy.ore:13' weight='1.0' />
+                <Replaces block='Metallurgy:fantasy.ore:14' weight='1.0' />
+                <Replaces block='Metallurgy:fantasy.ore:2' weight='1.0' />
+                <Replaces block='Metallurgy:fantasy.ore:4' weight='1.0' />
+                <Replaces block='Metallurgy:fantasy.ore:5' weight='1.0' />
+                <Replaces block='Metallurgy:fantasy.ore:6' weight='1.0' />
+                <Replaces block='Metallurgy:fantasy.ore:7' weight='1.0' />
+                <Replaces block='Metallurgy:fantasy.ore:8' weight='1.0' />
+                <Replaces block='Metallurgy:precious.ore' weight='1.0' />
+                <Replaces block='Metallurgy:precious.ore:1' weight='1.0' />
+                <Replaces block='Metallurgy:precious.ore:2' weight='1.0' />
+                <Replaces block='Metallurgy:utility.ore' weight='1.0' />
+                <Replaces block='Metallurgy:utility.ore:1' weight='1.0' />
+                <Replaces block='Metallurgy:utility.ore:2' weight='1.0' />
+                <Replaces block='Metallurgy:utility.ore:3' weight='1.0' />
+                <Replaces block='Metallurgy:utility.ore:4' weight='1.0' />
+                <Replaces block='Metallurgy:utility.ore:5' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Sulfur Generation -->
+
+            <!-- Starting SparseVeins Preset for Sulfur. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgSulfurDist = "SparseVeins"'>
+                    <Veins name='mtlgSulfurVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgSulfurFreq ' range=':=  _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Sulfur is complete. -->
+
+
+            <!-- Starting Cloud Preset for Sulfur. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgSulfurDist = "Cloud"'>
+                    <Cloud name='mtlgSulfurCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgSulfurFreq ' range=':=  _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgSulfurHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Sulfur is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Sulfur. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgSulfurDist = "Vanilla"'>
+                    <StandardGen name='mtlgSulfurStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 4 * mtlgSulfurFreq ' range=':=  _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Sulfur is complete. -->
+
+            <!-- End Sulfur Generation -->
+
+
+            <!-- Begin Phosphorite Generation -->
+
+            <!-- Starting SparseVeins Preset for Phosphorite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgPhosphoriteDist = "SparseVeins"'>
+                    <Veins name='mtlgPhosphoriteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgPhosphoriteFreq ' range=':=  _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Phosphorite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Phosphorite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgPhosphoriteDist = "Cloud"'>
+                    <Cloud name='mtlgPhosphoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgPhosphoriteFreq ' range=':=  _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgPhosphoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Phosphorite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Phosphorite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgPhosphoriteDist = "Vanilla"'>
+                    <StandardGen name='mtlgPhosphoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 4 * mtlgPhosphoriteFreq ' range=':=  _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Phosphorite is complete. -->
+
+            <!-- End Phosphorite Generation -->
+
+
+            <!-- Begin Saltpeter Generation -->
+
+            <!-- Starting SparseVeins Preset for Saltpeter. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgSaltpeterDist = "SparseVeins"'>
+                    <Veins name='mtlgSaltpeterVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgSaltpeterFreq ' range=':=  _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Saltpeter is complete. -->
+
+
+            <!-- Starting Cloud Preset for Saltpeter. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgSaltpeterDist = "Cloud"'>
+                    <Cloud name='mtlgSaltpeterCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgSaltpeterFreq ' range=':=  _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgSaltpeterHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Saltpeter is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Saltpeter. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgSaltpeterDist = "Vanilla"'>
+                    <StandardGen name='mtlgSaltpeterStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 4 * mtlgSaltpeterFreq ' range=':=  _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Saltpeter is complete. -->
+
+            <!-- End Saltpeter Generation -->
+
+
+            <!-- Begin Magnesium Generation -->
+
+            <!-- Starting SparseVeins Preset for Magnesium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgMagnesiumDist = "SparseVeins"'>
+                    <Veins name='mtlgMagnesiumVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgMagnesiumFreq ' range=':=  _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Magnesium is complete. -->
+
+
+            <!-- Starting Cloud Preset for Magnesium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgMagnesiumDist = "Cloud"'>
+                    <Cloud name='mtlgMagnesiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgMagnesiumFreq ' range=':=  _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgMagnesiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Magnesium is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Magnesium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgMagnesiumDist = "Vanilla"'>
+                    <StandardGen name='mtlgMagnesiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 4 * mtlgMagnesiumFreq ' range=':=  _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Magnesium is complete. -->
+
+            <!-- End Magnesium Generation -->
+
+
+            <!-- Begin Bitumen Generation -->
+
+            <!-- Starting SparseVeins Preset for Bitumen. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgBitumenDist = "SparseVeins"'>
+                    <Veins name='mtlgBitumenVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgBitumenFreq ' range=':=  _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Bitumen is complete. -->
+
+
+            <!-- Starting Cloud Preset for Bitumen. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgBitumenDist = "Cloud"'>
+                    <Cloud name='mtlgBitumenCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgBitumenFreq ' range=':=  _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgBitumenHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Bitumen is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Bitumen. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgBitumenDist = "Vanilla"'>
+                    <StandardGen name='mtlgBitumenStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 4 * mtlgBitumenFreq ' range=':=  _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Bitumen is complete. -->
+
+            <!-- End Bitumen Generation -->
+
+
+            <!-- Begin Potash Generation -->
+
+            <!-- Starting SparseVeins Preset for Potash. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgPotashDist = "SparseVeins"'>
+                    <Veins name='mtlgPotashVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgPotashFreq ' range=':=  _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Potash is complete. -->
+
+
+            <!-- Starting Cloud Preset for Potash. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgPotashDist = "Cloud"'>
+                    <Cloud name='mtlgPotashCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgPotashFreq ' range=':=  _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgPotashHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Potash is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Potash. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgPotashDist = "Vanilla"'>
+                    <StandardGen name='mtlgPotashStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 4 * mtlgPotashFreq ' range=':=  _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Potash is complete. -->
+
+            <!-- End Potash Generation -->
+
+
+            <!-- Begin Copper Generation -->
+
+            <!-- Starting LayeredVeins Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgCopperDist = "LayeredVeins"'>
+                    <Veins name='mtlgCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:base.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.005 * _default_ * mtlgCopperFreq ' range=':=  _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.002 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.002 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.002 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Copper is complete. -->
+
+
+            <!-- Starting Cloud Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgCopperDist = "Cloud"'>
+                    <Cloud name='mtlgCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:base.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.417 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.417 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.007  * _default_ * mtlgCopperFreq ' range=':=  _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:base.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Copper is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgCopperDist = "Vanilla"'>
+                    <StandardGen name='mtlgCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:base.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 12 * mtlgCopperFreq ' range=':=  _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Copper is complete. -->
+
+            <!-- End Copper Generation -->
+
+
+            <!-- Begin Tin Generation -->
+
+            <!-- Starting LayeredVeins Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgTinDist = "LayeredVeins"'>
+                    <Veins name='mtlgTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.991 * _default_ * mtlgTinFreq ' range=':=  _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.997 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.997 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.997 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Tin is complete. -->
+
+
+            <!-- Starting Cloud Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgTinDist = "Cloud"'>
+                    <Cloud name='mtlgTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.407 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.407 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.979  * _default_ * mtlgTinFreq ' range=':=  _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Tin is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgTinDist = "Vanilla"'>
+                    <StandardGen name='mtlgTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 10 * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 7 * mtlgTinFreq ' range=':=  _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Tin is complete. -->
+
+            <!-- End Tin Generation -->
+
+
+            <!-- Begin Manganese Generation -->
+
+            <!-- Starting LayeredVeins Preset for Manganese. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgManganeseDist = "LayeredVeins"'>
+                    <Veins name='mtlgManganeseVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgManganeseFreq ' range=':=  _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Manganese is complete. -->
+
+
+            <!-- Starting Cloud Preset for Manganese. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgManganeseDist = "Cloud"'>
+                    <Cloud name='mtlgManganeseCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgManganeseFreq ' range=':=  _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgManganeseHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Manganese is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Manganese. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgManganeseDist = "Vanilla"'>
+                    <StandardGen name='mtlgManganeseStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 5 * mtlgManganeseFreq ' range=':=  _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Manganese is complete. -->
+
+            <!-- End Manganese Generation -->
+
+
+            <!-- Begin Zinc Generation -->
+
+            <!-- Starting LayeredVeins Preset for Zinc. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgZincDist = "LayeredVeins"'>
+                    <Veins name='mtlgZincVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgZincFreq ' range=':=  _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Zinc is complete. -->
+
+
+            <!-- Starting Cloud Preset for Zinc. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgZincDist = "Cloud"'>
+                    <Cloud name='mtlgZincCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgZincFreq ' range=':=  _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgZincHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Zinc is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Zinc. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgZincDist = "Vanilla"'>
+                    <StandardGen name='mtlgZincStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 5 * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 6 * mtlgZincFreq ' range=':=  _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Zinc is complete. -->
+
+            <!-- End Zinc Generation -->
+
+
+            <!-- Begin Silver Generation -->
+
+            <!-- Starting LayeredVeins Preset for Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgSilverDist = "LayeredVeins"'>
+                    <Veins name='mtlgSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgSilverFreq ' range=':=  _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Silver is complete. -->
+
+
+            <!-- Starting Cloud Preset for Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgSilverDist = "Cloud"'>
+                    <Cloud name='mtlgSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgSilverFreq ' range=':=  _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Silver is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgSilverDist = "Vanilla"'>
+                    <StandardGen name='mtlgSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 5 * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 6 * mtlgSilverFreq ' range=':=  _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Silver is complete. -->
+
+            <!-- End Silver Generation -->
+
+
+            <!-- Begin Platinum Generation -->
+
+            <!-- Starting LayeredVeins Preset for Platinum. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgPlatinumDist = "LayeredVeins"'>
+                    <Veins name='mtlgPlatinumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgPlatinumFreq ' range=':=  _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Platinum is complete. -->
+
+
+            <!-- Starting Cloud Preset for Platinum. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgPlatinumDist = "Cloud"'>
+                    <Cloud name='mtlgPlatinumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgPlatinumFreq ' range=':=  _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgPlatinumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Platinum is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Platinum. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgPlatinumDist = "Vanilla"'>
+                    <StandardGen name='mtlgPlatinumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * mtlgPlatinumFreq ' range=':=  _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Platinum is complete. -->
+
+            <!-- End Platinum Generation -->
+
+
+            <!-- Begin Promethium Generation -->
+
+            <!-- Starting LayeredVeins Preset for Promethium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgPromethiumDist = "LayeredVeins"'>
+                    <Veins name='mtlgPromethiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgPromethiumFreq ' range=':=  _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Promethium is complete. -->
+
+
+            <!-- Starting Cloud Preset for Promethium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgPromethiumDist = "Cloud"'>
+                    <Cloud name='mtlgPromethiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgPromethiumFreq ' range=':=  _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgPromethiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Promethium is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Promethium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgPromethiumDist = "Vanilla"'>
+                    <StandardGen name='mtlgPromethiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 5 * mtlgPromethiumFreq ' range=':=  _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Promethium is complete. -->
+
+            <!-- End Promethium Generation -->
+
+
+            <!-- Begin Deep Iron Generation -->
+
+            <!-- Starting LayeredVeins Preset for Deep Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgDeepIronDist = "LayeredVeins"'>
+                    <Veins name='mtlgDeepIronVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgDeepIronFreq ' range=':=  _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Deep Iron is complete. -->
+
+
+            <!-- Starting Cloud Preset for Deep Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgDeepIronDist = "Cloud"'>
+                    <Cloud name='mtlgDeepIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgDeepIronFreq ' range=':=  _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgDeepIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Deep Iron is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Deep Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgDeepIronDist = "Vanilla"'>
+                    <StandardGen name='mtlgDeepIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 5 * mtlgDeepIronFreq ' range=':=  _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Deep Iron is complete. -->
+
+            <!-- End Deep Iron Generation -->
+
+
+            <!-- Begin Infuscolium Generation -->
+
+            <!-- Starting LayeredVeins Preset for Infuscolium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgInfuscoliumDist = "LayeredVeins"'>
+                    <Veins name='mtlgInfuscoliumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgInfuscoliumFreq ' range=':=  _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Infuscolium is complete. -->
+
+
+            <!-- Starting Cloud Preset for Infuscolium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgInfuscoliumDist = "Cloud"'>
+                    <Cloud name='mtlgInfuscoliumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgInfuscoliumFreq ' range=':=  _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgInfuscoliumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Infuscolium is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Infuscolium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgInfuscoliumDist = "Vanilla"'>
+                    <StandardGen name='mtlgInfuscoliumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 5 * mtlgInfuscoliumFreq ' range=':=  _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Infuscolium is complete. -->
+
+            <!-- End Infuscolium Generation -->
+
+
+            <!-- Begin Oureclase Generation -->
+
+            <!-- Starting LayeredVeins Preset for Oureclase. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgOureclaseDist = "LayeredVeins"'>
+                    <Veins name='mtlgOureclaseVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgOureclaseFreq ' range=':=  _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Oureclase is complete. -->
+
+
+            <!-- Starting Cloud Preset for Oureclase. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgOureclaseDist = "Cloud"'>
+                    <Cloud name='mtlgOureclaseCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgOureclaseFreq ' range=':=  _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgOureclaseHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Oureclase is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Oureclase. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgOureclaseDist = "Vanilla"'>
+                    <StandardGen name='mtlgOureclaseStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 4 * mtlgOureclaseFreq ' range=':=  _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Oureclase is complete. -->
+
+            <!-- End Oureclase Generation -->
+
+
+            <!-- Begin Astral Silver Generation -->
+
+            <!-- Starting LayeredVeins Preset for Astral Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgAstralSilverDist = "LayeredVeins"'>
+                    <Veins name='mtlgAstralSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgAstralSilverFreq ' range=':=  _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Astral Silver is complete. -->
+
+
+            <!-- Starting Cloud Preset for Astral Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgAstralSilverDist = "Cloud"'>
+                    <Cloud name='mtlgAstralSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgAstralSilverFreq ' range=':=  _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgAstralSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Astral Silver is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Astral Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgAstralSilverDist = "Vanilla"'>
+                    <StandardGen name='mtlgAstralSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 4 * mtlgAstralSilverFreq ' range=':=  _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Astral Silver is complete. -->
+
+            <!-- End Astral Silver Generation -->
+
+
+            <!-- Begin Carmot Generation -->
+
+            <!-- Starting LayeredVeins Preset for Carmot. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgCarmotDist = "LayeredVeins"'>
+                    <Veins name='mtlgCarmotVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgCarmotFreq ' range=':=  _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Carmot is complete. -->
+
+
+            <!-- Starting Cloud Preset for Carmot. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgCarmotDist = "Cloud"'>
+                    <Cloud name='mtlgCarmotCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgCarmotFreq ' range=':=  _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgCarmotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Carmot is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Carmot. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgCarmotDist = "Vanilla"'>
+                    <StandardGen name='mtlgCarmotStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * mtlgCarmotFreq ' range=':=  _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Carmot is complete. -->
+
+            <!-- End Carmot Generation -->
+
+
+            <!-- Begin Mithril Generation -->
+
+            <!-- Starting LayeredVeins Preset for Mithril. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgMithrilDist = "LayeredVeins"'>
+                    <Veins name='mtlgMithrilVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgMithrilFreq ' range=':=  _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Mithril is complete. -->
+
+
+            <!-- Starting Cloud Preset for Mithril. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgMithrilDist = "Cloud"'>
+                    <Cloud name='mtlgMithrilCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgMithrilFreq ' range=':=  _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgMithrilHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Mithril is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Mithril. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgMithrilDist = "Vanilla"'>
+                    <StandardGen name='mtlgMithrilStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * mtlgMithrilFreq ' range=':=  _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Mithril is complete. -->
+
+            <!-- End Mithril Generation -->
+
+
+            <!-- Begin Rubracium Generation -->
+
+            <!-- Starting LayeredVeins Preset for Rubracium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgRubraciumDist = "LayeredVeins"'>
+                    <Veins name='mtlgRubraciumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgRubraciumFreq ' range=':=  _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Rubracium is complete. -->
+
+
+            <!-- Starting Cloud Preset for Rubracium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgRubraciumDist = "Cloud"'>
+                    <Cloud name='mtlgRubraciumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgRubraciumFreq ' range=':=  _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgRubraciumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Rubracium is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Rubracium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgRubraciumDist = "Vanilla"'>
+                    <StandardGen name='mtlgRubraciumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * mtlgRubraciumFreq ' range=':=  _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Rubracium is complete. -->
+
+            <!-- End Rubracium Generation -->
+
+
+            <!-- Begin Orichalcum Generation -->
+
+            <!-- Starting LayeredVeins Preset for Orichalcum. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgOrichalcumDist = "LayeredVeins"'>
+                    <Veins name='mtlgOrichalcumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * mtlgOrichalcumFreq ' range=':=  _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Orichalcum is complete. -->
+
+
+            <!-- Starting Cloud Preset for Orichalcum. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgOrichalcumDist = "Cloud"'>
+                    <Cloud name='mtlgOrichalcumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.818 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.818 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * mtlgOrichalcumFreq ' range=':=  _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgOrichalcumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Orichalcum is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Orichalcum. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgOrichalcumDist = "Vanilla"'>
+                    <StandardGen name='mtlgOrichalcumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * mtlgOrichalcumFreq ' range=':=  _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Orichalcum is complete. -->
+
+            <!-- End Orichalcum Generation -->
+
+
+            <!-- Begin Adamantine Generation -->
+
+            <!-- Starting LayeredVeins Preset for Adamantine. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgAdamantineDist = "LayeredVeins"'>
+                    <Veins name='mtlgAdamantineVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgAdamantineFreq ' range=':=  _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Adamantine is complete. -->
+
+
+            <!-- Starting Cloud Preset for Adamantine. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgAdamantineDist = "Cloud"'>
+                    <Cloud name='mtlgAdamantineCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgAdamantineFreq ' range=':=  _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgAdamantineHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Adamantine is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Adamantine. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgAdamantineDist = "Vanilla"'>
+                    <StandardGen name='mtlgAdamantineStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * mtlgAdamantineFreq ' range=':=  _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Adamantine is complete. -->
+
+            <!-- End Adamantine Generation -->
+
+
+            <!-- Begin Atlarus Generation -->
+
+            <!-- Starting LayeredVeins Preset for Atlarus. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgAtlarusDist = "LayeredVeins"'>
+                    <Veins name='mtlgAtlarusVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgAtlarusFreq ' range=':=  _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Atlarus is complete. -->
+
+
+            <!-- Starting Cloud Preset for Atlarus. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgAtlarusDist = "Cloud"'>
+                    <Cloud name='mtlgAtlarusCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgAtlarusFreq ' range=':=  _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgAtlarusHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Atlarus is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Atlarus. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgAtlarusDist = "Vanilla"'>
+                    <StandardGen name='mtlgAtlarusStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * mtlgAtlarusFreq ' range=':=  _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Atlarus is complete. -->
+
+            <!-- End Atlarus Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+
+        <!-- Nether Setup Beginning -->
+
+        <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
+
+            <!-- Starting Original "Nether" Block Removal -->
+
+            <Substitute name='mtlgNetherBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='Metallurgy:nether.ore' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Nether" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Ignatius Generation -->
+
+            <!-- Starting LayeredVeins Preset for Ignatius. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgIgnatiusDist = "LayeredVeins"'>
+                    <Veins name='mtlgIgnatiusVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.870 * _default_ * mtlgIgnatiusFreq ' range=':=  _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.955 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.955 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.955 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Ignatius is complete. -->
+
+
+            <!-- Starting Cloud Preset for Ignatius. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgIgnatiusDist = "Cloud"'>
+                    <Cloud name='mtlgIgnatiusCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.318 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.318 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.738  * _default_ * mtlgIgnatiusFreq ' range=':=  _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgIgnatiusHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Ignatius is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Ignatius. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgIgnatiusDist = "Vanilla"'>
+                    <StandardGen name='mtlgIgnatiusStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 9 * mtlgIgnatiusFreq ' range=':=  _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Ignatius is complete. -->
+
+            <!-- End Ignatius Generation -->
+
+
+            <!-- Begin Shadow Iron Generation -->
+
+            <!-- Starting LayeredVeins Preset for Shadow Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgShadowIronDist = "LayeredVeins"'>
+                    <Veins name='mtlgShadowIronVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.768 * _default_ * mtlgShadowIronFreq ' range=':=  _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.916 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.916 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.916 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Shadow Iron is complete. -->
+
+
+            <!-- Starting Cloud Preset for Shadow Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgShadowIronDist = "Cloud"'>
+                    <Cloud name='mtlgShadowIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.238 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.238 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.533  * _default_ * mtlgShadowIronFreq ' range=':=  _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgShadowIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Shadow Iron is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Shadow Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgShadowIronDist = "Vanilla"'>
+                    <StandardGen name='mtlgShadowIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 7 * mtlgShadowIronFreq ' range=':=  _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Shadow Iron is complete. -->
+
+            <!-- End Shadow Iron Generation -->
+
+
+            <!-- Begin Lemurite Generation -->
+
+            <!-- Starting LayeredVeins Preset for Lemurite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgLemuriteDist = "LayeredVeins"'>
+                    <Veins name='mtlgLemuriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.711 * _default_ * mtlgLemuriteFreq ' range=':=  _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.892 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.892 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Lemurite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Lemurite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgLemuriteDist = "Cloud"'>
+                    <Cloud name='mtlgLemuriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.191 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.191 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * mtlgLemuriteFreq ' range=':=  _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgLemuriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Lemurite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Lemurite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgLemuriteDist = "Vanilla"'>
+                    <StandardGen name='mtlgLemuriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 6 * mtlgLemuriteFreq ' range=':=  _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Lemurite is complete. -->
+
+            <!-- End Lemurite Generation -->
+
+
+            <!-- Begin Midasium Generation -->
+
+            <!-- Starting LayeredVeins Preset for Midasium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgMidasiumDist = "LayeredVeins"'>
+                    <Veins name='mtlgMidasiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgMidasiumFreq ' range=':=  _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Midasium is complete. -->
+
+
+            <!-- Starting Cloud Preset for Midasium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgMidasiumDist = "Cloud"'>
+                    <Cloud name='mtlgMidasiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgMidasiumFreq ' range=':=  _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgMidasiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Midasium is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Midasium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgMidasiumDist = "Vanilla"'>
+                    <StandardGen name='mtlgMidasiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 5 * mtlgMidasiumFreq ' range=':=  _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Midasium is complete. -->
+
+            <!-- End Midasium Generation -->
+
+
+            <!-- Begin Vyroxeres Generation -->
+
+            <!-- Starting LayeredVeins Preset for Vyroxeres. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgVyroxeresDist = "LayeredVeins"'>
+                    <Veins name='mtlgVyroxeresVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.627 * _default_ * mtlgVyroxeresFreq ' range=':=  _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.856 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.856 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.856 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Vyroxeres is complete. -->
+
+
+            <!-- Starting Cloud Preset for Vyroxeres. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgVyroxeresDist = "Cloud"'>
+                    <Cloud name='mtlgVyroxeresCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.119 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.119 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.251  * _default_ * mtlgVyroxeresFreq ' range=':=  _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgVyroxeresHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Vyroxeres is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Vyroxeres. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgVyroxeresDist = "Vanilla"'>
+                    <StandardGen name='mtlgVyroxeresStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 7 * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 4 * mtlgVyroxeresFreq ' range=':=  _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Vyroxeres is complete. -->
+
+            <!-- End Vyroxeres Generation -->
+
+
+            <!-- Begin Ceruclase Generation -->
+
+            <!-- Starting LayeredVeins Preset for Ceruclase. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgCeruclaseDist = "LayeredVeins"'>
+                    <Veins name='mtlgCeruclaseVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * mtlgCeruclaseFreq ' range=':=  _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Ceruclase is complete. -->
+
+
+            <!-- Starting Cloud Preset for Ceruclase. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgCeruclaseDist = "Cloud"'>
+                    <Cloud name='mtlgCeruclaseCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgCeruclaseFreq ' range=':=  _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgCeruclaseHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Ceruclase is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Ceruclase. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgCeruclaseDist = "Vanilla"'>
+                    <StandardGen name='mtlgCeruclaseStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 4 * mtlgCeruclaseFreq ' range=':=  _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Ceruclase is complete. -->
+
+            <!-- End Ceruclase Generation -->
+
+
+            <!-- Begin Alduorite Generation -->
+
+            <!-- Starting LayeredVeins Preset for Alduorite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgAlduoriteDist = "LayeredVeins"'>
+                    <Veins name='mtlgAlduoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgAlduoriteFreq ' range=':=  _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Alduorite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Alduorite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgAlduoriteDist = "Cloud"'>
+                    <Cloud name='mtlgAlduoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgAlduoriteFreq ' range=':=  _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgAlduoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Alduorite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Alduorite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgAlduoriteDist = "Vanilla"'>
+                    <StandardGen name='mtlgAlduoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * mtlgAlduoriteFreq ' range=':=  _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Alduorite is complete. -->
+
+            <!-- End Alduorite Generation -->
+
+
+            <!-- Begin Kalendrite Generation -->
+
+            <!-- Starting LayeredVeins Preset for Kalendrite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgKalendriteDist = "LayeredVeins"'>
+                    <Veins name='mtlgKalendriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgKalendriteFreq ' range=':=  _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Kalendrite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Kalendrite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgKalendriteDist = "Cloud"'>
+                    <Cloud name='mtlgKalendriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgKalendriteFreq ' range=':=  _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgKalendriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Kalendrite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Kalendrite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgKalendriteDist = "Vanilla"'>
+                    <StandardGen name='mtlgKalendriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * mtlgKalendriteFreq ' range=':=  _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Kalendrite is complete. -->
+
+            <!-- End Kalendrite Generation -->
+
+
+            <!-- Begin Vulcanite Generation -->
+
+            <!-- Starting LayeredVeins Preset for Vulcanite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgVulcaniteDist = "LayeredVeins"'>
+                    <Veins name='mtlgVulcaniteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgVulcaniteFreq ' range=':=  _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Vulcanite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Vulcanite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgVulcaniteDist = "Cloud"'>
+                    <Cloud name='mtlgVulcaniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgVulcaniteFreq ' range=':=  _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgVulcaniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Vulcanite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Vulcanite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgVulcaniteDist = "Vanilla"'>
+                    <StandardGen name='mtlgVulcaniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * mtlgVulcaniteFreq ' range=':=  _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Vulcanite is complete. -->
+
+            <!-- End Vulcanite Generation -->
+
+
+            <!-- Begin Sanguinite Generation -->
+
+            <!-- Starting LayeredVeins Preset for Sanguinite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgSanguiniteDist = "LayeredVeins"'>
+                    <Veins name='mtlgSanguiniteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgSanguiniteFreq ' range=':=  _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Sanguinite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Sanguinite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgSanguiniteDist = "Cloud"'>
+                    <Cloud name='mtlgSanguiniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgSanguiniteFreq ' range=':=  _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgSanguiniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Sanguinite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Sanguinite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgSanguiniteDist = "Vanilla"'>
+                    <StandardGen name='mtlgSanguiniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * mtlgSanguiniteFreq ' range=':=  _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Sanguinite is complete. -->
+
+            <!-- End Sanguinite Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Nether Setup Complete -->
+
+
+
+
+
+        <!-- End Setup Beginning -->
+
+        <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
+
+            <!-- Starting Original "End" Block Removal -->
+
+            <Substitute name='mtlgEndBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='Metallurgy:ender.ore' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "End" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Eximite Generation -->
+
+            <!-- Starting LayeredVeins Preset for Eximite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgEximiteDist = "LayeredVeins"'>
+                    <Veins name='mtlgEximiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * mtlgEximiteFreq ' range=':=  _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Eximite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Eximite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgEximiteDist = "Cloud"'>
+                    <Cloud name='mtlgEximiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.076 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.076 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * mtlgEximiteFreq ' range=':=  _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgEximiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Eximite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Eximite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgEximiteDist = "Vanilla"'>
+                    <StandardGen name='mtlgEximiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 6 * mtlgEximiteFreq ' range=':=  _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Eximite is complete. -->
+
+            <!-- End Eximite Generation -->
+
+
+            <!-- Begin Meutoite Generation -->
+
+            <!-- Starting LayeredVeins Preset for Meutoite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgMeutoiteDist = "LayeredVeins"'>
+                    <Veins name='mtlgMeutoiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgMeutoiteFreq ' range=':=  _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Meutoite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Meutoite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgMeutoiteDist = "Cloud"'>
+                    <Cloud name='mtlgMeutoiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgMeutoiteFreq ' range=':=  _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mtlgMeutoiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Meutoite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Meutoite. -->
+            <ConfigSection>
+                <IfCondition condition=':= mtlgMeutoiteDist = "Vanilla"'>
+                    <StandardGen name='mtlgMeutoiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 6 * mtlgMeutoiteFreq ' range=':=  _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Meutoite is complete. -->
+
+            <!-- End Meutoite Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- End Setup Complete -->
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Metallurgy 4" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -27,10 +27,15 @@
                     Distribution options for MineChem Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableMineChem' displayName='Handle MineChem Setup?' default='true' displayState='shown_dynamic' displayGroup='groupMineChem'>
+                <Description> Should Custom Ore Generation handle MineChem ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle MineChem ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='MineChem ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Uranium Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mchmUraniumDist'  displayState='shown' displayGroup='groupMineChem'>
+                <OptionChoice name='mchmUraniumDist'  displayState=':= if(?enableMineChem, "shown", "hidden")' displayGroup='groupMineChem'>
                     <Description> Controls how Uranium is generated </Description>
                     <DisplayName>MineChem Uranium</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -50,11 +55,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Uranium is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mchmUraniumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMineChem'>
+                <OptionNumeric name='mchmUraniumFreq' default='1'  min='0' max='5' displayState=':= if(?enableMineChem, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMineChem'>
                     <Description> Frequency multiplier for MineChem Uranium distributions </Description>
                     <DisplayName>MineChem Uranium Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mchmUraniumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMineChem'>
+                <OptionNumeric name='mchmUraniumSize' default='1'  min='0' max='5' displayState=':= if(?enableMineChem, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMineChem'>
                     <Description> Size multiplier for MineChem Uranium distributions </Description>
                     <DisplayName>MineChem Uranium Size</DisplayName>
                 </OptionNumeric>
@@ -64,154 +69,161 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableMineChem'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='mchmOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='minechem:tile.oreUranium' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Uranium Generation -->
-
-            <!-- Starting LayeredVeins Preset for Uranium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mchmUraniumDist = "LayeredVeins"'>
-                    <Veins name='mchmUraniumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='mchmOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * mchmUraniumFreq ' range=':=  _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 17.5 ' range=':=  12.5 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <Replaces block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Uranium is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Uranium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mchmUraniumDist = "Cloud"'>
-                    <Cloud name='mchmUraniumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.818 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.818 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * mchmUraniumFreq ' range=':=  _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 17.5 ' range=':=  12.5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mchmUraniumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Uranium Generation -->
+
+                <!-- Starting LayeredVeins Preset for Uranium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mchmUraniumDist = "LayeredVeins"'>
+                        <Veins name='mchmUraniumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * mchmUraniumFreq ' range=':=  _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 17.5 ' range=':=  12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Uranium is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Uranium is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Uranium. -->
-            <ConfigSection>
-                <IfCondition condition=':= mchmUraniumDist = "Vanilla"'>
-                    <StandardGen name='mchmUraniumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * mchmUraniumFreq ' range=':=  _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 17.5 ' range=':=  12.5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Uranium is complete. -->
+                <!-- Starting Cloud Preset for Uranium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mchmUraniumDist = "Cloud"'>
+                        <Cloud name='mchmUraniumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.818 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.818 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * mchmUraniumFreq ' range=':=  _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 17.5 ' range=':=  12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mchmUraniumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Uranium is complete. -->
 
-            <!-- End Uranium Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Uranium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mchmUraniumDist = "Vanilla"'>
+                        <StandardGen name='mchmUraniumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mchmUraniumFreq ' range=':=  _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 17.5 ' range=':=  12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Uranium is complete. -->
+
+                <!-- End Uranium Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -1,250 +1,232 @@
- <!-- ================================================================
-      Custom Ore Generation "MineChem" Module: This configuration
-      covers uranium.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "MineChem" Module: This configuration
+     covers uranium.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="minechem">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+<!-- Minechem includes uranium ore in the case it's installed without
+     IC2 or Atomic Science also installed. -->
+
+
+
+
+<!-- Is the "MineChem" mod on the system?  Let's find out! -->
+<IfModInstalled name="minechem">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupMineChem' displayName='MineChem' displayState='shown'>
+                <Description>
+                    Distribution options for MineChem Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Uranium Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupMineChem' displayName='MineChem' displayState='shown'> 
-                    <Description>
-                        Distribution options for MineChem Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Uranium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mchmUraniumDist'  displayState='shown' displayGroup='groupMineChem'> 
-                        <Description> Controls how Uranium is generated </Description> 
-                        <DisplayName>MineChem Uranium</DisplayName>
-                        <Choice value='pipeVeins' displayValue='Pipe Veins'>
-                            <Description>
-                                Pipe Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Uranium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mchmUraniumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMineChem'>
-                        <Description> Frequency multiplier for MineChem Uranium distributions </Description>
-                        <DisplayName>MineChem Uranium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mchmUraniumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMineChem'>
-                        <Description> Size multiplier for MineChem Uranium distributions </Description>
-                        <DisplayName>MineChem Uranium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Uranium Configuration UI Complete -->
-                
+                <OptionChoice name='mchmUraniumDist'  displayState='shown' displayGroup='groupMineChem'>
+                    <Description> Controls how Uranium is generated </Description>
+                    <DisplayName>MineChem Uranium</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Uranium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mchmUraniumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMineChem'>
+                    <Description> Frequency multiplier for MineChem Uranium distributions </Description>
+                    <DisplayName>MineChem Uranium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mchmUraniumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMineChem'>
+                    <Description> Size multiplier for MineChem Uranium distributions </Description>
+                    <DisplayName>MineChem Uranium Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Uranium Configuration UI Complete -->
 
-
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='mchmOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='minechem:tile.oreUranium' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Uranium Generation --> 
-                
-                <!-- Begin PipeVeins distribution of Uranium -->
-                <IfCondition condition=':= mchmUraniumDist = "pipeVeins"'>
-                
-                    <Veins name='mchmUraniumBaseVeins' block='minechem:tile.oreUranium'  inherits='PresetPipeVeins' seed='0x38D0'>
-                        <Description>
-                            Short sparsely filled veins sloping up
-                            from near the bottom of the map.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ACFE91</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mchmUraniumSize * _default_' range=':= 1 * 1 * mchmUraniumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mchmUraniumSize * _default_' range=':= 1 * 1 * mchmUraniumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * mchmUraniumFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Pipe Filling (Uranium Pipe Veins) Settings -->
-                    <Veins name='mchmUraniumPipeVeins' block='minecraft:lava'  inherits='mchmUraniumBaseVeins' seed='0x38D0'>
-                        <Description>
-                            Fills the vein with an additional material
-                            (minecraft:lava).
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ACFE91</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 1 * mchmUraniumSize * _default_' range=':= 0.5 * 1 * 1 * mchmUraniumSize * _default_'/>
-                        <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 1 * mchmUraniumSize * _default_' range=':= 0.5 * 1 * 1 * mchmUraniumSize * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minechem:tile.oreUranium'/>
-                        <Replaces block='minecraft:dirt'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:gravel'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </Veins>
-                    <!-- End Pipe Filling (Uranium Pipe Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End PipeVeins distribution of Uranium -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Uranium -->
-                <IfCondition condition=':= mchmUraniumDist = "hugeVeins"'>
-                
-                    <Veins name='mchmUraniumBaseVeins' block='minechem:tile.oreUranium'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ACFE91</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * mchmUraniumSize * _default_' range=':= 1 * 1 * mchmUraniumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * mchmUraniumSize * _default_' range=':= 1 * 1 * mchmUraniumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * mchmUraniumFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Uranium -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Uranium -->
-                <IfCondition condition=':= mchmUraniumDist = "strategicCloud"'>
-                
-                    <Cloud name='mchmUraniumBaseCloud' block='minechem:tile.oreUranium' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ACFE91</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * mchmUraniumSize * _default_' range=':= 1 * 1 * mchmUraniumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * mchmUraniumSize * _default_' range=':= 1 * 1 * mchmUraniumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * mchmUraniumSize * _default_' range=':= 1 * 1 * 1 * mchmUraniumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * mchmUraniumFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Uranium Strategic Cloud Hint Veins -->
-                        <Veins name='mchmUraniumBaseHintVeins' block='minechem:tile.oreUranium' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60ACFE91</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Uranium Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Uranium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Uranium -->
-                <IfCondition condition=':= mchmUraniumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mchmUraniumBaseStandard' block='minechem:tile.oreUranium' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ACFE91</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mchmUraniumSize * _default_'/>
-                        <Setting name='Height' avg=':= 8' range=':= _default_' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.025 * mchmUraniumFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Uranium -->
-                
-                <!-- End Uranium Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='mchmOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='minechem:tile.oreUranium' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Uranium Generation -->
+
+            <!-- Starting LayeredVeins Preset for Uranium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mchmUraniumDist = "LayeredVeins"'>
+                    <Veins name='mchmUraniumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * mchmUraniumFreq ' range=':=  _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 17.5 ' range=':=  12.5 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Uranium is complete. -->
+
+
+            <!-- Starting Cloud Preset for Uranium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mchmUraniumDist = "Cloud"'>
+                    <Cloud name='mchmUraniumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.818 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.818 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * mchmUraniumFreq ' range=':=  _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 17.5 ' range=':=  12.5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mchmUraniumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Uranium is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Uranium. -->
+            <ConfigSection>
+                <IfCondition condition=':= mchmUraniumDist = "Vanilla"'>
+                    <StandardGen name='mchmUraniumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * mchmUraniumFreq ' range=':=  _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 17.5 ' range=':=  12.5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Uranium is complete. -->
+
+            <!-- End Uranium Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "MineChem" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -29,10 +29,15 @@
                     Distribution options for Minecraft Comes Alive Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableMinecraftComesAlive' displayName='Handle Minecraft Comes Alive Setup?' default='true' displayState='shown_dynamic' displayGroup='groupMinecraftComesAlive'>
+                <Description> Should Custom Ore Generation handle Minecraft Comes Alive ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Minecraft Comes Alive ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Minecraft Comes Alive ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Rose Gold Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='mccaRoseGoldDist'  displayState='shown' displayGroup='groupMinecraftComesAlive'>
+                <OptionChoice name='mccaRoseGoldDist'  displayState=':= if(?enableMinecraftComesAlive, "shown", "hidden")' displayGroup='groupMinecraftComesAlive'>
                     <Description> Controls how Rose Gold is generated </Description>
                     <DisplayName>Minecraft Comes Alive Rose Gold</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -52,11 +57,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Rose Gold is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='mccaRoseGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMinecraftComesAlive'>
+                <OptionNumeric name='mccaRoseGoldFreq' default='1'  min='0' max='5' displayState=':= if(?enableMinecraftComesAlive, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMinecraftComesAlive'>
                     <Description> Frequency multiplier for Minecraft Comes Alive Rose Gold distributions </Description>
                     <DisplayName>Minecraft Comes Alive Rose Gold Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='mccaRoseGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMinecraftComesAlive'>
+                <OptionNumeric name='mccaRoseGoldSize' default='1'  min='0' max='5' displayState=':= if(?enableMinecraftComesAlive, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupMinecraftComesAlive'>
                     <Description> Size multiplier for Minecraft Comes Alive Rose Gold distributions </Description>
                     <DisplayName>Minecraft Comes Alive Rose Gold Size</DisplayName>
                 </OptionNumeric>
@@ -66,154 +71,161 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableMinecraftComesAlive'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='mccaOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='MCA:tile.roseGoldOre' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Rose Gold Generation -->
-
-            <!-- Starting LayeredVeins Preset for Rose Gold. -->
-            <ConfigSection>
-                <IfCondition condition=':= mccaRoseGoldDist = "LayeredVeins"'>
-                    <Veins name='mccaRoseGoldVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='mccaOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mccaRoseGoldFreq ' range=':=  _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 26 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <Replaces block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Rose Gold is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Rose Gold. -->
-            <ConfigSection>
-                <IfCondition condition=':= mccaRoseGoldDist = "Cloud"'>
-                    <Cloud name='mccaRoseGoldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mccaRoseGoldFreq ' range=':=  _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 26 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='mccaRoseGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Rose Gold Generation -->
+
+                <!-- Starting LayeredVeins Preset for Rose Gold. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mccaRoseGoldDist = "LayeredVeins"'>
+                        <Veins name='mccaRoseGoldVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mccaRoseGoldFreq ' range=':=  _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 26 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Rose Gold is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Rose Gold is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Rose Gold. -->
-            <ConfigSection>
-                <IfCondition condition=':= mccaRoseGoldDist = "Vanilla"'>
-                    <StandardGen name='mccaRoseGoldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 5 * mccaRoseGoldFreq ' range=':=  _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 26 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Rose Gold is complete. -->
+                <!-- Starting Cloud Preset for Rose Gold. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mccaRoseGoldDist = "Cloud"'>
+                        <Cloud name='mccaRoseGoldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mccaRoseGoldFreq ' range=':=  _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 26 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='mccaRoseGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Rose Gold is complete. -->
 
-            <!-- End Rose Gold Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Rose Gold. -->
+                <ConfigSection>
+                    <IfCondition condition=':= mccaRoseGoldDist = "Vanilla"'>
+                        <StandardGen name='mccaRoseGoldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * mccaRoseGoldFreq ' range=':=  _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 26 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Rose Gold is complete. -->
+
+                <!-- End Rose Gold Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -1,246 +1,234 @@
- <!-- ================================================================
-      Custom Ore Generation "Minecraft Comes Alive" Module: This
-      configuration covers rose gold.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Minecraft Comes Alive" Module: This
+     configuration covers rose gold.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="MCA">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+<!-- Minecraft Comes Alive is a mod focusing around villager
+     interactions.  However, it does introduce a new ore for "Rose
+     Gold." -->
+
+
+
+
+<!-- Is the "Minecraft Comes Alive" mod on the system?  Let's find
+     out! -->
+<IfModInstalled name="MCA">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupMinecraftComesAlive' displayName='Minecraft Comes Alive' displayState='shown'>
+                <Description>
+                    Distribution options for Minecraft Comes Alive Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Rose Gold Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupMinecraftComesAlive' displayName='Minecraft Comes Alive' displayState='shown'> 
-                    <Description>
-                        Distribution options for Minecraft Comes Alive Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Rose Gold Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='mccaRoseGoldDist'  displayState='shown' displayGroup='groupMinecraftComesAlive'> 
-                        <Description> Controls how Rose Gold is generated </Description> 
-                        <DisplayName>Minecraft Comes Alive Rose Gold</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Rose Gold is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='mccaRoseGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMinecraftComesAlive'>
-                        <Description> Frequency multiplier for Minecraft Comes Alive Rose Gold distributions </Description>
-                        <DisplayName>Minecraft Comes Alive Rose Gold Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='mccaRoseGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMinecraftComesAlive'>
-                        <Description> Size multiplier for Minecraft Comes Alive Rose Gold distributions </Description>
-                        <DisplayName>Minecraft Comes Alive Rose Gold Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Rose Gold Configuration UI Complete -->
-                
-            </ConfigSection>
-            <!-- Setup Screen Complete -->
-
-
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='mccaOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='MCA:tile.roseGoldOre' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Rose Gold Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Rose Gold -->
-                <IfCondition condition=':= mccaRoseGoldDist = "layeredVeins"'>
-                
-                    <Veins name='mccaRoseGoldBaseVeins' block='MCA:tile.roseGoldOre'  inherits='PresetLayeredVeins' >
+                <OptionChoice name='mccaRoseGoldDist'  displayState='shown' displayGroup='groupMinecraftComesAlive'>
+                    <Description> Controls how Rose Gold is generated </Description>
+                    <DisplayName>Minecraft Comes Alive Rose Gold</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Rose Gold is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='mccaRoseGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMinecraftComesAlive'>
+                    <Description> Frequency multiplier for Minecraft Comes Alive Rose Gold distributions </Description>
+                    <DisplayName>Minecraft Comes Alive Rose Gold Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='mccaRoseGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupMinecraftComesAlive'>
+                    <Description> Size multiplier for Minecraft Comes Alive Rose Gold distributions </Description>
+                    <DisplayName>Minecraft Comes Alive Rose Gold Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Rose Gold Configuration UI Complete -->
+
+        </ConfigSection>
+        <!-- Setup Screen Complete -->
+
+
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='mccaOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='MCA:tile.roseGoldOre' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Rose Gold Generation -->
+
+            <!-- Starting LayeredVeins Preset for Rose Gold. -->
+            <ConfigSection>
+                <IfCondition condition=':= mccaRoseGoldDist = "LayeredVeins"'>
+                    <Veins name='mccaRoseGoldVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
                             horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFDDA2</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mccaRoseGoldSize * _default_' range=':= 1 * 0.8 * mccaRoseGoldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mccaRoseGoldSize * _default_' range=':= 1 * 0.8 * mccaRoseGoldSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mccaRoseGoldFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
+                        <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mccaRoseGoldFreq ' range=':=  _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 26 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Rose Gold Layered Veins) Settings -->
-                    <Veins name='mccaRoseGoldPrefersVeins' block='MCA:tile.roseGoldOre'  inherits='mccaRoseGoldBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFDDA2</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Rose Gold Layered Veins) Settings -->
-                
                 </IfCondition>
-                <!-- End LayeredVeins distribution of Rose Gold -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Rose Gold -->
-                <IfCondition condition=':= mccaRoseGoldDist = "smallDeposits"'>
-                
-                    <Veins name='mccaRoseGoldBaseVeins' block='MCA:tile.roseGoldOre'  inherits='PresetSmallDeposits' >
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Rose Gold is complete. -->
+
+
+            <!-- Starting Cloud Preset for Rose Gold. -->
+            <ConfigSection>
+                <IfCondition condition=':= mccaRoseGoldDist = "Cloud"'>
+                    <Cloud name='mccaRoseGoldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFDDA2</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * mccaRoseGoldSize * _default_' range=':= 1 * 0.8 * mccaRoseGoldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * mccaRoseGoldSize * _default_' range=':= 1 * 0.8 * mccaRoseGoldSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * mccaRoseGoldFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Rose Gold Deposit Veins) Settings -->
-                    <Veins name='mccaRoseGoldPrefersVeins' block='MCA:tile.roseGoldOre'  inherits='mccaRoseGoldBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFDDA2</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Rose Gold Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Rose Gold -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Rose Gold -->
-                <IfCondition condition=':= mccaRoseGoldDist = "strategicCloud"'>
-                
-                    <Cloud name='mccaRoseGoldBaseCloud' block='MCA:tile.roseGoldOre' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFDDA2</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * mccaRoseGoldSize * _default_' range=':= 1 * 0.8 * mccaRoseGoldSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * mccaRoseGoldSize * _default_' range=':= 1 * 0.8 * mccaRoseGoldSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * mccaRoseGoldSize * _default_' range=':= 1 * 0.8 * 0.8 * mccaRoseGoldSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * mccaRoseGoldFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Rose Gold Strategic Cloud Hint Veins -->
-                        <Veins name='mccaRoseGoldBaseHintVeins' block='MCA:tile.roseGoldOre' inherits='PresetHintVeins'>
+                        <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mccaRoseGoldFreq ' range=':=  _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 26 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='mccaRoseGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FFDDA2</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
+                            <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
                         </Veins>
-                        <!-- End Rose Gold Strategic Cloud Hint Veins -->
-
                     </Cloud>
-                    
-                
                 </IfCondition>
-                <!-- End  StrategicCloud distribution of Rose Gold -->
-                
-                
-                <!-- Begin  Vanilla distribution of Rose Gold -->
-                <IfCondition condition=':= mccaRoseGoldDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='mccaRoseGoldBaseStandard' block='MCA:tile.roseGoldOre' inherits='PresetStandardGen'>
+            </ConfigSection>
+            <!-- Cloud Preset for Rose Gold is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Rose Gold. -->
+            <ConfigSection>
+                <IfCondition condition=':= mccaRoseGoldDist = "Vanilla"'>
+                    <StandardGen name='mccaRoseGoldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
                         <Description>
-                            This mimics vanilla ore generation.
+                            A master preset for standardgen ore
+                            distributions.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFDDA2</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * mccaRoseGoldSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * mccaRoseGoldFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
+                        <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 5 * mccaRoseGoldFreq ' range=':=  _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 26 ' range=':=  14 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
-                    
-                
                 </IfCondition>
-                <!-- End  Vanilla distribution of Rose Gold -->
-                
-                <!-- End Rose Gold Generation --> 
+            </ConfigSection>
+            <!-- Vanilla Preset for Rose Gold is complete. -->
 
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
+            <!-- End Rose Gold Generation -->
 
-        
-        </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Minecraft Comes Alive" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -25,10 +25,15 @@
                     Distribution options for Pams HarvestCraft Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enablePamsHarvestCraft' displayName='Handle Pams HarvestCraft Setup?' default='true' displayState='shown_dynamic' displayGroup='groupPamsHarvestCraft'>
+                <Description> Should Custom Ore Generation handle Pams HarvestCraft ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Pams HarvestCraft ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Pams HarvestCraft ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Salt Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='hvstSaltDist'  displayState='shown' displayGroup='groupPamsHarvestCraft'>
+                <OptionChoice name='hvstSaltDist'  displayState=':= if(?enablePamsHarvestCraft, "shown", "hidden")' displayGroup='groupPamsHarvestCraft'>
                     <Description> Controls how Salt is generated </Description>
                     <DisplayName>Pams HarvestCraft Salt</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -48,11 +53,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Salt is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='hvstSaltFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupPamsHarvestCraft'>
+                <OptionNumeric name='hvstSaltFreq' default='1'  min='0' max='5' displayState=':= if(?enablePamsHarvestCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupPamsHarvestCraft'>
                     <Description> Frequency multiplier for Pams HarvestCraft Salt distributions </Description>
                     <DisplayName>Pams HarvestCraft Salt Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='hvstSaltSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupPamsHarvestCraft'>
+                <OptionNumeric name='hvstSaltSize' default='1'  min='0' max='5' displayState=':= if(?enablePamsHarvestCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupPamsHarvestCraft'>
                     <Description> Size multiplier for Pams HarvestCraft Salt distributions </Description>
                     <DisplayName>Pams HarvestCraft Salt Size</DisplayName>
                 </OptionNumeric>
@@ -62,160 +67,168 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enablePamsHarvestCraft'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='hvstOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='harvestcraft:salt' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Salt Generation -->
-
-            <!-- Starting SparseVeins Preset for Salt. -->
-            <ConfigSection>
-                <IfCondition condition=':= hvstSaltDist = "SparseVeins"'>
-                    <Veins name='hvstSaltVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='hvstOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='harvestcraft:salt' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 4.287 * _default_ * hvstSaltFreq ' range=':=  _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.625 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.625 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.625 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <Replaces block='harvestcraft:salt' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Salt is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Salt. -->
-            <ConfigSection>
-                <IfCondition condition=':= hvstSaltDist = "Cloud"'>
-                    <Cloud name='hvstSaltCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='harvestcraft:salt' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.702 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.702 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.896  * _default_ * hvstSaltFreq ' range=':=  _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='hvstSaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Salt Generation -->
+
+                <!-- Starting SparseVeins Preset for Salt. -->
+                <ConfigSection>
+                    <IfCondition condition=':= hvstSaltDist = "SparseVeins"'>
+                        <Veins name='hvstSaltVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='harvestcraft:salt' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 4.287 * _default_ * hvstSaltFreq ' range=':=  _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.625 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.625 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.625 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Salt is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Salt is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Salt. -->
-            <ConfigSection>
-                <IfCondition condition=':= hvstSaltDist = "Vanilla"'>
-                    <StandardGen name='hvstSaltStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='harvestcraft:salt' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 5 * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 30 * hvstSaltFreq ' range=':=  _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Salt is complete. -->
+                <!-- Starting Cloud Preset for Salt. -->
+                <ConfigSection>
+                    <IfCondition condition=':= hvstSaltDist = "Cloud"'>
+                        <Cloud name='hvstSaltCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.702 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.702 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.896  * _default_ * hvstSaltFreq ' range=':=  _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='hvstSaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Salt is complete. -->
 
-            <!-- End Salt Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Salt. -->
+                <ConfigSection>
+                    <IfCondition condition=':= hvstSaltDist = "Vanilla"'>
+                        <StandardGen name='hvstSaltStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 30 * hvstSaltFreq ' range=':=  _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Salt is complete. -->
+
+                <!-- End Salt Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -1,254 +1,236 @@
- <!-- ================================================================
-      Custom Ore Generation "Pams HarvestCraft" Module: This
-      configuration covers salt.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Pams HarvestCraft" Module: This
+     configuration covers salt.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="harvestcraft">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "Pams HarvestCraft" mod on the system?  Let's find out! -->
+<IfModInstalled name="harvestcraft">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupPamsHarvestCraft' displayName='Pams HarvestCraft' displayState='shown'>
+                <Description>
+                    Distribution options for Pams HarvestCraft Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Salt Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupPamsHarvestCraft' displayName='Pams HarvestCraft' displayState='shown'> 
-                    <Description>
-                        Distribution options for Pams HarvestCraft Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Salt Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='hvstSaltDist'  displayState='shown' displayGroup='groupPamsHarvestCraft'> 
-                        <Description> Controls how Salt is generated </Description> 
-                        <DisplayName>Pams HarvestCraft Salt</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Salt is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='hvstSaltFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupPamsHarvestCraft'>
-                        <Description> Frequency multiplier for Pams HarvestCraft Salt distributions </Description>
-                        <DisplayName>Pams HarvestCraft Salt Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='hvstSaltSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupPamsHarvestCraft'>
-                        <Description> Size multiplier for Pams HarvestCraft Salt distributions </Description>
-                        <DisplayName>Pams HarvestCraft Salt Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Salt Configuration UI Complete -->
-                
-            </ConfigSection>
-            <!-- Setup Screen Complete -->
-
-
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='hvstOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='harvestcraft:salt' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Salt Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Salt -->
-                <IfCondition condition=':= hvstSaltDist = "sparseVeins"'>
-                
-                    <Veins name='hvstSaltBaseVeins' block='harvestcraft:salt'  inherits='PresetSparseVeins' >
+                <OptionChoice name='hvstSaltDist'  displayState='shown' displayGroup='groupPamsHarvestCraft'>
+                    <Description> Controls how Salt is generated </Description>
+                    <DisplayName>Pams HarvestCraft Salt</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6090927C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * hvstSaltSize * _default_' range=':= 1 * 1 * hvstSaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * hvstSaltSize * _default_' range=':= 1 * 1 * hvstSaltSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * hvstSaltFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 1.2 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchInclination' avg=':= -_default_' range=':= 0'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Salt Sparse Veins) Settings -->
-                    <Veins name='hvstSaltPrefersVeins' block='harvestcraft:salt'  inherits='hvstSaltBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6090927C</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Ocean'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Salt Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Salt -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Salt -->
-                <IfCondition condition=':= hvstSaltDist = "smallDeposits"'>
-                
-                    <Veins name='hvstSaltBaseVeins' block='harvestcraft:salt'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6090927C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * hvstSaltSize * _default_' range=':= 1 * 1 * hvstSaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 60' range=':= 4' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * hvstSaltSize * _default_' range=':= 1 * 1 * hvstSaltSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * hvstSaltFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 1.2 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchInclination' avg=':= -_default_' range=':= 0'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Salt Deposit Veins) Settings -->
-                    <Veins name='hvstSaltPrefersVeins' block='harvestcraft:salt'  inherits='hvstSaltBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6090927C</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Ocean'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Salt Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Salt -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Salt -->
-                <IfCondition condition=':= hvstSaltDist = "strategicCloud"'>
-                
-                    <Cloud name='hvstSaltBaseCloud' block='harvestcraft:salt' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6090927C</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.7 * hvstSaltSize * _default_' range=':= 1 * 0.7 * hvstSaltSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.7 * hvstSaltSize * _default_' range=':= 1 * 0.7 * hvstSaltSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.8 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.7 * 0.7 * hvstSaltSize * _default_' range=':= 1 * 0.7 * 0.7 * hvstSaltSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4 * hvstSaltFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Salt Strategic Cloud Hint Veins -->
-                        <Veins name='hvstSaltBaseHintVeins' block='harvestcraft:salt' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6090927C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Salt Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Salt is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='hvstSaltFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupPamsHarvestCraft'>
+                    <Description> Frequency multiplier for Pams HarvestCraft Salt distributions </Description>
+                    <DisplayName>Pams HarvestCraft Salt Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='hvstSaltSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupPamsHarvestCraft'>
+                    <Description> Size multiplier for Pams HarvestCraft Salt distributions </Description>
+                    <DisplayName>Pams HarvestCraft Salt Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Salt Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Salt -->
-                
-                
-                <!-- Begin  Vanilla distribution of Salt -->
-                <IfCondition condition=':= hvstSaltDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='hvstSaltBaseStandard' block='harvestcraft:salt' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6090927C</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * hvstSaltSize * _default_'/>
-                        <Setting name='Height' avg=':= 54' range=':= 38' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.3 * hvstSaltFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Salt -->
-                
-                <!-- End Salt Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='hvstOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='harvestcraft:salt' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Salt Generation -->
+
+            <!-- Starting SparseVeins Preset for Salt. -->
+            <ConfigSection>
+                <IfCondition condition=':= hvstSaltDist = "SparseVeins"'>
+                    <Veins name='hvstSaltVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='harvestcraft:salt' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 4.287 * _default_ * hvstSaltFreq ' range=':=  _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.625 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.625 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.625 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Salt is complete. -->
+
+
+            <!-- Starting Cloud Preset for Salt. -->
+            <ConfigSection>
+                <IfCondition condition=':= hvstSaltDist = "Cloud"'>
+                    <Cloud name='hvstSaltCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='harvestcraft:salt' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.702 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.702 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.896  * _default_ * hvstSaltFreq ' range=':=  _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='hvstSaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='harvestcraft:salt' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Salt is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Salt. -->
+            <ConfigSection>
+                <IfCondition condition=':= hvstSaltDist = "Vanilla"'>
+                    <StandardGen name='hvstSaltStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='harvestcraft:salt' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 5 * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 30 * hvstSaltFreq ' range=':=  _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Salt is complete. -->
+
+            <!-- End Salt Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Pams HarvestCraft" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -26,10 +26,15 @@
                     Distribution options for Project Red Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableProjectRed' displayName='Handle Project Red Setup?' default='true' displayState='shown_dynamic' displayGroup='groupProjectRed'>
+                <Description> Should Custom Ore Generation handle Project Red ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Project Red ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Project Red ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Ruby Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='predRubyDist'  displayState='shown' displayGroup='groupProjectRed'>
+                <OptionChoice name='predRubyDist'  displayState=':= if(?enableProjectRed, "shown", "hidden")' displayGroup='groupProjectRed'>
                     <Description> Controls how Ruby is generated </Description>
                     <DisplayName>Project Red Ruby</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -49,11 +54,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Ruby is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='predRubyFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predRubyFreq' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Frequency multiplier for Project Red Ruby distributions </Description>
                     <DisplayName>Project Red Ruby Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='predRubySize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predRubySize' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Size multiplier for Project Red Ruby distributions </Description>
                     <DisplayName>Project Red Ruby Size</DisplayName>
                 </OptionNumeric>
@@ -63,7 +68,7 @@
 
             <!-- Sapphire Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='predSapphireDist'  displayState='shown' displayGroup='groupProjectRed'>
+                <OptionChoice name='predSapphireDist'  displayState=':= if(?enableProjectRed, "shown", "hidden")' displayGroup='groupProjectRed'>
                     <Description> Controls how Sapphire is generated </Description>
                     <DisplayName>Project Red Sapphire</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -83,11 +88,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Sapphire is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='predSapphireFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predSapphireFreq' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Frequency multiplier for Project Red Sapphire distributions </Description>
                     <DisplayName>Project Red Sapphire Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='predSapphireSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predSapphireSize' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Size multiplier for Project Red Sapphire distributions </Description>
                     <DisplayName>Project Red Sapphire Size</DisplayName>
                 </OptionNumeric>
@@ -97,7 +102,7 @@
 
             <!-- Peridot Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='predPeridotDist'  displayState='shown' displayGroup='groupProjectRed'>
+                <OptionChoice name='predPeridotDist'  displayState=':= if(?enableProjectRed, "shown", "hidden")' displayGroup='groupProjectRed'>
                     <Description> Controls how Peridot is generated </Description>
                     <DisplayName>Project Red Peridot</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -117,11 +122,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Peridot is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='predPeridotFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predPeridotFreq' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Frequency multiplier for Project Red Peridot distributions </Description>
                     <DisplayName>Project Red Peridot Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='predPeridotSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predPeridotSize' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Size multiplier for Project Red Peridot distributions </Description>
                     <DisplayName>Project Red Peridot Size</DisplayName>
                 </OptionNumeric>
@@ -131,7 +136,7 @@
 
             <!-- Copper Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='predCopperDist'  displayState='shown' displayGroup='groupProjectRed'>
+                <OptionChoice name='predCopperDist'  displayState=':= if(?enableProjectRed, "shown", "hidden")' displayGroup='groupProjectRed'>
                     <Description> Controls how Copper is generated </Description>
                     <DisplayName>Project Red Copper</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -151,11 +156,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='predCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predCopperFreq' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Frequency multiplier for Project Red Copper distributions </Description>
                     <DisplayName>Project Red Copper Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='predCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predCopperSize' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Size multiplier for Project Red Copper distributions </Description>
                     <DisplayName>Project Red Copper Size</DisplayName>
                 </OptionNumeric>
@@ -165,7 +170,7 @@
 
             <!-- Tin Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='predTinDist'  displayState='shown' displayGroup='groupProjectRed'>
+                <OptionChoice name='predTinDist'  displayState=':= if(?enableProjectRed, "shown", "hidden")' displayGroup='groupProjectRed'>
                     <Description> Controls how Tin is generated </Description>
                     <DisplayName>Project Red Tin</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -185,11 +190,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='predTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predTinFreq' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Frequency multiplier for Project Red Tin distributions </Description>
                     <DisplayName>Project Red Tin Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='predTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predTinSize' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Size multiplier for Project Red Tin distributions </Description>
                     <DisplayName>Project Red Tin Size</DisplayName>
                 </OptionNumeric>
@@ -199,7 +204,7 @@
 
             <!-- Silver Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='predSilverDist'  displayState='shown' displayGroup='groupProjectRed'>
+                <OptionChoice name='predSilverDist'  displayState=':= if(?enableProjectRed, "shown", "hidden")' displayGroup='groupProjectRed'>
                     <Description> Controls how Silver is generated </Description>
                     <DisplayName>Project Red Silver</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -219,11 +224,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='predSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predSilverFreq' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Frequency multiplier for Project Red Silver distributions </Description>
                     <DisplayName>Project Red Silver Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='predSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predSilverSize' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Size multiplier for Project Red Silver distributions </Description>
                     <DisplayName>Project Red Silver Size</DisplayName>
                 </OptionNumeric>
@@ -233,7 +238,7 @@
 
             <!-- Electrotine Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='predElectrotineDist'  displayState='shown' displayGroup='groupProjectRed'>
+                <OptionChoice name='predElectrotineDist'  displayState=':= if(?enableProjectRed, "shown", "hidden")' displayGroup='groupProjectRed'>
                     <Description> Controls how Electrotine is generated </Description>
                     <DisplayName>Project Red Electrotine</DisplayName>
                     <Choice value='VerticalVeins' displayValue='Vertical Veins'>
@@ -253,11 +258,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Electrotine is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='predElectrotineFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predElectrotineFreq' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Frequency multiplier for Project Red Electrotine distributions </Description>
                     <DisplayName>Project Red Electrotine Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='predElectrotineSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predElectrotineSize' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Size multiplier for Project Red Electrotine distributions </Description>
                     <DisplayName>Project Red Electrotine Size</DisplayName>
                 </OptionNumeric>
@@ -267,7 +272,7 @@
 
             <!-- Marble Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='predMarbleDist'  displayState='shown' displayGroup='groupProjectRed'>
+                <OptionChoice name='predMarbleDist'  displayState=':= if(?enableProjectRed, "shown", "hidden")' displayGroup='groupProjectRed'>
                     <Description> Controls how Marble is generated </Description>
                     <DisplayName>Project Red Marble</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -287,11 +292,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Marble is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='predMarbleFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predMarbleFreq' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Frequency multiplier for Project Red Marble distributions </Description>
                     <DisplayName>Project Red Marble Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='predMarbleSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                <OptionNumeric name='predMarbleSize' default='1'  min='0' max='5' displayState=':= if(?enableProjectRed, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupProjectRed'>
                     <Description> Size multiplier for Project Red Marble distributions </Description>
                     <DisplayName>Project Red Marble Size</DisplayName>
                 </OptionNumeric>
@@ -301,1010 +306,1031 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableProjectRed'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='predOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
-                <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
-                <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
-                <Replaces block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
-                <Replaces block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
-                <Replaces block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
-                <Replaces block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
-                <Replaces block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Ruby Generation -->
-
-            <!-- Starting PipeVeins Preset for Ruby. -->
-            <ConfigSection>
-                <IfCondition condition=':= predRubyDist = "PipeVeins"'>
-                    <Veins name='predRubyVeins'  inherits='PresetPipeVeins' seed='0xE23A' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='predOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predRubyFreq ' range=':=  _default_ * predRubyFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='predRubyVeinsPipe'  inherits='predRubyVeins' seed='0xE23A' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
-                        <OreBlock block='minecraft:lava' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predRubySize  * 0.5 ' range=':=  _default_ * predRubySize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predRubySize  * 0.5 ' range=':=  _default_ * predRubySize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <Replaces block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Ruby is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Ruby. -->
-            <ConfigSection>
-                <IfCondition condition=':= predRubyDist = "Cloud"'>
-                    <Cloud name='predRubyCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predRubyFreq ' range=':=  _default_ * predRubyFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='predRubyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Ruby Generation -->
+
+                <!-- Starting PipeVeins Preset for Ruby. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predRubyDist = "PipeVeins"'>
+                        <Veins name='predRubyVeins'  inherits='PresetPipeVeins' seed='0xE23A' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
                             </Description>
-                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predRubyFreq ' range=':=  _default_ * predRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Ruby is complete. -->
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='predRubyVeinsPipe'  inherits='predRubyVeins' seed='0xE23A' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predRubySize  * 0.5 ' range=':=  _default_ * predRubySize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predRubySize  * 0.5 ' range=':=  _default_ * predRubySize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Ruby is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Ruby. -->
-            <ConfigSection>
-                <IfCondition condition=':= predRubyDist = "Vanilla"'>
-                    <StandardGen name='predRubyStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * predRubyFreq ' range=':=  _default_ * predRubyFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Ruby is complete. -->
-
-            <!-- End Ruby Generation -->
-
-
-            <!-- Begin Sapphire Generation -->
-
-            <!-- Starting PipeVeins Preset for Sapphire. -->
-            <ConfigSection>
-                <IfCondition condition=':= predSapphireDist = "PipeVeins"'>
-                    <Veins name='predSapphireVeins'  inherits='PresetPipeVeins' seed='0x5196' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
-                        <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predSapphireFreq ' range=':=  _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='predSapphireVeinsPipe'  inherits='predSapphireVeins' seed='0x5196' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
-                        <OreBlock block='minecraft:lava' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predSapphireSize  * 0.5 ' range=':=  _default_ * predSapphireSize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predSapphireSize  * 0.5 ' range=':=  _default_ * predSapphireSize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Sapphire is complete. -->
-
-
-            <!-- Starting Cloud Preset for Sapphire. -->
-            <ConfigSection>
-                <IfCondition condition=':= predSapphireDist = "Cloud"'>
-                    <Cloud name='predSapphireCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predSapphireFreq ' range=':=  _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='predSapphireHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
+                <!-- Starting Cloud Preset for Ruby. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predRubyDist = "Cloud"'>
+                        <Cloud name='predRubyCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Sapphire is complete. -->
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predRubyFreq ' range=':=  _default_ * predRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='predRubyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Ruby is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Sapphire. -->
-            <ConfigSection>
-                <IfCondition condition=':= predSapphireDist = "Vanilla"'>
-                    <StandardGen name='predSapphireStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * predSapphireFreq ' range=':=  _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Sapphire is complete. -->
-
-            <!-- End Sapphire Generation -->
-
-
-            <!-- Begin Peridot Generation -->
-
-            <!-- Starting PipeVeins Preset for Peridot. -->
-            <ConfigSection>
-                <IfCondition condition=':= predPeridotDist = "PipeVeins"'>
-                    <Veins name='predPeridotVeins'  inherits='PresetPipeVeins' seed='0x8759' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
-                        <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predPeridotFreq ' range=':=  _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 22 ' range=':=  6 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='predPeridotVeinsPipe'  inherits='predPeridotVeins' seed='0x8759' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
-                        <OreBlock block='minecraft:lava' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predPeridotSize  * 0.5 ' range=':=  _default_ * predPeridotSize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predPeridotSize  * 0.5 ' range=':=  _default_ * predPeridotSize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Peridot is complete. -->
-
-
-            <!-- Starting Cloud Preset for Peridot. -->
-            <ConfigSection>
-                <IfCondition condition=':= predPeridotDist = "Cloud"'>
-                    <Cloud name='predPeridotCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predPeridotFreq ' range=':=  _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 22 ' range=':=  6 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='predPeridotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
+                <!-- Starting Vanilla Preset for Ruby. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predRubyDist = "Vanilla"'>
+                        <StandardGen name='predRubyStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Peridot is complete. -->
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * predRubyFreq ' range=':=  _default_ * predRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Ruby is complete. -->
+
+                <!-- End Ruby Generation -->
 
 
-            <!-- Starting Vanilla Preset for Peridot. -->
-            <ConfigSection>
-                <IfCondition condition=':= predPeridotDist = "Vanilla"'>
-                    <StandardGen name='predPeridotStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * predPeridotFreq ' range=':=  _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 22 ' range=':=  6 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Peridot is complete. -->
+                <!-- Begin Sapphire Generation -->
 
-            <!-- End Peridot Generation -->
-
-
-            <!-- Begin Copper Generation -->
-
-            <!-- Starting LayeredVeins Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= predCopperDist = "LayeredVeins"'>
-                    <Veins name='predCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * predCopperFreq ' range=':=  _default_ * predCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Copper is complete. -->
-
-
-            <!-- Starting Cloud Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= predCopperDist = "Cloud"'>
-                    <Cloud name='predCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.375 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.375 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * predCopperFreq ' range=':=  _default_ * predCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='predCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <!-- Starting PipeVeins Preset for Sapphire. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predSapphireDist = "PipeVeins"'>
+                        <Veins name='predSapphireVeins'  inherits='PresetPipeVeins' seed='0x5196' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
                             </Description>
-                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predSapphireFreq ' range=':=  _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Copper is complete. -->
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='predSapphireVeinsPipe'  inherits='predSapphireVeins' seed='0x5196' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predSapphireSize  * 0.5 ' range=':=  _default_ * predSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predSapphireSize  * 0.5 ' range=':=  _default_ * predSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Sapphire is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= predCopperDist = "Vanilla"'>
-                    <StandardGen name='predCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 8 * predCopperFreq ' range=':=  _default_ * predCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Copper is complete. -->
-
-            <!-- End Copper Generation -->
-
-
-            <!-- Begin Tin Generation -->
-
-            <!-- Starting LayeredVeins Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= predTinDist = "LayeredVeins"'>
-                    <Veins name='predTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.749 * _default_ * predTinFreq ' range=':=  _default_ * predTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.908 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 27 ' range=':=  21 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.908 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.908 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Tin is complete. -->
-
-
-            <!-- Starting Cloud Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= predTinDist = "Cloud"'>
-                    <Cloud name='predTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.223 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.223 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.496  * _default_ * predTinFreq ' range=':=  _default_ * predTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 27 ' range=':=  21 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='predTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                <!-- Starting Cloud Preset for Sapphire. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predSapphireDist = "Cloud"'>
+                        <Cloud name='predSapphireCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Tin is complete. -->
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predSapphireFreq ' range=':=  _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='predSapphireHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Sapphire is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= predTinDist = "Vanilla"'>
-                    <StandardGen name='predTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 5 * predTinFreq ' range=':=  _default_ * predTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 27 ' range=':=  21 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Tin is complete. -->
-
-            <!-- End Tin Generation -->
-
-
-            <!-- Begin Silver Generation -->
-
-            <!-- Starting LayeredVeins Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= predSilverDist = "LayeredVeins"'>
-                    <Veins name='predSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.237 * _default_ * predSilverFreq ' range=':=  _default_ * predSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.619 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.619 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.619 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Silver is complete. -->
-
-
-            <!-- Starting Cloud Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= predSilverDist = "Cloud"'>
-                    <Cloud name='predSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.688 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.688 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.473  * _default_ * predSilverFreq ' range=':=  _default_ * predSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='predSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                <!-- Starting Vanilla Preset for Sapphire. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predSapphireDist = "Vanilla"'>
+                        <StandardGen name='predSapphireStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Silver is complete. -->
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * predSapphireFreq ' range=':=  _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Sapphire is complete. -->
+
+                <!-- End Sapphire Generation -->
 
 
-            <!-- Starting Vanilla Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= predSilverDist = "Vanilla"'>
-                    <StandardGen name='predSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * predSilverFreq ' range=':=  _default_ * predSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Silver is complete. -->
+                <!-- Begin Peridot Generation -->
 
-            <!-- End Silver Generation -->
-
-
-            <!-- Begin Electrotine Generation -->
-
-            <!-- Starting VerticalVeins Preset for Electrotine. -->
-            <ConfigSection>
-                <IfCondition condition=':= predElectrotineDist = "VerticalVeins"'>
-                    <Veins name='predElectrotineVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
-                        <Description>
-                            Single vertical veins that occur with  no
-                            motherlodes.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.878 * _default_ * predElectrotineFreq ' range=':=  _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.958 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.958 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.958 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- VerticalVeins Preset for Electrotine is complete. -->
-
-
-            <!-- Starting Cloud Preset for Electrotine. -->
-            <ConfigSection>
-                <IfCondition condition=':= predElectrotineDist = "Cloud"'>
-                    <Cloud name='predElectrotineCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * predElectrotineFreq ' range=':=  _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='predElectrotineHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
+                <!-- Starting PipeVeins Preset for Peridot. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predPeridotDist = "PipeVeins"'>
+                        <Veins name='predPeridotVeins'  inherits='PresetPipeVeins' seed='0x8759' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
                             </Description>
-                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predPeridotFreq ' range=':=  _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':=  6 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Electrotine is complete. -->
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='predPeridotVeinsPipe'  inherits='predPeridotVeins' seed='0x8759' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predPeridotSize  * 0.5 ' range=':=  _default_ * predPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predPeridotSize  * 0.5 ' range=':=  _default_ * predPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Peridot is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Electrotine. -->
-            <ConfigSection>
-                <IfCondition condition=':= predElectrotineDist = "Vanilla"'>
-                    <StandardGen name='predElectrotineStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * predElectrotineFreq ' range=':=  _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Electrotine is complete. -->
-
-            <!-- End Electrotine Generation -->
-
-
-            <!-- Begin Marble Generation -->
-
-            <!-- Starting LayeredVeins Preset for Marble. -->
-            <ConfigSection>
-                <IfCondition condition=':= predMarbleDist = "LayeredVeins"'>
-                    <Veins name='predMarbleVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * predMarbleFreq ' range=':=  _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Marble is complete. -->
-
-
-            <!-- Starting Cloud Preset for Marble. -->
-            <ConfigSection>
-                <IfCondition condition=':= predMarbleDist = "Cloud"'>
-                    <Cloud name='predMarbleCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * predMarbleFreq ' range=':=  _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='predMarbleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                <!-- Starting Cloud Preset for Peridot. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predPeridotDist = "Cloud"'>
+                        <Cloud name='predPeridotCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predPeridotFreq ' range=':=  _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 22 ' range=':=  6 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='predPeridotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Peridot is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Peridot. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predPeridotDist = "Vanilla"'>
+                        <StandardGen name='predPeridotStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * predPeridotFreq ' range=':=  _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 22 ' range=':=  6 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Peridot is complete. -->
+
+                <!-- End Peridot Generation -->
+
+
+                <!-- Begin Copper Generation -->
+
+                <!-- Starting LayeredVeins Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predCopperDist = "LayeredVeins"'>
+                        <Veins name='predCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * predCopperFreq ' range=':=  _default_ * predCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Marble is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Marble. -->
-            <ConfigSection>
-                <IfCondition condition=':= predMarbleDist = "Vanilla"'>
-                    <StandardGen name='predMarbleStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 16 * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * predMarbleFreq ' range=':=  _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Marble is complete. -->
+                <!-- Starting Cloud Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predCopperDist = "Cloud"'>
+                        <Cloud name='predCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * predCopperFreq ' range=':=  _default_ * predCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='predCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Copper is complete. -->
 
-            <!-- End Marble Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predCopperDist = "Vanilla"'>
+                        <StandardGen name='predCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * predCopperFreq ' range=':=  _default_ * predCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Copper is complete. -->
+
+                <!-- End Copper Generation -->
+
+
+                <!-- Begin Tin Generation -->
+
+                <!-- Starting LayeredVeins Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predTinDist = "LayeredVeins"'>
+                        <Veins name='predTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.749 * _default_ * predTinFreq ' range=':=  _default_ * predTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.908 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 27 ' range=':=  21 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.908 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.908 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Tin is complete. -->
+
+
+                <!-- Starting Cloud Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predTinDist = "Cloud"'>
+                        <Cloud name='predTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.223 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.223 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.496  * _default_ * predTinFreq ' range=':=  _default_ * predTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 27 ' range=':=  21 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='predTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tin is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predTinDist = "Vanilla"'>
+                        <StandardGen name='predTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * predTinFreq ' range=':=  _default_ * predTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 27 ' range=':=  21 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tin is complete. -->
+
+                <!-- End Tin Generation -->
+
+
+                <!-- Begin Silver Generation -->
+
+                <!-- Starting LayeredVeins Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predSilverDist = "LayeredVeins"'>
+                        <Veins name='predSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.237 * _default_ * predSilverFreq ' range=':=  _default_ * predSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.619 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.619 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.619 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Silver is complete. -->
+
+
+                <!-- Starting Cloud Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predSilverDist = "Cloud"'>
+                        <Cloud name='predSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.688 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.688 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.473  * _default_ * predSilverFreq ' range=':=  _default_ * predSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='predSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Silver is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predSilverDist = "Vanilla"'>
+                        <StandardGen name='predSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * predSilverFreq ' range=':=  _default_ * predSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Silver is complete. -->
+
+                <!-- End Silver Generation -->
+
+
+                <!-- Begin Electrotine Generation -->
+
+                <!-- Starting VerticalVeins Preset for Electrotine. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predElectrotineDist = "VerticalVeins"'>
+                        <Veins name='predElectrotineVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
+                            <Description>
+                                Single vertical veins that occur  with
+                                no motherlodes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.878 * _default_ * predElectrotineFreq ' range=':=  _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.958 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.958 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.958 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- VerticalVeins Preset for Electrotine is complete. -->
+
+
+                <!-- Starting Cloud Preset for Electrotine. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predElectrotineDist = "Cloud"'>
+                        <Cloud name='predElectrotineCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * predElectrotineFreq ' range=':=  _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='predElectrotineHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Electrotine is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Electrotine. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predElectrotineDist = "Vanilla"'>
+                        <StandardGen name='predElectrotineStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * predElectrotineFreq ' range=':=  _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Electrotine is complete. -->
+
+                <!-- End Electrotine Generation -->
+
+
+                <!-- Begin Marble Generation -->
+
+                <!-- Starting LayeredVeins Preset for Marble. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predMarbleDist = "LayeredVeins"'>
+                        <Veins name='predMarbleVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * predMarbleFreq ' range=':=  _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Marble is complete. -->
+
+
+                <!-- Starting Cloud Preset for Marble. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predMarbleDist = "Cloud"'>
+                        <Cloud name='predMarbleCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * predMarbleFreq ' range=':=  _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='predMarbleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Marble is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Marble. -->
+                <ConfigSection>
+                    <IfCondition condition=':= predMarbleDist = "Vanilla"'>
+                        <StandardGen name='predMarbleStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 16 * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * predMarbleFreq ' range=':=  _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Marble is complete. -->
+
+                <!-- End Marble Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -1,1552 +1,1325 @@
- <!-- ================================================================
-      Custom Ore Generation "Project Red" Module: This configuration
-      covers ruby, sapphire, peridot, copper, tin, silver,
-      electrotine, marble, and  basalt.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Project Red" Module: This configuration
+     covers ruby, sapphire, peridot, copper, tin, silver, electrotine,
+     and marble.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="ProjRed|Exploration">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "Project Red" mod on the system?  Let's find out! -->
+<IfModInstalled name="ProjRed|Exploration">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupProjectRed' displayName='Project Red' displayState='shown'>
+                <Description>
+                    Distribution options for Project Red Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Ruby Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupProjectRed' displayName='Project Red' displayState='shown'> 
-                    <Description>
-                        Distribution options for Project Red Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Ruby Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='predRubyDist'  displayState='shown' displayGroup='groupProjectRed'> 
-                        <Description> Controls how Ruby is generated </Description> 
-                        <DisplayName>Project Red Ruby</DisplayName>
-                        <Choice value='pipeVeins' displayValue='Pipe Veins'>
-                            <Description>
-                                Pipe Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Ruby is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='predRubyFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Frequency multiplier for Project Red Ruby distributions </Description>
-                        <DisplayName>Project Red Ruby Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='predRubySize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Size multiplier for Project Red Ruby distributions </Description>
-                        <DisplayName>Project Red Ruby Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Ruby Configuration UI Complete -->
-                
-                
-                <!-- Sapphire Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='predSapphireDist'  displayState='shown' displayGroup='groupProjectRed'> 
-                        <Description> Controls how Sapphire is generated </Description> 
-                        <DisplayName>Project Red Sapphire</DisplayName>
-                        <Choice value='pipeVeins' displayValue='Pipe Veins'>
-                            <Description>
-                                Pipe Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Sapphire is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='predSapphireFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Frequency multiplier for Project Red Sapphire distributions </Description>
-                        <DisplayName>Project Red Sapphire Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='predSapphireSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Size multiplier for Project Red Sapphire distributions </Description>
-                        <DisplayName>Project Red Sapphire Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Sapphire Configuration UI Complete -->
-                
-                
-                <!-- Peridot Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='predPeridotDist'  displayState='shown' displayGroup='groupProjectRed'> 
-                        <Description> Controls how Peridot is generated </Description> 
-                        <DisplayName>Project Red Peridot</DisplayName>
-                        <Choice value='pipeVeins' displayValue='Pipe Veins'>
-                            <Description>
-                                Pipe Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Peridot is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='predPeridotFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Frequency multiplier for Project Red Peridot distributions </Description>
-                        <DisplayName>Project Red Peridot Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='predPeridotSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Size multiplier for Project Red Peridot distributions </Description>
-                        <DisplayName>Project Red Peridot Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Peridot Configuration UI Complete -->
-                
-                
-                <!-- Copper Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='predCopperDist'  displayState='shown' displayGroup='groupProjectRed'> 
-                        <Description> Controls how Copper is generated </Description> 
-                        <DisplayName>Project Red Copper</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='predCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Frequency multiplier for Project Red Copper distributions </Description>
-                        <DisplayName>Project Red Copper Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='predCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Size multiplier for Project Red Copper distributions </Description>
-                        <DisplayName>Project Red Copper Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Copper Configuration UI Complete -->
-                
-                
-                <!-- Tin Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='predTinDist'  displayState='shown' displayGroup='groupProjectRed'> 
-                        <Description> Controls how Tin is generated </Description> 
-                        <DisplayName>Project Red Tin</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='predTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Frequency multiplier for Project Red Tin distributions </Description>
-                        <DisplayName>Project Red Tin Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='predTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Size multiplier for Project Red Tin distributions </Description>
-                        <DisplayName>Project Red Tin Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Tin Configuration UI Complete -->
-                
-                
-                <!-- Silver Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='predSilverDist'  displayState='shown' displayGroup='groupProjectRed'> 
-                        <Description> Controls how Silver is generated </Description> 
-                        <DisplayName>Project Red Silver</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='predSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Frequency multiplier for Project Red Silver distributions </Description>
-                        <DisplayName>Project Red Silver Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='predSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Size multiplier for Project Red Silver distributions </Description>
-                        <DisplayName>Project Red Silver Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Silver Configuration UI Complete -->
-                
-                
-                <!-- Electrotine Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='predElectrotineDist'  displayState='shown' displayGroup='groupProjectRed'> 
-                        <Description> Controls how Electrotine is generated </Description> 
-                        <DisplayName>Project Red Electrotine</DisplayName>
-                        <Choice value='verticalVeins' displayValue='Vertical Veins'>
-                            <Description>
-                                Vertical Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Electrotine is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='predElectrotineFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Frequency multiplier for Project Red Electrotine distributions </Description>
-                        <DisplayName>Project Red Electrotine Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='predElectrotineSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Size multiplier for Project Red Electrotine distributions </Description>
-                        <DisplayName>Project Red Electrotine Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Electrotine Configuration UI Complete -->
-                
-                
-                <!-- Marble Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='predMarbleDist'  displayState='shown' displayGroup='groupProjectRed'> 
-                        <Description> Controls how Marble is generated </Description> 
-                        <DisplayName>Project Red Marble</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Marble is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='predMarbleFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Frequency multiplier for Project Red Marble distributions </Description>
-                        <DisplayName>Project Red Marble Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='predMarbleSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Size multiplier for Project Red Marble distributions </Description>
-                        <DisplayName>Project Red Marble Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Marble Configuration UI Complete -->
-                
-                
-                <!-- Basalt Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='predBasaltDist'  displayState='shown' displayGroup='groupProjectRed'> 
-                        <Description> Controls how Basalt is generated </Description> 
-                        <DisplayName>Project Red Basalt</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Basalt is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='predBasaltFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Frequency multiplier for Project Red Basalt distributions </Description>
-                        <DisplayName>Project Red Basalt Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='predBasaltSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
-                        <Description> Size multiplier for Project Red Basalt distributions </Description>
-                        <DisplayName>Project Red Basalt Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Basalt Configuration UI Complete -->
-                
+                <OptionChoice name='predRubyDist'  displayState='shown' displayGroup='groupProjectRed'>
+                    <Description> Controls how Ruby is generated </Description>
+                    <DisplayName>Project Red Ruby</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
+                        <Description>
+                            Short and sparsely filled compound veins containing one material inside another.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Ruby is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='predRubyFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Frequency multiplier for Project Red Ruby distributions </Description>
+                    <DisplayName>Project Red Ruby Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='predRubySize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Size multiplier for Project Red Ruby distributions </Description>
+                    <DisplayName>Project Red Ruby Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Ruby Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='predOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='ProjRed|Exploration:projectred.exploration.ore' />
-                    <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' />
-                    <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' />
-                    <Replaces block='ProjRed|Exploration:projectred.exploration.ore:3' />
-                    <Replaces block='ProjRed|Exploration:projectred.exploration.ore:4' />
-                    <Replaces block='ProjRed|Exploration:projectred.exploration.ore:5' />
-                    <Replaces block='ProjRed|Exploration:projectred.exploration.ore:6' />
-                    <Replaces block='ProjRed|Exploration:projectred.exploration.stone' />
-                    <Replaces block='ProjRed|Exploration:projectred.exploration.stone:3' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Ruby Generation --> 
-                
-                <!-- Begin PipeVeins distribution of Ruby -->
-                <IfCondition condition=':= predRubyDist = "pipeVeins"'>
-                
-                    <Veins name='predRubyBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore'  inherits='PresetPipeVeins' seed='0xE23A'>
+            <!-- Sapphire Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='predSapphireDist'  displayState='shown' displayGroup='groupProjectRed'>
+                    <Description> Controls how Sapphire is generated </Description>
+                    <DisplayName>Project Red Sapphire</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
-                            Short sparsely filled veins sloping up
+                            Short and sparsely filled compound veins containing one material inside another.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Sapphire is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='predSapphireFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Frequency multiplier for Project Red Sapphire distributions </Description>
+                    <DisplayName>Project Red Sapphire Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='predSapphireSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Size multiplier for Project Red Sapphire distributions </Description>
+                    <DisplayName>Project Red Sapphire Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Sapphire Configuration UI Complete -->
+
+
+            <!-- Peridot Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='predPeridotDist'  displayState='shown' displayGroup='groupProjectRed'>
+                    <Description> Controls how Peridot is generated </Description>
+                    <DisplayName>Project Red Peridot</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
+                        <Description>
+                            Short and sparsely filled compound veins containing one material inside another.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Peridot is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='predPeridotFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Frequency multiplier for Project Red Peridot distributions </Description>
+                    <DisplayName>Project Red Peridot Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='predPeridotSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Size multiplier for Project Red Peridot distributions </Description>
+                    <DisplayName>Project Red Peridot Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Peridot Configuration UI Complete -->
+
+
+            <!-- Copper Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='predCopperDist'  displayState='shown' displayGroup='groupProjectRed'>
+                    <Description> Controls how Copper is generated </Description>
+                    <DisplayName>Project Red Copper</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='predCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Frequency multiplier for Project Red Copper distributions </Description>
+                    <DisplayName>Project Red Copper Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='predCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Size multiplier for Project Red Copper distributions </Description>
+                    <DisplayName>Project Red Copper Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Copper Configuration UI Complete -->
+
+
+            <!-- Tin Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='predTinDist'  displayState='shown' displayGroup='groupProjectRed'>
+                    <Description> Controls how Tin is generated </Description>
+                    <DisplayName>Project Red Tin</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='predTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Frequency multiplier for Project Red Tin distributions </Description>
+                    <DisplayName>Project Red Tin Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='predTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Size multiplier for Project Red Tin distributions </Description>
+                    <DisplayName>Project Red Tin Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Tin Configuration UI Complete -->
+
+
+            <!-- Silver Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='predSilverDist'  displayState='shown' displayGroup='groupProjectRed'>
+                    <Description> Controls how Silver is generated </Description>
+                    <DisplayName>Project Red Silver</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='predSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Frequency multiplier for Project Red Silver distributions </Description>
+                    <DisplayName>Project Red Silver Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='predSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Size multiplier for Project Red Silver distributions </Description>
+                    <DisplayName>Project Red Silver Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Silver Configuration UI Complete -->
+
+
+            <!-- Electrotine Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='predElectrotineDist'  displayState='shown' displayGroup='groupProjectRed'>
+                    <Description> Controls how Electrotine is generated </Description>
+                    <DisplayName>Project Red Electrotine</DisplayName>
+                    <Choice value='VerticalVeins' displayValue='Vertical Veins'>
+                        <Description>
+                            Single vertical veins that occur with no motherlodes.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Electrotine is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='predElectrotineFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Frequency multiplier for Project Red Electrotine distributions </Description>
+                    <DisplayName>Project Red Electrotine Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='predElectrotineSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Size multiplier for Project Red Electrotine distributions </Description>
+                    <DisplayName>Project Red Electrotine Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Electrotine Configuration UI Complete -->
+
+
+            <!-- Marble Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='predMarbleDist'  displayState='shown' displayGroup='groupProjectRed'>
+                    <Description> Controls how Marble is generated </Description>
+                    <DisplayName>Project Red Marble</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Marble is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='predMarbleFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Frequency multiplier for Project Red Marble distributions </Description>
+                    <DisplayName>Project Red Marble Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='predMarbleSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupProjectRed'>
+                    <Description> Size multiplier for Project Red Marble distributions </Description>
+                    <DisplayName>Project Red Marble Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Marble Configuration UI Complete -->
+
+        </ConfigSection>
+        <!-- Setup Screen Complete -->
+
+
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='predOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
+                <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
+                <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
+                <Replaces block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
+                <Replaces block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
+                <Replaces block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
+                <Replaces block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
+                <Replaces block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Ruby Generation -->
+
+            <!-- Starting PipeVeins Preset for Ruby. -->
+            <ConfigSection>
+                <IfCondition condition=':= predRubyDist = "PipeVeins"'>
+                    <Veins name='predRubyVeins'  inherits='PresetPipeVeins' seed='0xE23A' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
                             from near the bottom of the map.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60900113</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * predRubySize * _default_' range=':= 1 * 1 * predRubySize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predRubySize * _default_' range=':= 1 * 1 * predRubySize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * predRubyFreq * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <Replaces block='minecraft:stone'/>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predRubyFreq ' range=':=  _default_ * predRubyFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-                    
-                    <!-- Begin Pipe Filling (Ruby Pipe Veins) Settings -->
-                    <Veins name='predRubyPipeVeins' block='minecraft:stone'  inherits='predRubyBaseVeins' seed='0xE23A'>
-                        <Description>
-                            Fills the vein with an additional material
-                            (minecraft:stone).
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60900113</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 1 * predRubySize * _default_' range=':= 0.5 * 1 * 1 * predRubySize * _default_'/>
-                        <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 1 * predRubySize * _default_' range=':= 0.5 * 1 * 1 * predRubySize * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore'/>
-                        <Replaces block='minecraft:dirt'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:gravel'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        <Replaces block='minecraft:end_stone'/>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='predRubyVeinsPipe'  inherits='predRubyVeins' seed='0xE23A' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
+                        <OreBlock block='minecraft:lava' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predRubySize  * 0.5 ' range=':=  _default_ * predRubySize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predRubySize  * 0.5 ' range=':=  _default_ * predRubySize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                     </Veins>
-                    <!-- End Pipe Filling (Ruby Pipe Veins) Settings -->
-                
                 </IfCondition>
-                <!-- End PipeVeins distribution of Ruby -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Ruby -->
-                <IfCondition condition=':= predRubyDist = "smallDeposits"'>
-                
-                    <Veins name='predRubyBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore'  inherits='PresetSmallDeposits' >
+            </ConfigSection>
+            <!-- PipeVeins Preset for Ruby is complete. -->
+
+
+            <!-- Starting Cloud Preset for Ruby. -->
+            <ConfigSection>
+                <IfCondition condition=':= predRubyDist = "Cloud"'>
+                    <Cloud name='predRubyCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60900113</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * predRubySize * _default_' range=':= 1 * 1 * predRubySize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predRubySize * _default_' range=':= 1 * 1 * predRubySize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * predRubyFreq * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Ruby -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Ruby -->
-                <IfCondition condition=':= predRubyDist = "strategicCloud"'>
-                
-                    <Cloud name='predRubyBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60900113</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.4 * predRubySize * _default_' range=':= 1 * 0.4 * predRubySize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.4 * predRubySize * _default_' range=':= 1 * 0.4 * predRubySize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 15' range=':= 5' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.8 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.2 * 0.4 * predRubySize * _default_' range=':= 1 * 0.2 * 0.4 * predRubySize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 35 * predRubyFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                        
-                        <!-- Begin Ruby Strategic Cloud Hint Veins -->
-                        <Veins name='predRubyBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore' inherits='PresetHintVeins'>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predRubyFreq ' range=':=  _default_ * predRubyFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='predRubyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60900113</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
                         </Veins>
-                        <!-- End Ruby Strategic Cloud Hint Veins -->
-
                     </Cloud>
-                
                 </IfCondition>
-                <!-- End  StrategicCloud distribution of Ruby -->
-                
-                
-                <!-- Begin  Vanilla distribution of Ruby -->
-                <IfCondition condition=':= predRubyDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='predRubyBaseStandard' block='ProjRed|Exploration:projectred.exploration.ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60900113</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 7/8 * predRubySize * _default_'/>
-                        <Setting name='Height' avg=':= 24' range=':= 24' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.1 * predRubyFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Ruby -->
-                
-                <!-- End Ruby Generation --> 
+            </ConfigSection>
+            <!-- Cloud Preset for Ruby is complete. -->
 
-                
-                <!-- Begin Sapphire Generation --> 
-                
-                <!-- Begin PipeVeins distribution of Sapphire -->
-                <IfCondition condition=':= predSapphireDist = "pipeVeins"'>
-                
-                    <Veins name='predSapphireBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:1'  inherits='PresetPipeVeins' seed='0x5196'>
+
+            <!-- Starting Vanilla Preset for Ruby. -->
+            <ConfigSection>
+                <IfCondition condition=':= predRubyDist = "Vanilla"'>
+                    <StandardGen name='predRubyStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
                         <Description>
-                            Short sparsely filled veins sloping up
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 1 * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * predRubyFreq ' range=':=  _default_ * predRubyFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Ruby is complete. -->
+
+            <!-- End Ruby Generation -->
+
+
+            <!-- Begin Sapphire Generation -->
+
+            <!-- Starting PipeVeins Preset for Sapphire. -->
+            <ConfigSection>
+                <IfCondition condition=':= predSapphireDist = "PipeVeins"'>
+                    <Veins name='predSapphireVeins'  inherits='PresetPipeVeins' seed='0x5196' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
                             from near the bottom of the map.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600011C8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * predSapphireSize * _default_' range=':= 1 * 1 * predSapphireSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predSapphireSize * _default_' range=':= 1 * 1 * predSapphireSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * predSapphireFreq * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <Replaces block='minecraft:stone'/>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predSapphireFreq ' range=':=  _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-                    
-                    <!-- Begin Pipe Filling (Sapphire Pipe Veins) Settings -->
-                    <Veins name='predSapphirePipeVeins' block='minecraft:stone'  inherits='predSapphireBaseVeins' seed='0x5196'>
-                        <Description>
-                            Fills the vein with an additional material
-                            (minecraft:stone).
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600011C8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 1 * predSapphireSize * _default_' range=':= 0.5 * 1 * 1 * predSapphireSize * _default_'/>
-                        <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 1 * predSapphireSize * _default_' range=':= 0.5 * 1 * 1 * predSapphireSize * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1'/>
-                        <Replaces block='minecraft:dirt'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:gravel'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        <Replaces block='minecraft:end_stone'/>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='predSapphireVeinsPipe'  inherits='predSapphireVeins' seed='0x5196' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
+                        <OreBlock block='minecraft:lava' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predSapphireSize  * 0.5 ' range=':=  _default_ * predSapphireSize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predSapphireSize  * 0.5 ' range=':=  _default_ * predSapphireSize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                     </Veins>
-                    <!-- End Pipe Filling (Sapphire Pipe Veins) Settings -->
-                
                 </IfCondition>
-                <!-- End PipeVeins distribution of Sapphire -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Sapphire -->
-                <IfCondition condition=':= predSapphireDist = "smallDeposits"'>
-                
-                    <Veins name='predSapphireBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:1'  inherits='PresetSmallDeposits' >
+            </ConfigSection>
+            <!-- PipeVeins Preset for Sapphire is complete. -->
+
+
+            <!-- Starting Cloud Preset for Sapphire. -->
+            <ConfigSection>
+                <IfCondition condition=':= predSapphireDist = "Cloud"'>
+                    <Cloud name='predSapphireCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600011C8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * predSapphireSize * _default_' range=':= 1 * 1 * predSapphireSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predSapphireSize * _default_' range=':= 1 * 1 * predSapphireSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * predSapphireFreq * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Sapphire -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Sapphire -->
-                <IfCondition condition=':= predSapphireDist = "strategicCloud"'>
-                
-                    <Cloud name='predSapphireBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600011C8</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.4 * predSapphireSize * _default_' range=':= 1 * 0.4 * predSapphireSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.4 * predSapphireSize * _default_' range=':= 1 * 0.4 * predSapphireSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 15' range=':= 5' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.8 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.2 * 0.4 * predSapphireSize * _default_' range=':= 1 * 0.2 * 0.4 * predSapphireSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 35 * predSapphireFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                        
-                        <!-- Begin Sapphire Strategic Cloud Hint Veins -->
-                        <Veins name='predSapphireBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:1' inherits='PresetHintVeins'>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predSapphireFreq ' range=':=  _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='predSapphireHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x600011C8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
                         </Veins>
-                        <!-- End Sapphire Strategic Cloud Hint Veins -->
-
                     </Cloud>
-                
                 </IfCondition>
-                <!-- End  StrategicCloud distribution of Sapphire -->
-                
-                
-                <!-- Begin  Vanilla distribution of Sapphire -->
-                <IfCondition condition=':= predSapphireDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='predSapphireBaseStandard' block='ProjRed|Exploration:projectred.exploration.ore:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600011C8</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 7/8 * predSapphireSize * _default_'/>
-                        <Setting name='Height' avg=':= 24' range=':= 24' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.1 * predSapphireFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Sapphire -->
-                
-                <!-- End Sapphire Generation --> 
+            </ConfigSection>
+            <!-- Cloud Preset for Sapphire is complete. -->
 
-                
-                <!-- Begin Peridot Generation --> 
-                
-                <!-- Begin PipeVeins distribution of Peridot -->
-                <IfCondition condition=':= predPeridotDist = "pipeVeins"'>
-                
-                    <Veins name='predPeridotBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:2'  inherits='PresetPipeVeins' seed='0x8759'>
+
+            <!-- Starting Vanilla Preset for Sapphire. -->
+            <ConfigSection>
+                <IfCondition condition=':= predSapphireDist = "Vanilla"'>
+                    <StandardGen name='predSapphireStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
                         <Description>
-                            Short sparsely filled veins sloping up
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 1 * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * predSapphireFreq ' range=':=  _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Sapphire is complete. -->
+
+            <!-- End Sapphire Generation -->
+
+
+            <!-- Begin Peridot Generation -->
+
+            <!-- Starting PipeVeins Preset for Peridot. -->
+            <ConfigSection>
+                <IfCondition condition=':= predPeridotDist = "PipeVeins"'>
+                    <Veins name='predPeridotVeins'  inherits='PresetPipeVeins' seed='0x8759' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
                             from near the bottom of the map.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60057529</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * predPeridotSize * _default_' range=':= 1 * 1 * predPeridotSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predPeridotSize * _default_' range=':= 1 * 1 * predPeridotSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * predPeridotFreq * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <Replaces block='minecraft:stone'/>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predPeridotFreq ' range=':=  _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 22 ' range=':=  6 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-                    
-                    <!-- Begin Pipe Filling (Peridot Pipe Veins) Settings -->
-                    <Veins name='predPeridotPipeVeins' block='minecraft:stone'  inherits='predPeridotBaseVeins' seed='0x8759'>
-                        <Description>
-                            Fills the vein with an additional material
-                            (minecraft:stone).
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60057529</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 1 * predPeridotSize * _default_' range=':= 0.5 * 1 * 1 * predPeridotSize * _default_'/>
-                        <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 1 * predPeridotSize * _default_' range=':= 0.5 * 1 * 1 * predPeridotSize * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2'/>
-                        <Replaces block='minecraft:dirt'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:gravel'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        <Replaces block='minecraft:end_stone'/>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='predPeridotVeinsPipe'  inherits='predPeridotVeins' seed='0x8759' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
+                        <OreBlock block='minecraft:lava' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predPeridotSize  * 0.5 ' range=':=  _default_ * predPeridotSize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predPeridotSize  * 0.5 ' range=':=  _default_ * predPeridotSize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                     </Veins>
-                    <!-- End Pipe Filling (Peridot Pipe Veins) Settings -->
-                
                 </IfCondition>
-                <!-- End PipeVeins distribution of Peridot -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Peridot -->
-                <IfCondition condition=':= predPeridotDist = "smallDeposits"'>
-                
-                    <Veins name='predPeridotBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:2'  inherits='PresetSmallDeposits' >
+            </ConfigSection>
+            <!-- PipeVeins Preset for Peridot is complete. -->
+
+
+            <!-- Starting Cloud Preset for Peridot. -->
+            <ConfigSection>
+                <IfCondition condition=':= predPeridotDist = "Cloud"'>
+                    <Cloud name='predPeridotCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60057529</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * predPeridotSize * _default_' range=':= 1 * 1 * predPeridotSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predPeridotSize * _default_' range=':= 1 * 1 * predPeridotSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.5 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * predPeridotFreq * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Peridot -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Peridot -->
-                <IfCondition condition=':= predPeridotDist = "strategicCloud"'>
-                
-                    <Cloud name='predPeridotBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60057529</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.4 * predPeridotSize * _default_' range=':= 1 * 0.4 * predPeridotSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.4 * predPeridotSize * _default_' range=':= 1 * 0.4 * predPeridotSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 15' range=':= 5' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.8 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.2 * 0.4 * predPeridotSize * _default_' range=':= 1 * 0.2 * 0.4 * predPeridotSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 35 * predPeridotFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                        
-                        <!-- Begin Peridot Strategic Cloud Hint Veins -->
-                        <Veins name='predPeridotBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:2' inherits='PresetHintVeins'>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predPeridotFreq ' range=':=  _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 22 ' range=':=  6 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='predPeridotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60057529</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
                         </Veins>
-                        <!-- End Peridot Strategic Cloud Hint Veins -->
-
                     </Cloud>
-                
                 </IfCondition>
-                <!-- End  StrategicCloud distribution of Peridot -->
-                
-                
-                <!-- Begin  Vanilla distribution of Peridot -->
-                <IfCondition condition=':= predPeridotDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='predPeridotBaseStandard' block='ProjRed|Exploration:projectred.exploration.ore:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60057529</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 7/8 * predPeridotSize * _default_'/>
-                        <Setting name='Height' avg=':= 24' range=':= 24' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.1 * predPeridotFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Peridot -->
-                
-                <!-- End Peridot Generation --> 
+            </ConfigSection>
+            <!-- Cloud Preset for Peridot is complete. -->
 
-                
-                <!-- Begin Copper Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Copper -->
-                <IfCondition condition=':= predCopperDist = "layeredVeins"'>
-                
-                    <Veins name='predCopperBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:3'  inherits='PresetLayeredVeins' >
+
+            <!-- Starting Vanilla Preset for Peridot. -->
+            <ConfigSection>
+                <IfCondition condition=':= predPeridotDist = "Vanilla"'>
+                    <StandardGen name='predPeridotStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 1 * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * predPeridotFreq ' range=':=  _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 22 ' range=':=  6 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Peridot is complete. -->
+
+            <!-- End Peridot Generation -->
+
+
+            <!-- Begin Copper Generation -->
+
+            <!-- Starting LayeredVeins Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= predCopperDist = "LayeredVeins"'>
+                    <Veins name='predCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
                             horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.9 * predCopperSize * _default_' range=':= 1 * 0.9 * predCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 45' range=':= 10' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.9 * predCopperSize * _default_' range=':= 1 * 0.9 * predCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * predCopperFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.95 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.95 * _default_' range=':= 0.95 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Replaces block='minecraft:stone'/>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * predCopperFreq ' range=':=  _default_ * predCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='predCopperPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:3'  inherits='predCopperBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Jungle'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                
                 </IfCondition>
-                <!-- End Layered Veins distribution of Copper -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Copper -->
-                <IfCondition condition=':= predCopperDist = "hugeVeins"'>
-                
-                    <Veins name='predCopperBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:3'  inherits='PresetHugeVeins' >
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Copper is complete. -->
+
+
+            <!-- Starting Cloud Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= predCopperDist = "Cloud"'>
+                    <Cloud name='predCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.9 * predCopperSize * _default_' range=':= 1 * 0.9 * predCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 45' range=':= 10' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.9 * predCopperSize * _default_' range=':= 1 * 0.9 * predCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * predCopperFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.95 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.95 * _default_' range=':= 0.95 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                    <Veins name='predCopperPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:3'  inherits='predCopperBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Jungle'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Copper -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Copper -->
-                <IfCondition condition=':= predCopperDist = "strategicCloud"'>
-                
-                    <Cloud name='predCopperBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.95 * predCopperSize * _default_' range=':= 1 * 0.95 * predCopperSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.95 * predCopperSize * _default_' range=':= 1 * 0.95 * predCopperSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.95 * 0.95 * predCopperSize * _default_' range=':= 1 * 0.95 * 0.95 * predCopperSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * predCopperFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Copper Strategic Cloud Hint Veins -->
-                        <Veins name='predCopperBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='PresetHintVeins'>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.375 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.375 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * predCopperFreq ' range=':=  _default_ * predCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='predCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
                         </Veins>
-                        <!-- End Copper Strategic Cloud Hint Veins -->
-
                     </Cloud>
-                    
-                
                 </IfCondition>
-                <!-- End  StrategicCloud distribution of Copper -->
-                
-                
-                <!-- Begin  Vanilla distribution of Copper -->
-                <IfCondition condition=':= predCopperDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='predCopperBaseStandard' block='ProjRed|Exploration:projectred.exploration.ore:3' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * predCopperSize * _default_'/>
-                        <Setting name='Height' avg=':= 57' range=':= 17' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1.2 * predCopperFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Copper -->
-                
-                <!-- End Copper Generation --> 
+            </ConfigSection>
+            <!-- Cloud Preset for Copper is complete. -->
 
-                
-                <!-- Begin Tin Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Tin -->
-                <IfCondition condition=':= predTinDist = "layeredVeins"'>
-                
-                    <Veins name='predTinBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:4'  inherits='PresetLayeredVeins' >
+
+            <!-- Starting Vanilla Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= predCopperDist = "Vanilla"'>
+                    <StandardGen name='predCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 8 * predCopperFreq ' range=':=  _default_ * predCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Copper is complete. -->
+
+            <!-- End Copper Generation -->
+
+
+            <!-- Begin Tin Generation -->
+
+            <!-- Starting LayeredVeins Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= predTinDist = "LayeredVeins"'>
+                    <Veins name='predTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
                             horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * predTinSize * _default_' range=':= 1 * 0.85 * predTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * predTinSize * _default_' range=':= 1 * 0.85 * predTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * predTinFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.9 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.9 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 11'/>
-                        <Replaces block='minecraft:stone'/>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.749 * _default_ * predTinFreq ' range=':=  _default_ * predTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.908 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 27 ' range=':=  21 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.908 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.908 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='predTinPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:4'  inherits='predTinBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                
                 </IfCondition>
-                <!-- End Layered Veins distribution of Tin -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Tin -->
-                <IfCondition condition=':= predTinDist = "hugeVeins"'>
-                
-                    <Veins name='predTinBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:4'  inherits='PresetHugeVeins' >
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Tin is complete. -->
+
+
+            <!-- Starting Cloud Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= predTinDist = "Cloud"'>
+                    <Cloud name='predTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * predTinSize * _default_' range=':= 1 * 0.85 * predTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * predTinSize * _default_' range=':= 1 * 0.85 * predTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * predTinFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.9 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.9 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 11'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                    <Veins name='predTinPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:4'  inherits='predTinBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Tin -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Tin -->
-                <IfCondition condition=':= predTinDist = "strategicCloud"'>
-                
-                    <Cloud name='predTinBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.9 * predTinSize * _default_' range=':= 1 * 0.9 * predTinSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.9 * predTinSize * _default_' range=':= 1 * 0.9 * predTinSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.9 * 0.9 * predTinSize * _default_' range=':= 1 * 0.9 * 0.9 * predTinSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * predTinFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Tin Strategic Cloud Hint Veins -->
-                        <Veins name='predTinBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='PresetHintVeins'>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.223 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.223 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.496  * _default_ * predTinFreq ' range=':=  _default_ * predTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 27 ' range=':=  21 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='predTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
                         </Veins>
-                        <!-- End Tin Strategic Cloud Hint Veins -->
-
                     </Cloud>
-                    
-                
                 </IfCondition>
-                <!-- End  StrategicCloud distribution of Tin -->
-                
-                
-                <!-- Begin  Vanilla distribution of Tin -->
-                <IfCondition condition=':= predTinDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='predTinBaseStandard' block='ProjRed|Exploration:projectred.exploration.ore:4' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * predTinSize * _default_'/>
-                        <Setting name='Height' avg=':= 37' range=':= 17' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.75 * predTinFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Tin -->
-                
-                <!-- End Tin Generation --> 
+            </ConfigSection>
+            <!-- Cloud Preset for Tin is complete. -->
 
-                
-                <!-- Begin Silver Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Silver -->
-                <IfCondition condition=':= predSilverDist = "layeredVeins"'>
-                
-                    <Veins name='predSilverBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:5'  inherits='PresetLayeredVeins' >
+
+            <!-- Starting Vanilla Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= predTinDist = "Vanilla"'>
+                    <StandardGen name='predTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 5 * predTinFreq ' range=':=  _default_ * predTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 27 ' range=':=  21 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Tin is complete. -->
+
+            <!-- End Tin Generation -->
+
+
+            <!-- Begin Silver Generation -->
+
+            <!-- Starting LayeredVeins Preset for Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= predSilverDist = "LayeredVeins"'>
+                    <Veins name='predSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
                             horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * predSilverSize * _default_' range=':= 1 * 0.85 * predSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * predSilverSize * _default_' range=':= 1 * 0.85 * predSilverSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * predSilverFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Replaces block='minecraft:stone'/>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.237 * _default_ * predSilverFreq ' range=':=  _default_ * predSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.619 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.619 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.619 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                    <Veins name='predSilverPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:5'  inherits='predSilverBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                
                 </IfCondition>
-                <!-- End Layered Veins distribution of Silver -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Silver -->
-                <IfCondition condition=':= predSilverDist = "hugeVeins"'>
-                
-                    <Veins name='predSilverBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:5'  inherits='PresetHugeVeins' >
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Silver is complete. -->
+
+
+            <!-- Starting Cloud Preset for Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= predSilverDist = "Cloud"'>
+                    <Cloud name='predSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * predSilverSize * _default_' range=':= 1 * 0.85 * predSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * predSilverSize * _default_' range=':= 1 * 0.85 * predSilverSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * predSilverFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Silver Huge Veins) Settings -->
-                    <Veins name='predSilverPrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:5'  inherits='predSilverBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Silver Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Silver -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Silver -->
-                <IfCondition condition=':= predSilverDist = "strategicCloud"'>
-                
-                    <Cloud name='predSilverBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * predSilverSize * _default_' range=':= 1 * 0.8 * predSilverSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * predSilverSize * _default_' range=':= 1 * 0.8 * predSilverSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.5 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * predSilverSize * _default_' range=':= 1 * 0.8 * 0.8 * predSilverSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * predSilverFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Silver Strategic Cloud Hint Veins -->
-                        <Veins name='predSilverBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='PresetHintVeins'>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.688 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.688 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.473  * _default_ * predSilverFreq ' range=':=  _default_ * predSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='predSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E3F2F7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
                         </Veins>
-                        <!-- End Silver Strategic Cloud Hint Veins -->
-
                     </Cloud>
-                    
-                
                 </IfCondition>
-                <!-- End  StrategicCloud distribution of Silver -->
-                
-                
-                <!-- Begin  Vanilla distribution of Silver -->
-                <IfCondition condition=':= predSilverDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='predSilverBaseStandard' block='ProjRed|Exploration:projectred.exploration.ore:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * predSilverSize * _default_'/>
-                        <Setting name='Height' avg=':= 18' range=':= 12' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.15 * predSilverFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Silver -->
-                
-                <!-- End Silver Generation --> 
+            </ConfigSection>
+            <!-- Cloud Preset for Silver is complete. -->
 
-                
-                <!-- Begin Electrotine Generation --> 
-                
-                <!-- Begin VerticalVeins distribution of Electrotine -->
-                <IfCondition condition=':= predElectrotineDist = "verticalVeins"'>
-                
-                    <Veins name='predElectrotineBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:6'  inherits='PresetVerticalVeins' >
+
+            <!-- Starting Vanilla Preset for Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= predSilverDist = "Vanilla"'>
+                    <StandardGen name='predSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
                         <Description>
-                            Single vertical veins that occur with no
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * predSilverFreq ' range=':=  _default_ * predSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Silver is complete. -->
+
+            <!-- End Silver Generation -->
+
+
+            <!-- Begin Electrotine Generation -->
+
+            <!-- Starting VerticalVeins Preset for Electrotine. -->
+            <ConfigSection>
+                <IfCondition condition=':= predElectrotineDist = "VerticalVeins"'>
+                    <Veins name='predElectrotineVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
+                        <Description>
+                            Single vertical veins that occur with  no
                             motherlodes.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6001FFFC</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * predElectrotineSize * _default_' range=':= 1 * 1 * predElectrotineSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predElectrotineSize * _default_' range=':= 1 * 1 * predElectrotineSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.3 * predElectrotineFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.878 * _default_ * predElectrotineFreq ' range=':=  _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.958 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.958 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.958 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Electrotine Vertical Veins) Settings -->
-                    <Veins name='predElectrotinePrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:6'  inherits='predElectrotineBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6001FFFC</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Desert'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Electrotine Vertical Veins) Settings -->
-                
                 </IfCondition>
-                <!-- End VerticalVeins distribution of Electrotine -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Electrotine -->
-                <IfCondition condition=':= predElectrotineDist = "smallDeposits"'>
-                
-                    <Veins name='predElectrotineBaseVeins' block='ProjRed|Exploration:projectred.exploration.ore:6'  inherits='PresetSmallDeposits' >
+            </ConfigSection>
+            <!-- VerticalVeins Preset for Electrotine is complete. -->
+
+
+            <!-- Starting Cloud Preset for Electrotine. -->
+            <ConfigSection>
+                <IfCondition condition=':= predElectrotineDist = "Cloud"'>
+                    <Cloud name='predElectrotineCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6001FFFC</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * predElectrotineSize * _default_' range=':= 1 * 1 * predElectrotineSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predElectrotineSize * _default_' range=':= 1 * 1 * predElectrotineSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.3 * predElectrotineFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Electrotine Deposit Veins) Settings -->
-                    <Veins name='predElectrotinePrefersVeins' block='ProjRed|Exploration:projectred.exploration.ore:6'  inherits='predElectrotineBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6001FFFC</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Desert'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Electrotine Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Electrotine -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Electrotine -->
-                <IfCondition condition=':= predElectrotineDist = "strategicCloud"'>
-                
-                    <Cloud name='predElectrotineBaseCloud' block='ProjRed|Exploration:projectred.exploration.ore:6' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6001FFFC</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1.2 * predElectrotineSize * _default_' range=':= 1 * 1.2 * predElectrotineSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.2 * predElectrotineSize * _default_' range=':= 1 * 1.2 * predElectrotineSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.75 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1.2 * predElectrotineSize * _default_' range=':= 1 * 1 * 1.2 * predElectrotineSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 5 * predElectrotineFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Electrotine Strategic Cloud Hint Veins -->
-                        <Veins name='predElectrotineBaseHintVeins' block='ProjRed|Exploration:projectred.exploration.ore:6' inherits='PresetHintVeins'>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * predElectrotineFreq ' range=':=  _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='predElectrotineHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6001FFFC</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
                         </Veins>
-                        <!-- End Electrotine Strategic Cloud Hint Veins -->
-
                     </Cloud>
-                    
-                
                 </IfCondition>
-                <!-- End  StrategicCloud distribution of Electrotine -->
-                
-                
-                <!-- Begin  Vanilla distribution of Electrotine -->
-                <IfCondition condition=':= predElectrotineDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='predElectrotineBaseStandard' block='ProjRed|Exploration:projectred.exploration.ore:6' inherits='PresetStandardGen'>
+            </ConfigSection>
+            <!-- Cloud Preset for Electrotine is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Electrotine. -->
+            <ConfigSection>
+                <IfCondition condition=':= predElectrotineDist = "Vanilla"'>
+                    <StandardGen name='predElectrotineStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
                         <Description>
-                            This mimics vanilla ore generation.
+                            A master preset for standardgen ore
+                            distributions.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6001FFFC</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 7/8 * predElectrotineSize * _default_'/>
-                        <Setting name='Height' avg=':= 8' range=':= 8' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.4 * predElectrotineFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * predElectrotineFreq ' range=':=  _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
-                    
-                
                 </IfCondition>
-                <!-- End  Vanilla distribution of Electrotine -->
-                
-                <!-- End Electrotine Generation --> 
+            </ConfigSection>
+            <!-- Vanilla Preset for Electrotine is complete. -->
 
-                
-                <!-- Begin Marble Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Marble -->
-                <IfCondition condition=':= predMarbleDist = "layeredVeins"'>
-                
-                    <Veins name='predMarbleBaseVeins' block='ProjRed|Exploration:projectred.exploration.stone'  inherits='PresetLayeredVeins' >
+            <!-- End Electrotine Generation -->
+
+
+            <!-- Begin Marble Generation -->
+
+            <!-- Starting LayeredVeins Preset for Marble. -->
+            <ConfigSection>
+                <IfCondition condition=':= predMarbleDist = "LayeredVeins"'>
+                    <Veins name='predMarbleVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
+                            Small, fairly rare motherlodes with  2-4
                             horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFFFFF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * predMarbleSize * _default_' range=':= 1 * 1 * predMarbleSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predMarbleSize * _default_' range=':= 1 * 1 * predMarbleSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * predMarbleFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * predMarbleFreq ' range=':=  _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Marble Layered Veins) Settings -->
-                    <Veins name='predMarblePrefersVeins' block='ProjRed|Exploration:projectred.exploration.stone'  inherits='predMarbleBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFFFFF</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Marble Layered Veins) Settings -->
-                
                 </IfCondition>
-                <!-- End Layered Veins distribution of Marble -->
-                
-                <!-- End Marble Generation --> 
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Marble is complete. -->
 
-                
-                <!-- Begin Basalt Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Basalt -->
-                <IfCondition condition=':= predBasaltDist = "layeredVeins"'>
-                
-                    <Veins name='predBasaltBaseVeins' block='ProjRed|Exploration:projectred.exploration.stone:3'  inherits='PresetLayeredVeins' >
+
+            <!-- Starting Cloud Preset for Marble. -->
+            <ConfigSection>
+                <IfCondition condition=':= predMarbleDist = "Cloud"'>
+                    <Cloud name='predMarbleCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60111111</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * predBasaltSize * _default_' range=':= 1 * 1 * predBasaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * predBasaltSize * _default_' range=':= 1 * 1 * predBasaltSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * predBasaltFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Basalt Layered Veins) Settings -->
-                    <Veins name='predBasaltPrefersVeins' block='ProjRed|Exploration:projectred.exploration.stone:3'  inherits='predBasaltBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60111111</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Basalt Layered Veins) Settings -->
-                
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * predMarbleFreq ' range=':=  _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='predMarbleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
                 </IfCondition>
-                <!-- End Layered Veins distribution of Basalt -->
-                
-                <!-- End Basalt Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-        
-        </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+            </ConfigSection>
+            <!-- Cloud Preset for Marble is complete. -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+            <!-- Starting Vanilla Preset for Marble. -->
+            <ConfigSection>
+                <IfCondition condition=':= predMarbleDist = "Vanilla"'>
+                    <StandardGen name='predMarbleStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 16 * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * predMarbleFreq ' range=':=  _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Marble is complete. -->
+
+            <!-- End Marble Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Project Red" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -1,7 +1,7 @@
 <!-- =================================================================
      Custom Ore Generation "RailCraft" Module: This configuration
      covers poor iron, poor gold, poor copper, poor tin, poor lead,
-     and abyssal ores.
+     saltpeter, firestone, sulfur, and abyssal ores.
      ================================================================= -->
 
 
@@ -26,15 +26,20 @@
                     Distribution options for RailCraft Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableRailCraft' displayName='Handle RailCraft Setup?' default='true' displayState='shown_dynamic' displayGroup='groupRailCraft'>
+                <Description> Should Custom Ore Generation handle RailCraft ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle RailCraft ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='RailCraft ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Poor Iron Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='rlcrPoorIronDist' default='none'  displayState='shown' displayGroup='groupRailCraft'>
+                <OptionChoice name='rlcrPoorIronDist'  displayState=':= if(?enableRailCraft, "shown", "hidden")' displayGroup='groupRailCraft'>
                     <Description> Controls how Poor Iron is generated </Description>
                     <DisplayName>RailCraft Poor Iron</DisplayName>
-                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Large veins filled very lightly with ore.
                         </Description>
                     </Choice>
                     <Choice value='Cloud' displayValue='Strategic Cloud'>
@@ -49,11 +54,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Poor Iron is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='rlcrPoorIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                <OptionNumeric name='rlcrPoorIronFreq' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
                     <Description> Frequency multiplier for RailCraft Poor Iron distributions </Description>
                     <DisplayName>RailCraft Poor Iron Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='rlcrPoorIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                <OptionNumeric name='rlcrPoorIronSize' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
                     <Description> Size multiplier for RailCraft Poor Iron distributions </Description>
                     <DisplayName>RailCraft Poor Iron Size</DisplayName>
                 </OptionNumeric>
@@ -63,12 +68,12 @@
 
             <!-- Poor Gold Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='rlcrPoorGoldDist' default='none'  displayState='shown' displayGroup='groupRailCraft'>
+                <OptionChoice name='rlcrPoorGoldDist'  displayState=':= if(?enableRailCraft, "shown", "hidden")' displayGroup='groupRailCraft'>
                     <Description> Controls how Poor Gold is generated </Description>
                     <DisplayName>RailCraft Poor Gold</DisplayName>
-                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Large veins filled very lightly with ore.
                         </Description>
                     </Choice>
                     <Choice value='Cloud' displayValue='Strategic Cloud'>
@@ -83,11 +88,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Poor Gold is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='rlcrPoorGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                <OptionNumeric name='rlcrPoorGoldFreq' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
                     <Description> Frequency multiplier for RailCraft Poor Gold distributions </Description>
                     <DisplayName>RailCraft Poor Gold Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='rlcrPoorGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                <OptionNumeric name='rlcrPoorGoldSize' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
                     <Description> Size multiplier for RailCraft Poor Gold distributions </Description>
                     <DisplayName>RailCraft Poor Gold Size</DisplayName>
                 </OptionNumeric>
@@ -97,12 +102,12 @@
 
             <!-- Poor Copper Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='rlcrPoorCopperDist' default='none'  displayState='shown' displayGroup='groupRailCraft'>
+                <OptionChoice name='rlcrPoorCopperDist'  displayState=':= if(?enableRailCraft, "shown", "hidden")' displayGroup='groupRailCraft'>
                     <Description> Controls how Poor Copper is generated </Description>
                     <DisplayName>RailCraft Poor Copper</DisplayName>
-                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Large veins filled very lightly with ore.
                         </Description>
                     </Choice>
                     <Choice value='Cloud' displayValue='Strategic Cloud'>
@@ -117,11 +122,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Poor Copper is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='rlcrPoorCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                <OptionNumeric name='rlcrPoorCopperFreq' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
                     <Description> Frequency multiplier for RailCraft Poor Copper distributions </Description>
                     <DisplayName>RailCraft Poor Copper Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='rlcrPoorCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                <OptionNumeric name='rlcrPoorCopperSize' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
                     <Description> Size multiplier for RailCraft Poor Copper distributions </Description>
                     <DisplayName>RailCraft Poor Copper Size</DisplayName>
                 </OptionNumeric>
@@ -131,12 +136,12 @@
 
             <!-- Poor Tin Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='rlcrPoorTinDist' default='none'  displayState='shown' displayGroup='groupRailCraft'>
+                <OptionChoice name='rlcrPoorTinDist'  displayState=':= if(?enableRailCraft, "shown", "hidden")' displayGroup='groupRailCraft'>
                     <Description> Controls how Poor Tin is generated </Description>
                     <DisplayName>RailCraft Poor Tin</DisplayName>
-                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Large veins filled very lightly with ore.
                         </Description>
                     </Choice>
                     <Choice value='Cloud' displayValue='Strategic Cloud'>
@@ -151,11 +156,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Poor Tin is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='rlcrPoorTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                <OptionNumeric name='rlcrPoorTinFreq' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
                     <Description> Frequency multiplier for RailCraft Poor Tin distributions </Description>
                     <DisplayName>RailCraft Poor Tin Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='rlcrPoorTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                <OptionNumeric name='rlcrPoorTinSize' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
                     <Description> Size multiplier for RailCraft Poor Tin distributions </Description>
                     <DisplayName>RailCraft Poor Tin Size</DisplayName>
                 </OptionNumeric>
@@ -165,12 +170,12 @@
 
             <!-- Poor Lead Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='rlcrPoorLeadDist' default='none'  displayState='shown' displayGroup='groupRailCraft'>
+                <OptionChoice name='rlcrPoorLeadDist'  displayState=':= if(?enableRailCraft, "shown", "hidden")' displayGroup='groupRailCraft'>
                     <Description> Controls how Poor Lead is generated </Description>
                     <DisplayName>RailCraft Poor Lead</DisplayName>
-                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Large veins filled very lightly with ore.
                         </Description>
                     </Choice>
                     <Choice value='Cloud' displayValue='Strategic Cloud'>
@@ -185,11 +190,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Poor Lead is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='rlcrPoorLeadFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                <OptionNumeric name='rlcrPoorLeadFreq' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
                     <Description> Frequency multiplier for RailCraft Poor Lead distributions </Description>
                     <DisplayName>RailCraft Poor Lead Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='rlcrPoorLeadSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                <OptionNumeric name='rlcrPoorLeadSize' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
                     <Description> Size multiplier for RailCraft Poor Lead distributions </Description>
                     <DisplayName>RailCraft Poor Lead Size</DisplayName>
                 </OptionNumeric>
@@ -197,9 +202,111 @@
             <!-- Poor Lead Configuration UI Complete -->
 
 
+            <!-- Saltpeter Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='rlcrSaltpeterDist'  displayState=':= if(?enableRailCraft, "shown", "hidden")' displayGroup='groupRailCraft'>
+                    <Description> Controls how Saltpeter is generated </Description>
+                    <DisplayName>RailCraft Saltpeter</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
+                        <Description>
+                            Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Saltpeter is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='rlcrSaltpeterFreq' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
+                    <Description> Frequency multiplier for RailCraft Saltpeter distributions </Description>
+                    <DisplayName>RailCraft Saltpeter Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='rlcrSaltpeterSize' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
+                    <Description> Size multiplier for RailCraft Saltpeter distributions </Description>
+                    <DisplayName>RailCraft Saltpeter Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Saltpeter Configuration UI Complete -->
+
+
+            <!-- Firestone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='rlcrFirestoneDist'  displayState=':= if(?enableRailCraft, "shown", "hidden")' displayGroup='groupRailCraft'>
+                    <Description> Controls how Firestone is generated </Description>
+                    <DisplayName>RailCraft Firestone</DisplayName>
+                    <Choice value='SmallDeposits' displayValue='Small Deposits'>
+                        <Description>
+                            Small motherlodes without any branches.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Firestone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='rlcrFirestoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
+                    <Description> Frequency multiplier for RailCraft Firestone distributions </Description>
+                    <DisplayName>RailCraft Firestone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='rlcrFirestoneSize' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
+                    <Description> Size multiplier for RailCraft Firestone distributions </Description>
+                    <DisplayName>RailCraft Firestone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Firestone Configuration UI Complete -->
+
+
+            <!-- Sulfur Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='rlcrSulfurDist'  displayState=':= if(?enableRailCraft, "shown", "hidden")' displayGroup='groupRailCraft'>
+                    <Description> Controls how Sulfur is generated </Description>
+                    <DisplayName>RailCraft Sulfur</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
+                        <Description>
+                            Short and sparsely filled compound veins containing one material inside another.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Sulfur is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='rlcrSulfurFreq' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
+                    <Description> Frequency multiplier for RailCraft Sulfur distributions </Description>
+                    <DisplayName>RailCraft Sulfur Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='rlcrSulfurSize' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
+                    <Description> Size multiplier for RailCraft Sulfur distributions </Description>
+                    <DisplayName>RailCraft Sulfur Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Sulfur Configuration UI Complete -->
+
+
             <!-- Abyssal Ores Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='rlcrAbyssalOresDist'  displayState='shown' displayGroup='groupRailCraft'>
+                <OptionChoice name='rlcrAbyssalOresDist'  displayState=':= if(?enableRailCraft, "shown", "hidden")' displayGroup='groupRailCraft'>
                     <Description> Controls how Abyssal Ores is generated </Description>
                     <DisplayName>RailCraft Abyssal Ores</DisplayName>
                     <Choice value='Geode' displayValue='Geode'>
@@ -209,11 +316,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Abyssal Ores is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='rlcrAbyssalOresFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                <OptionNumeric name='rlcrAbyssalOresFreq' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
                     <Description> Frequency multiplier for RailCraft Abyssal Ores distributions </Description>
                     <DisplayName>RailCraft Abyssal Ores Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='rlcrAbyssalOresSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                <OptionNumeric name='rlcrAbyssalOresSize' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
                     <Description> Size multiplier for RailCraft Abyssal Ores distributions </Description>
                     <DisplayName>RailCraft Abyssal Ores Size</DisplayName>
                 </OptionNumeric>
@@ -223,733 +330,1182 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableRailCraft'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='rlcrOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='Railcraft:cube:6' weight='1.0' />
-                <Replaces block='Railcraft:ore:10' weight='1.0' />
-                <Replaces block='Railcraft:ore:11' weight='1.0' />
-                <Replaces block='Railcraft:ore:2' weight='1.0' />
-                <Replaces block='Railcraft:ore:3' weight='1.0' />
-                <Replaces block='Railcraft:ore:4' weight='1.0' />
-                <Replaces block='Railcraft:ore:7' weight='1.0' />
-                <Replaces block='Railcraft:ore:8' weight='1.0' />
-                <Replaces block='Railcraft:ore:9' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Poor Iron Generation -->
-
-            <!-- Starting LayeredVeins Preset for Poor Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorIronDist = "LayeredVeins"'>
-                    <Veins name='rlcrPoorIronVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                <IfCondition condition=':= ?blockExists("minecraft:sand")'>
+                    <Substitute name='rlcrOverworldBlockSubstitute0' block='minecraft:sand'>
                         <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='Railcraft:ore:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 7.921 * _default_ * rlcrPoorIronFreq ' range=':=  _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.993 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  4 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.993 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.993 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <Replaces block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Poor Iron is complete. -->
 
 
-            <!-- Starting Cloud Preset for Poor Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorIronDist = "Cloud"'>
-                    <Cloud name='rlcrPoorIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='rlcrOverworldBlockSubstitute2' block='minecraft:stone'>
                         <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='Railcraft:ore:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 2.313 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 2.313 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 5.351  * _default_ * rlcrPoorIronFreq ' range=':=  _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  4 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='rlcrPoorIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <Replaces block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <Replaces block='Railcraft:ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <Replaces block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <Replaces block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <Replaces block='Railcraft:ore:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <Replaces block='Railcraft:ore:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <Replaces block='Railcraft:ore:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <Replaces block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <Replaces block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <Replaces block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <Replaces block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
+                    </Substitute>
+                </IfCondition>
+
+                <!-- Original "Overworld" Block Removal Complete -->
+
+                <!-- Adding blocks -->
+
+                <!-- Begin Poor Iron Generation -->
+
+                <!-- Starting SparseVeins Preset for Poor Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorIronDist = "SparseVeins"'>
+                        <Veins name='rlcrPoorIronVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='Railcraft:ore:7' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 7.921 * _default_ * rlcrPoorIronFreq ' range=':=  _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.993 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.993 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.993 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Poor Iron is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Poor Iron is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Poor Iron. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorIronDist = "Vanilla"'>
-                    <StandardGen name='rlcrPoorIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 16 * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 32 * rlcrPoorIronFreq ' range=':=  _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 40 ' range=':=  4 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Poor Iron is complete. -->
-
-            <!-- End Poor Iron Generation -->
-
-
-            <!-- Begin Poor Gold Generation -->
-
-            <!-- Starting LayeredVeins Preset for Poor Gold. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorGoldDist = "LayeredVeins"'>
-                    <Veins name='rlcrPoorGoldVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:8' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.980 * _default_ * rlcrPoorGoldFreq ' range=':=  _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.256 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 15 ' range=':=  1 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.256 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.256 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Poor Gold is complete. -->
-
-
-            <!-- Starting Cloud Preset for Poor Gold. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorGoldDist = "Cloud"'>
-                    <Cloud name='rlcrPoorGoldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:8' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.157 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.157 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * rlcrPoorGoldFreq ' range=':=  _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 15 ' range=':=  1 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='rlcrPoorGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                <!-- Starting Cloud Preset for Poor Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorIronDist = "Cloud"'>
+                        <Cloud name='rlcrPoorIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Railcraft:ore:8' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Poor Gold is complete. -->
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 2.313 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.313 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.351  * _default_ * rlcrPoorIronFreq ' range=':=  _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  4 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='rlcrPoorIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Poor Iron is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Poor Gold. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorGoldDist = "Vanilla"'>
-                    <StandardGen name='rlcrPoorGoldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:8' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 32 * rlcrPoorGoldFreq ' range=':=  _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 15 ' range=':=  1 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Poor Gold is complete. -->
-
-            <!-- End Poor Gold Generation -->
-
-
-            <!-- Begin Poor Copper Generation -->
-
-            <!-- Starting LayeredVeins Preset for Poor Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorCopperDist = "LayeredVeins"'>
-                    <Veins name='rlcrPoorCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:9' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 5.601 * _default_ * rlcrPoorCopperFreq ' range=':=  _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.776 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 60 ' range=':=  3 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.776 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.776 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Poor Copper is complete. -->
-
-
-            <!-- Starting Cloud Preset for Poor Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorCopperDist = "Cloud"'>
-                    <Cloud name='rlcrPoorCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:9' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.945 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.945 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 3.784  * _default_ * rlcrPoorCopperFreq ' range=':=  _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 60 ' range=':=  3 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='rlcrPoorCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <!-- Starting Vanilla Preset for Poor Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorIronDist = "Vanilla"'>
+                        <StandardGen name='rlcrPoorIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Railcraft:ore:9' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Poor Copper is complete. -->
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 16 * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 32 * rlcrPoorIronFreq ' range=':=  _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':=  4 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Poor Iron is complete. -->
+
+                <!-- End Poor Iron Generation -->
 
 
-            <!-- Starting Vanilla Preset for Poor Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorCopperDist = "Vanilla"'>
-                    <StandardGen name='rlcrPoorCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:9' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 32 * rlcrPoorCopperFreq ' range=':=  _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 60 ' range=':=  3 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Poor Copper is complete. -->
+                <!-- Begin Poor Gold Generation -->
 
-            <!-- End Poor Copper Generation -->
-
-
-            <!-- Begin Poor Tin Generation -->
-
-            <!-- Starting LayeredVeins Preset for Poor Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorTinDist = "LayeredVeins"'>
-                    <Veins name='rlcrPoorTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:10' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.801 * _default_ * rlcrPoorTinFreq ' range=':=  _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.410 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 50 ' range=':=  2 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.410 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.410 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Poor Tin is complete. -->
-
-
-            <!-- Starting Cloud Preset for Poor Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorTinDist = "Cloud"'>
-                    <Cloud name='rlcrPoorTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:10' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.375 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.375 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * rlcrPoorTinFreq ' range=':=  _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 50 ' range=':=  2 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='rlcrPoorTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                <!-- Starting SparseVeins Preset for Poor Gold. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorGoldDist = "SparseVeins"'>
+                        <Veins name='rlcrPoorGoldVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='Railcraft:ore:10' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.980 * _default_ * rlcrPoorGoldFreq ' range=':=  _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.256 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':=  1 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.256 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.256 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Poor Tin is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Poor Gold is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Poor Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorTinDist = "Vanilla"'>
-                    <StandardGen name='rlcrPoorTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:10' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 2 * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 32 * rlcrPoorTinFreq ' range=':=  _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 50 ' range=':=  2 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Poor Tin is complete. -->
-
-            <!-- End Poor Tin Generation -->
-
-
-            <!-- Begin Poor Lead Generation -->
-
-            <!-- Starting LayeredVeins Preset for Poor Lead. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorLeadDist = "LayeredVeins"'>
-                    <Veins name='rlcrPoorLeadVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:11' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 4.851 * _default_ * rlcrPoorLeadFreq ' range=':=  _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.693 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 30 ' range=':=  3 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.693 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.693 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Poor Lead is complete. -->
-
-
-            <!-- Starting Cloud Preset for Poor Lead. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorLeadDist = "Cloud"'>
-                    <Cloud name='rlcrPoorLeadCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:11' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.810 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.810 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 3.277  * _default_ * rlcrPoorLeadFreq ' range=':=  _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 30 ' range=':=  3 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='rlcrPoorLeadHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                <!-- Starting Cloud Preset for Poor Gold. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorGoldDist = "Cloud"'>
+                        <Cloud name='rlcrPoorGoldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Railcraft:ore:11' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.157 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.157 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * rlcrPoorGoldFreq ' range=':=  _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 15 ' range=':=  1 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='rlcrPoorGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Poor Gold is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Poor Gold. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorGoldDist = "Vanilla"'>
+                        <StandardGen name='rlcrPoorGoldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 32 * rlcrPoorGoldFreq ' range=':=  _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 15 ' range=':=  1 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Poor Gold is complete. -->
+
+                <!-- End Poor Gold Generation -->
+
+
+                <!-- Begin Poor Copper Generation -->
+
+                <!-- Starting SparseVeins Preset for Poor Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorCopperDist = "SparseVeins"'>
+                        <Veins name='rlcrPoorCopperVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 5.601 * _default_ * rlcrPoorCopperFreq ' range=':=  _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.776 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 60 ' range=':=  3 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.776 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.776 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Poor Lead is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Poor Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Poor Lead. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrPoorLeadDist = "Vanilla"'>
-                    <StandardGen name='rlcrPoorLeadStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:11' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 32 * rlcrPoorLeadFreq ' range=':=  _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 30 ' range=':=  3 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Poor Lead is complete. -->
+                <!-- Starting Cloud Preset for Poor Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorCopperDist = "Cloud"'>
+                        <Cloud name='rlcrPoorCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.945 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.945 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 3.784  * _default_ * rlcrPoorCopperFreq ' range=':=  _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 60 ' range=':=  3 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='rlcrPoorCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Poor Copper is complete. -->
 
-            <!-- End Poor Lead Generation -->
+
+                <!-- Starting Vanilla Preset for Poor Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorCopperDist = "Vanilla"'>
+                        <StandardGen name='rlcrPoorCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 32 * rlcrPoorCopperFreq ' range=':=  _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 60 ' range=':=  3 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Poor Copper is complete. -->
+
+                <!-- End Poor Copper Generation -->
 
 
-            <!-- Begin Abyssal Ores Generation -->
+                <!-- Begin Poor Tin Generation -->
 
-            <!-- Starting Geode Preset for Abyssal Ores. -->
-            <ConfigSection>
-                <IfCondition condition=':= rlcrAbyssalOresDist = "Geode"'>
-                    <Veins name='rlcrAbyssalOresGeodeShell'  inherits='PresetSmallDeposits' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
-                        <Description>
-                            Multi-layered deposit.  On the  outside is
-                            a shell, usually made of  some form of
-                            stone.  Within this  shell is sprinkled
-                            ores.  Inside both  is an air pocket from
-                            which the  enterprising miner can look for
-                            the  contained ores.
-                        </Description>
-                        <OreBlock block='Railcraft:cube:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='Ocean'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.5 * rlcrAbyssalOresFreq ' range=':=  _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= _default_ * rlcrAbyssalOresSize  * 3 ' range=':=  _default_ * rlcrAbyssalOresSize  * 3 ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  4 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <Veins name='rlcrAbyssalOresGeodeOre'  inherits='rlcrAbyssalOresGeodeShell' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
-                        <Description>
-                            Multi-layered deposit.  On the  outside is
-                            a shell, usually made of  some form of
-                            stone.  Within this  shell is sprinkled
-                            ores.  Inside both  is an air pocket from
-                            which the  enterprising miner can look for
-                            the  contained ores.
-                        </Description>
-                        <OreBlock block='Railcraft:ore:2' weight='0.05' />
-                        <OreBlock block='Railcraft:ore:3' weight='0.05' />
-                        <OreBlock block='Railcraft:ore:4' weight='0.15' />
-                        <Replaces block='Railcraft:cube:6' weight='1.0' />
-                        <Biome name='Ocean'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.5 * rlcrAbyssalOresFreq ' range=':=  _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= _default_ * rlcrAbyssalOresSize  * 0.5 ' range=':=  _default_ * rlcrAbyssalOresSize  * 0.5 ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  4 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <Veins name='rlcrAbyssalOresGeodeBubble'  inherits='rlcrAbyssalOresGeodeOre' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
-                        <Description>
-                            Multi-layered deposit.  On the  outside is
-                            a shell, usually made of  some form of
-                            stone.  Within this  shell is sprinkled
-                            ores.  Inside both  is an air pocket from
-                            which the  enterprising miner can look for
-                            the  contained ores.
-                        </Description>
-                        <OreBlock block='minecraft:air' weight='1.0' />
-                        <Replaces block='Railcraft:cube:6' weight='1.0' />
-                        <Replaces block='Railcraft:ore:2' weight='1.0' />
-                        <Replaces block='Railcraft:ore:3' weight='1.0' />
-                        <Replaces block='Railcraft:ore:4' weight='1.0' />
-                        <Biome name='Ocean'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.5 * rlcrAbyssalOresFreq ' range=':=  _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= _default_ * rlcrAbyssalOresSize  * 0.5 ' range=':=  _default_ * rlcrAbyssalOresSize  * 0.5 ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  4 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                <!-- Starting SparseVeins Preset for Poor Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorTinDist = "SparseVeins"'>
+                        <Veins name='rlcrPoorTinVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.801 * _default_ * rlcrPoorTinFreq ' range=':=  _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.410 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 50 ' range=':=  2 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.410 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.410 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Poor Tin is complete. -->
 
-                    <!-- Beginning "Preferred" configuration. -->
-                </IfCondition>
-            </ConfigSection>
-            <!-- Geode Preset for Abyssal Ores is complete. -->
 
-            <!-- End Abyssal Ores Generation -->
+                <!-- Starting Cloud Preset for Poor Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorTinDist = "Cloud"'>
+                        <Cloud name='rlcrPoorTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * rlcrPoorTinFreq ' range=':=  _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 50 ' range=':=  2 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='rlcrPoorTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Poor Tin is complete. -->
 
-            <!-- Finished adding blocks -->
+
+                <!-- Starting Vanilla Preset for Poor Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorTinDist = "Vanilla"'>
+                        <StandardGen name='rlcrPoorTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 2 * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 32 * rlcrPoorTinFreq ' range=':=  _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 50 ' range=':=  2 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Poor Tin is complete. -->
+
+                <!-- End Poor Tin Generation -->
+
+
+                <!-- Begin Poor Lead Generation -->
+
+                <!-- Starting SparseVeins Preset for Poor Lead. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorLeadDist = "SparseVeins"'>
+                        <Veins name='rlcrPoorLeadVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 4.851 * _default_ * rlcrPoorLeadFreq ' range=':=  _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.693 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':=  3 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.693 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.693 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Poor Lead is complete. -->
+
+
+                <!-- Starting Cloud Preset for Poor Lead. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorLeadDist = "Cloud"'>
+                        <Cloud name='rlcrPoorLeadCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.810 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.810 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 3.277  * _default_ * rlcrPoorLeadFreq ' range=':=  _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 30 ' range=':=  3 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='rlcrPoorLeadHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Poor Lead is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Poor Lead. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrPoorLeadDist = "Vanilla"'>
+                        <StandardGen name='rlcrPoorLeadStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 32 * rlcrPoorLeadFreq ' range=':=  _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 30 ' range=':=  3 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Poor Lead is complete. -->
+
+                <!-- End Poor Lead Generation -->
+
+
+                <!-- Begin Saltpeter Generation -->
+
+                <!-- Starting SparseVeins Preset for Saltpeter. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrSaltpeterDist = "SparseVeins"'>
+                        <Veins name='rlcrSaltpeterVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60CED0BA' drawBoundBox='false' boundBoxColor='0x60CED0BA'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.801 * _default_ * rlcrSaltpeterFreq ' range=':=  _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.410 * _default_ * rlcrSaltpeterSize ' range=':=  _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 75 ' range=':=  25 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.410 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrSaltpeterSize ' range=':=  _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.410 * _default_ * rlcrSaltpeterSize ' range=':=  _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Saltpeter is complete. -->
+
+
+                <!-- Starting Cloud Preset for Saltpeter. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrSaltpeterDist = "Cloud"'>
+                        <Cloud name='rlcrSaltpeterCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CED0BA' drawBoundBox='false' boundBoxColor='0x60CED0BA'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * rlcrSaltpeterSize ' range=':=  _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * rlcrSaltpeterSize ' range=':=  _default_ * rlcrSaltpeterSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * rlcrSaltpeterFreq ' range=':=  _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 75 ' range=':=  25 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='rlcrSaltpeterHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CED0BA' drawBoundBox='false' boundBoxColor='0x60CED0BA'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Saltpeter is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Saltpeter. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrSaltpeterDist = "Vanilla"'>
+                        <StandardGen name='rlcrSaltpeterStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60CED0BA' drawBoundBox='false' boundBoxColor='0x60CED0BA'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
+                            <Setting name='Size' avg=':= 1 * rlcrSaltpeterSize ' range=':=  _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 64 * rlcrSaltpeterFreq ' range=':=  _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 75 ' range=':=  25 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Saltpeter is complete. -->
+
+                <!-- End Saltpeter Generation -->
+
+
+                <!-- Begin Firestone Generation -->
+
+                <!-- Starting SmallDeposits Preset for Firestone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrFirestoneDist = "SmallDeposits"'>
+                        <Veins name='rlcrFirestoneVeins'  inherits='PresetSmallDeposits' drawWireframe='true' wireframeColor='0x60C64E0D' drawBoundBox='false' boundBoxColor='0x60C64E0D'>
+                            <Description>
+                                Small motherlodes without any
+                                branches.  Similar to the  deposits
+                                produced by StandardGen
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.191 * _default_ * rlcrFirestoneFreq ' range=':=  _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.576 * _default_ * rlcrFirestoneSize ' range=':=  _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  15 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.576 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrFirestoneSize ' range=':=  _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.576 * _default_ * rlcrFirestoneSize ' range=':=  _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SmallDeposits Preset for Firestone is complete. -->
+
+
+                <!-- Starting Cloud Preset for Firestone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrFirestoneDist = "Cloud"'>
+                        <Cloud name='rlcrFirestoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C64E0D' drawBoundBox='false' boundBoxColor='0x60C64E0D'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * rlcrFirestoneSize ' range=':=  _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * rlcrFirestoneSize ' range=':=  _default_ * rlcrFirestoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * rlcrFirestoneFreq ' range=':=  _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':=  15 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='rlcrFirestoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C64E0D' drawBoundBox='false' boundBoxColor='0x60C64E0D'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Firestone is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Firestone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrFirestoneDist = "Vanilla"'>
+                        <StandardGen name='rlcrFirestoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C64E0D' drawBoundBox='false' boundBoxColor='0x60C64E0D'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * rlcrFirestoneSize ' range=':=  _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * rlcrFirestoneFreq ' range=':=  _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':=  15 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Firestone is complete. -->
+
+                <!-- End Firestone Generation -->
+
+
+                <!-- Begin Sulfur Generation -->
+
+                <!-- Starting PipeVeins Preset for Sulfur. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrSulfurDist = "PipeVeins"'>
+                        <Veins name='rlcrSulfurVeins'  inherits='PresetPipeVeins' seed='0x504F' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
+                            <Description>
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.872 * _default_ * rlcrSulfurFreq ' range=':=  _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.956 * _default_ * rlcrSulfurSize ' range=':=  _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.956 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrSulfurSize ' range=':=  _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.956 * _default_ * rlcrSulfurSize ' range=':=  _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='rlcrSulfurVeinsPipe'  inherits='rlcrSulfurVeins' seed='0x504F' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <Replaces block='Railcraft:ore' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.956 * _default_ * rlcrSulfurSize  * 0.5 ' range=':=  _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.956 * _default_ * rlcrSulfurSize  * 0.5 ' range=':=  _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Sulfur is complete. -->
+
+
+                <!-- Starting Cloud Preset for Sulfur. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrSulfurDist = "Cloud"'>
+                        <Cloud name='rlcrSulfurCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.223 * _default_ * rlcrSulfurSize ' range=':=  _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.223 * _default_ * rlcrSulfurSize ' range=':=  _default_ * rlcrSulfurSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.496  * _default_ * rlcrSulfurFreq ' range=':=  _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='rlcrSulfurHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Sulfur is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Sulfur. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrSulfurDist = "Vanilla"'>
+                        <StandardGen name='rlcrSulfurStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 10 * rlcrSulfurSize ' range=':=  _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * rlcrSulfurFreq ' range=':=  _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Sulfur is complete. -->
+
+                <!-- End Sulfur Generation -->
+
+
+                <!-- Begin Abyssal Ores Generation -->
+
+                <!-- Starting Geode Preset for Abyssal Ores. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrAbyssalOresDist = "Geode"'>
+                        <Veins name='rlcrAbyssalOresGeodeShell'  inherits='PresetSmallDeposits' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
+                            <Description>
+                                Multi-layered deposit.  On the
+                                outside is a shell, usually made  of
+                                some form of stone.  Within  this
+                                shell is sprinkled ores.  Inside both
+                                is an air pocket from  which the
+                                enterprising miner can  look for the
+                                contained ores.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <OreBlock block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='Ocean'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.5 * rlcrAbyssalOresFreq ' range=':=  _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= _default_ * rlcrAbyssalOresSize  * 3 ' range=':=  _default_ * rlcrAbyssalOresSize  * 3 ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                        <Veins name='rlcrAbyssalOresGeodeOre'  inherits='rlcrAbyssalOresGeodeShell' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
+                            <Description>
+                                Multi-layered deposit.  On the
+                                outside is a shell, usually made  of
+                                some form of stone.  Within  this
+                                shell is sprinkled ores.  Inside both
+                                is an air pocket from  which the
+                                enterprising miner can  look for the
+                                contained ores.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <OreBlock block='Railcraft:ore:2' weight='0.05' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <OreBlock block='Railcraft:ore:3' weight='0.05' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <OreBlock block='Railcraft:ore:4' weight='0.15' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <Replaces block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
+                            <Biome name='Ocean'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.5 * rlcrAbyssalOresFreq ' range=':=  _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= _default_ * rlcrAbyssalOresSize  * 0.5 ' range=':=  _default_ * rlcrAbyssalOresSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                        <Veins name='rlcrAbyssalOresGeodeBubble'  inherits='rlcrAbyssalOresGeodeOre' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
+                            <Description>
+                                Multi-layered deposit.  On the
+                                outside is a shell, usually made  of
+                                some form of stone.  Within  this
+                                shell is sprinkled ores.  Inside both
+                                is an air pocket from  which the
+                                enterprising miner can  look for the
+                                contained ores.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:air")'> <OreBlock block='minecraft:air' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <Replaces block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <Replaces block='Railcraft:ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <Replaces block='Railcraft:ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <Replaces block='Railcraft:ore:4' weight='1.0' /> </IfCondition>
+                            <Biome name='Ocean'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.5 * rlcrAbyssalOresFreq ' range=':=  _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= _default_ * rlcrAbyssalOresSize  * 0.5 ' range=':=  _default_ * rlcrAbyssalOresSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Geode Preset for Abyssal Ores is complete. -->
+
+                <!-- End Abyssal Ores Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -1,1824 +1,970 @@
- <!-- ================================================================
-      Custom Ore Generation "RailCraft" Module: This configuration
-      covers quarry stone, sulfur, poor iron, poor gold, poor copper,
-      poor tin,  poor lead, saltpeter, abyssal ores, and firestone.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "RailCraft" Module: This configuration
+     covers poor iron, poor gold, poor copper, poor tin, poor lead,
+     and abyssal ores.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="Railcraft">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "RailCraft" mod on the system?  Let's find out! -->
+<IfModInstalled name="Railcraft">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupRailCraft' displayName='RailCraft' displayState='shown'>
+                <Description>
+                    Distribution options for RailCraft Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Poor Iron Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupRailCraft' displayName='RailCraft' displayState='shown'> 
-                    <Description>
-                        Distribution options for RailCraft Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Quarry Stone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='rlcrQuarryStoneDist'  displayState='shown' displayGroup='groupRailCraft'> 
-                        <Description> Controls how Quarry Stone is generated </Description> 
-                        <DisplayName>RailCraft Quarry Stone</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Quarry Stone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='rlcrQuarryStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Frequency multiplier for RailCraft Quarry Stone distributions </Description>
-                        <DisplayName>RailCraft Quarry Stone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='rlcrQuarryStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Size multiplier for RailCraft Quarry Stone distributions </Description>
-                        <DisplayName>RailCraft Quarry Stone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Quarry Stone Configuration UI Complete -->
-                
-                
-                <!-- Sulfur Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='rlcrSulfurDist'  displayState='shown' displayGroup='groupRailCraft'> 
-                        <Description> Controls how Sulfur is generated </Description> 
-                        <DisplayName>RailCraft Sulfur</DisplayName>
-                        <Choice value='pipeVeins' displayValue='Pipe Veins'>
-                            <Description>
-                                Pipe Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Sulfur is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='rlcrSulfurFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Frequency multiplier for RailCraft Sulfur distributions </Description>
-                        <DisplayName>RailCraft Sulfur Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='rlcrSulfurSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Size multiplier for RailCraft Sulfur distributions </Description>
-                        <DisplayName>RailCraft Sulfur Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Sulfur Configuration UI Complete -->
-                
-                
-                <!-- Poor Iron Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='rlcrPoorIronDist'  displayState='shown' displayGroup='groupRailCraft'> 
-                        <Description> Controls how Poor Iron is generated </Description> 
-                        <DisplayName>RailCraft Poor Iron</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Poor Iron is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='rlcrPoorIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Frequency multiplier for RailCraft Poor Iron distributions </Description>
-                        <DisplayName>RailCraft Poor Iron Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='rlcrPoorIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Size multiplier for RailCraft Poor Iron distributions </Description>
-                        <DisplayName>RailCraft Poor Iron Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Poor Iron Configuration UI Complete -->
-                
-                
-                <!-- Poor Gold Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='rlcrPoorGoldDist'  displayState='shown' displayGroup='groupRailCraft'> 
-                        <Description> Controls how Poor Gold is generated </Description> 
-                        <DisplayName>RailCraft Poor Gold</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Poor Gold is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='rlcrPoorGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Frequency multiplier for RailCraft Poor Gold distributions </Description>
-                        <DisplayName>RailCraft Poor Gold Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='rlcrPoorGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Size multiplier for RailCraft Poor Gold distributions </Description>
-                        <DisplayName>RailCraft Poor Gold Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Poor Gold Configuration UI Complete -->
-                
-                
-                <!-- Poor Copper Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='rlcrPoorCopperDist'  displayState='shown' displayGroup='groupRailCraft'> 
-                        <Description> Controls how Poor Copper is generated </Description> 
-                        <DisplayName>RailCraft Poor Copper</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Poor Copper is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='rlcrPoorCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Frequency multiplier for RailCraft Poor Copper distributions </Description>
-                        <DisplayName>RailCraft Poor Copper Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='rlcrPoorCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Size multiplier for RailCraft Poor Copper distributions </Description>
-                        <DisplayName>RailCraft Poor Copper Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Poor Copper Configuration UI Complete -->
-                
-                
-                <!-- Poor Tin Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='rlcrPoorTinDist'  displayState='shown' displayGroup='groupRailCraft'> 
-                        <Description> Controls how Poor Tin is generated </Description> 
-                        <DisplayName>RailCraft Poor Tin</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Poor Tin is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='rlcrPoorTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Frequency multiplier for RailCraft Poor Tin distributions </Description>
-                        <DisplayName>RailCraft Poor Tin Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='rlcrPoorTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Size multiplier for RailCraft Poor Tin distributions </Description>
-                        <DisplayName>RailCraft Poor Tin Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Poor Tin Configuration UI Complete -->
-                
-                
-                <!-- Poor Lead Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='rlcrPoorLeadDist'  displayState='shown' displayGroup='groupRailCraft'> 
-                        <Description> Controls how Poor Lead is generated </Description> 
-                        <DisplayName>RailCraft Poor Lead</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Poor Lead is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='rlcrPoorLeadFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Frequency multiplier for RailCraft Poor Lead distributions </Description>
-                        <DisplayName>RailCraft Poor Lead Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='rlcrPoorLeadSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Size multiplier for RailCraft Poor Lead distributions </Description>
-                        <DisplayName>RailCraft Poor Lead Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Poor Lead Configuration UI Complete -->
-                
-                
-                <!-- Saltpeter Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='rlcrSaltpeterDist'  displayState='shown' displayGroup='groupRailCraft'> 
-                        <Description> Controls how Saltpeter is generated </Description> 
-                        <DisplayName>RailCraft Saltpeter</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Saltpeter is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='rlcrSaltpeterFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Frequency multiplier for RailCraft Saltpeter distributions </Description>
-                        <DisplayName>RailCraft Saltpeter Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='rlcrSaltpeterSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Size multiplier for RailCraft Saltpeter distributions </Description>
-                        <DisplayName>RailCraft Saltpeter Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Saltpeter Configuration UI Complete -->
-                
-                
-                <!-- Abyssal Ores Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='rlcrAbyssalOresDist'  displayState='shown' displayGroup='groupRailCraft'> 
-                        <Description> Controls how Abyssal Ores is generated </Description> 
-                        <DisplayName>RailCraft Abyssal Ores</DisplayName>
-                        <Choice value='geodes' displayValue='Geodes'>
-                            <Description>
-                                Geodes.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Abyssal Ores is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='rlcrAbyssalOresFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Frequency multiplier for RailCraft Abyssal Ores distributions </Description>
-                        <DisplayName>RailCraft Abyssal Ores Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='rlcrAbyssalOresSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Size multiplier for RailCraft Abyssal Ores distributions </Description>
-                        <DisplayName>RailCraft Abyssal Ores Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Abyssal Ores Configuration UI Complete -->
-                
-                
-                <!-- Firestone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='rlcrFirestoneDist'  displayState='shown' displayGroup='groupRailCraft'> 
-                        <Description> Controls how Firestone is generated </Description> 
-                        <DisplayName>RailCraft Firestone</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Firestone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='rlcrFirestoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Frequency multiplier for RailCraft Firestone distributions </Description>
-                        <DisplayName>RailCraft Firestone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='rlcrFirestoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
-                        <Description> Size multiplier for RailCraft Firestone distributions </Description>
-                        <DisplayName>RailCraft Firestone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Firestone Configuration UI Complete -->
-                
+                <OptionChoice name='rlcrPoorIronDist' default='none'  displayState='shown' displayGroup='groupRailCraft'>
+                    <Description> Controls how Poor Iron is generated </Description>
+                    <DisplayName>RailCraft Poor Iron</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Poor Iron is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='rlcrPoorIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                    <Description> Frequency multiplier for RailCraft Poor Iron distributions </Description>
+                    <DisplayName>RailCraft Poor Iron Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='rlcrPoorIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                    <Description> Size multiplier for RailCraft Poor Iron distributions </Description>
+                    <DisplayName>RailCraft Poor Iron Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Poor Iron Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='rlcrOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='Railcraft:cube:7' />
-                    <Replaces block='Railcraft:ore' />
-                    <Replaces block='Railcraft:ore:7' />
-                    <Replaces block='Railcraft:ore:8' />
-                    <Replaces block='Railcraft:ore:9' />
-                    <Replaces block='Railcraft:ore:10' />
-                    <Replaces block='Railcraft:ore:11' />
-                    <Replaces block='Railcraft:ore:2' />
-                    <Replaces block='Railcraft:cube:6' />
-                </Substitute>
-                <Substitute name='rlcrOverworldOreSubstitute1' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='Railcraft:ore:1' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Quarry Stone Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Quarry Stone -->
-                <IfCondition condition=':= rlcrQuarryStoneDist = "layeredVeins"'>
-                
-                    <Veins name='rlcrQuarryStoneBaseVeins' block='Railcraft:cube:7'  inherits='PresetLayeredVeins' >
+            <!-- Poor Gold Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='rlcrPoorGoldDist' default='none'  displayState='shown' displayGroup='groupRailCraft'>
+                    <Description> Controls how Poor Gold is generated </Description>
+                    <DisplayName>RailCraft Poor Gold</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFFFFF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * rlcrQuarryStoneSize * _default_' range=':= 1 * 1 * rlcrQuarryStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * rlcrQuarryStoneSize * _default_' range=':= 1 * 1 * rlcrQuarryStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * rlcrQuarryStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Quarry Stone Layered Veins) Settings -->
-                    <Veins name='rlcrQuarryStonePrefersVeins' block='Railcraft:cube:7'  inherits='rlcrQuarryStoneBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFFFFF</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Quarry Stone Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Quarry Stone -->
-                
-                <!-- End Quarry Stone Generation --> 
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Poor Gold is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='rlcrPoorGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                    <Description> Frequency multiplier for RailCraft Poor Gold distributions </Description>
+                    <DisplayName>RailCraft Poor Gold Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='rlcrPoorGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                    <Description> Size multiplier for RailCraft Poor Gold distributions </Description>
+                    <DisplayName>RailCraft Poor Gold Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Poor Gold Configuration UI Complete -->
 
-                
-                <!-- Begin Sulfur Generation --> 
-                
-                <!-- Begin PipeVeins distribution of Sulfur -->
-                <IfCondition condition=':= rlcrSulfurDist = "pipeVeins"'>
-                
-                    <Veins name='rlcrSulfurBaseVeins' block='Railcraft:ore'  inherits='PresetPipeVeins' seed='0x68D1'>
-                        <Description>
-                            Short sparsely filled veins sloping up
-                            from near the bottom of the map.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFE25C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * rlcrSulfurSize * _default_' range=':= 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * rlcrSulfurSize * _default_' range=':= 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * rlcrSulfurFreq * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Pipe Filling (Sulfur Pipe Veins) Settings -->
-                    <Veins name='rlcrSulfurPipeVeins' block='Railcraft:cube:6'  inherits='rlcrSulfurBaseVeins' seed='0x68D1'>
-                        <Description>
-                            Fills the vein with an additional material
-                            (Railcraft:cube:6).
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFE25C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * 1 * rlcrSulfurSize * _default_' range=':= 0.5 * 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Setting name='SegmentRadius' avg=':= 0.5 * 1 * 1 * rlcrSulfurSize * _default_' range=':= 0.5 * 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='Railcraft:ore'/>
-                        <Replaces block='minecraft:dirt'/>
-                        <Replaces block='minecraft:stone'/>
-                        <Replaces block='minecraft:gravel'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        <Replaces block='minecraft:end_stone'/>
-                    </Veins>
-                    <!-- End Pipe Filling (Sulfur Pipe Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End PipeVeins distribution of Sulfur -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Sulfur -->
-                <IfCondition condition=':= rlcrSulfurDist = "hugeVeins"'>
-                
-                    <Veins name='rlcrSulfurBaseVeins' block='Railcraft:ore'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFE25C</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * rlcrSulfurSize * _default_' range=':= 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 3' range=':= _default_' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * rlcrSulfurSize * _default_' range=':= 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * rlcrSulfurFreq * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Sulfur -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Sulfur -->
-                <IfCondition condition=':= rlcrSulfurDist = "strategicCloud"'>
-                
-                    <Cloud name='rlcrSulfurBaseCloud' block='Railcraft:ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFE25C</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * rlcrSulfurSize * _default_' range=':= 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * rlcrSulfurSize * _default_' range=':= 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * rlcrSulfurSize * _default_' range=':= 1 * 1 * 1 * rlcrSulfurSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * rlcrSulfurFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                        
-                        <!-- Begin Sulfur Strategic Cloud Hint Veins -->
-                        <Veins name='rlcrSulfurBaseHintVeins' block='Railcraft:ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FFE25C</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                        </Veins>
-                        <!-- End Sulfur Strategic Cloud Hint Veins -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Sulfur -->
-                
-                
-                <!-- Begin  Vanilla distribution of Sulfur -->
-                <IfCondition condition=':= rlcrSulfurDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='rlcrSulfurBaseStandard' block='Railcraft:ore' inherits='PresetStandardGen'>
+            <!-- Poor Copper Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='rlcrPoorCopperDist' default='none'  displayState='shown' displayGroup='groupRailCraft'>
+                    <Description> Controls how Poor Copper is generated </Description>
+                    <DisplayName>RailCraft Poor Copper</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            This mimics vanilla ore generation.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFE25C</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * rlcrSulfurSize * _default_'/>
-                        <Setting name='Height' avg=':= 8' range=':= _default_' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.025 * rlcrSulfurFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Sulfur -->
-                
-                <!-- End Sulfur Generation --> 
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Poor Copper is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='rlcrPoorCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                    <Description> Frequency multiplier for RailCraft Poor Copper distributions </Description>
+                    <DisplayName>RailCraft Poor Copper Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='rlcrPoorCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                    <Description> Size multiplier for RailCraft Poor Copper distributions </Description>
+                    <DisplayName>RailCraft Poor Copper Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Poor Copper Configuration UI Complete -->
 
-                
-                <!-- Begin Poor Iron Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Poor Iron -->
-                <IfCondition condition=':= rlcrPoorIronDist = "layeredVeins"'>
-                
-                    <Veins name='rlcrPoorIronBaseVeins' block='Railcraft:ore:7'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrPoorIronSize * _default_' range=':= 3 * 1 * rlcrPoorIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrPoorIronSize * _default_' range=':= 3 * 1 * rlcrPoorIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorIronFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Poor Iron Layered Veins) Settings -->
-                    <Veins name='rlcrPoorIronPrefersVeins' block='Railcraft:ore:7'  inherits='rlcrPoorIronBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Poor Iron Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Poor Iron -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Poor Iron -->
-                <IfCondition condition=':= rlcrPoorIronDist = "hugeVeins"'>
-                
-                    <Veins name='rlcrPoorIronBaseVeins' block='Railcraft:ore:7'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrPoorIronSize * _default_' range=':= 3 * 1 * rlcrPoorIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrPoorIronSize * _default_' range=':= 3 * 1 * rlcrPoorIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorIronFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Poor Iron Huge Veins) Settings -->
-                    <Veins name='rlcrPoorIronPrefersVeins' block='Railcraft:ore:7'  inherits='rlcrPoorIronBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Poor Iron Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Poor Iron -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Poor Iron -->
-                <IfCondition condition=':= rlcrPoorIronDist = "strategicCloud"'>
-                
-                    <Cloud name='rlcrPoorIronBaseCloud' block='Railcraft:ore:7' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 3 * 1 * rlcrPoorIronSize * _default_' range=':= 3 * 1 * rlcrPoorIronSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * rlcrPoorIronSize * _default_' range=':= 3 * 1 * rlcrPoorIronSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * 1 * rlcrPoorIronSize * _default_' range=':= 3 * 1 * 1 * rlcrPoorIronSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * rlcrPoorIronFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Poor Iron Strategic Cloud Hint Veins -->
-                        <Veins name='rlcrPoorIronBaseHintVeins' block='Railcraft:ore:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDC2AF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Poor Iron Strategic Cloud Hint Veins -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Poor Iron -->
-                
-                
-                <!-- Begin  Vanilla distribution of Poor Iron -->
-                <IfCondition condition=':= rlcrPoorIronDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='rlcrPoorIronBaseStandard' block='Railcraft:ore:7' inherits='PresetStandardGen'>
+            <!-- Poor Tin Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='rlcrPoorTinDist' default='none'  displayState='shown' displayGroup='groupRailCraft'>
+                    <Description> Controls how Poor Tin is generated </Description>
+                    <DisplayName>RailCraft Poor Tin</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            This mimics vanilla ore generation.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='Size' avg=':= 3 * 1 * rlcrPoorIronSize * _default_'/>
-                        <Setting name='Height' avg=':= 32' range=':= 32' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * rlcrPoorIronFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Poor Iron -->
-                
-                <!-- End Poor Iron Generation --> 
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Poor Tin is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='rlcrPoorTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                    <Description> Frequency multiplier for RailCraft Poor Tin distributions </Description>
+                    <DisplayName>RailCraft Poor Tin Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='rlcrPoorTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                    <Description> Size multiplier for RailCraft Poor Tin distributions </Description>
+                    <DisplayName>RailCraft Poor Tin Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Poor Tin Configuration UI Complete -->
 
-                
-                <!-- Begin Poor Gold Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Poor Gold -->
-                <IfCondition condition=':= rlcrPoorGoldDist = "layeredVeins"'>
-                
-                    <Veins name='rlcrPoorGoldBaseVeins' block='Railcraft:ore:8'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 0.8 * rlcrPoorGoldSize * _default_' range=':= 3 * 0.8 * rlcrPoorGoldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 0.8 * rlcrPoorGoldSize * _default_' range=':= 3 * 0.8 * rlcrPoorGoldSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * rlcrPoorGoldFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Poor Gold Layered Veins) Settings -->
-                    <Veins name='rlcrPoorGoldPrefersVeins' block='Railcraft:ore:8'  inherits='rlcrPoorGoldBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Poor Gold Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Poor Gold -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Poor Gold -->
-                <IfCondition condition=':= rlcrPoorGoldDist = "hugeVeins"'>
-                
-                    <Veins name='rlcrPoorGoldBaseVeins' block='Railcraft:ore:8'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 0.8 * rlcrPoorGoldSize * _default_' range=':= 3 * 0.8 * rlcrPoorGoldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 0.8 * rlcrPoorGoldSize * _default_' range=':= 3 * 0.8 * rlcrPoorGoldSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * rlcrPoorGoldFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Poor Gold Huge Veins) Settings -->
-                    <Veins name='rlcrPoorGoldPrefersVeins' block='Railcraft:ore:8'  inherits='rlcrPoorGoldBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Poor Gold Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Poor Gold -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Poor Gold -->
-                <IfCondition condition=':= rlcrPoorGoldDist = "strategicCloud"'>
-                
-                    <Cloud name='rlcrPoorGoldBaseCloud' block='Railcraft:ore:8' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 3 * 0.8 * rlcrPoorGoldSize * _default_' range=':= 3 * 0.8 * rlcrPoorGoldSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 0.8 * rlcrPoorGoldSize * _default_' range=':= 3 * 0.8 * rlcrPoorGoldSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 16' range=':= 16' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 0.8 * 0.8 * rlcrPoorGoldSize * _default_' range=':= 3 * 0.8 * 0.8 * rlcrPoorGoldSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * rlcrPoorGoldFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Poor Gold Strategic Cloud Hint Veins -->
-                        <Veins name='rlcrPoorGoldBaseHintVeins' block='Railcraft:ore:8' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EAEF57</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Poor Gold Strategic Cloud Hint Veins -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Poor Gold -->
-                
-                
-                <!-- Begin  Vanilla distribution of Poor Gold -->
-                <IfCondition condition=':= rlcrPoorGoldDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='rlcrPoorGoldBaseStandard' block='Railcraft:ore:8' inherits='PresetStandardGen'>
+            <!-- Poor Lead Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='rlcrPoorLeadDist' default='none'  displayState='shown' displayGroup='groupRailCraft'>
+                    <Description> Controls how Poor Lead is generated </Description>
+                    <DisplayName>RailCraft Poor Lead</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            This mimics vanilla ore generation.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='Size' avg=':= 3 * 1 * rlcrPoorGoldSize * _default_'/>
-                        <Setting name='Height' avg=':= 16' range=':= 16' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * rlcrPoorGoldFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Poor Gold -->
-                
-                <!-- End Poor Gold Generation --> 
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Poor Lead is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='rlcrPoorLeadFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                    <Description> Frequency multiplier for RailCraft Poor Lead distributions </Description>
+                    <DisplayName>RailCraft Poor Lead Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='rlcrPoorLeadSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                    <Description> Size multiplier for RailCraft Poor Lead distributions </Description>
+                    <DisplayName>RailCraft Poor Lead Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Poor Lead Configuration UI Complete -->
 
-                
-                <!-- Begin Poor Copper Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Poor Copper -->
-                <IfCondition condition=':= rlcrPoorCopperDist = "layeredVeins"'>
-                
-                    <Veins name='rlcrPoorCopperBaseVeins' block='Railcraft:ore:9'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrPoorCopperSize * _default_' range=':= 3 * 1 * rlcrPoorCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrPoorCopperSize * _default_' range=':= 3 * 1 * rlcrPoorCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorCopperFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Poor Copper Layered Veins) Settings -->
-                    <Veins name='rlcrPoorCopperPrefersVeins' block='Railcraft:ore:9'  inherits='rlcrPoorCopperBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Poor Copper Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Poor Copper -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Poor Copper -->
-                <IfCondition condition=':= rlcrPoorCopperDist = "hugeVeins"'>
-                
-                    <Veins name='rlcrPoorCopperBaseVeins' block='Railcraft:ore:9'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrPoorCopperSize * _default_' range=':= 3 * 1 * rlcrPoorCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrPoorCopperSize * _default_' range=':= 3 * 1 * rlcrPoorCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorCopperFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Poor Copper Huge Veins) Settings -->
-                    <Veins name='rlcrPoorCopperPrefersVeins' block='Railcraft:ore:9'  inherits='rlcrPoorCopperBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Poor Copper Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Poor Copper -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Poor Copper -->
-                <IfCondition condition=':= rlcrPoorCopperDist = "strategicCloud"'>
-                
-                    <Cloud name='rlcrPoorCopperBaseCloud' block='Railcraft:ore:9' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 3 * 1 * rlcrPoorCopperSize * _default_' range=':= 3 * 1 * rlcrPoorCopperSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * rlcrPoorCopperSize * _default_' range=':= 3 * 1 * rlcrPoorCopperSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * 1 * rlcrPoorCopperSize * _default_' range=':= 3 * 1 * 1 * rlcrPoorCopperSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * rlcrPoorCopperFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Poor Copper Strategic Cloud Hint Veins -->
-                        <Veins name='rlcrPoorCopperBaseHintVeins' block='Railcraft:ore:9' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Poor Copper Strategic Cloud Hint Veins -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Poor Copper -->
-                
-                
-                <!-- Begin  Vanilla distribution of Poor Copper -->
-                <IfCondition condition=':= rlcrPoorCopperDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='rlcrPoorCopperBaseStandard' block='Railcraft:ore:9' inherits='PresetStandardGen'>
+            <!-- Abyssal Ores Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='rlcrAbyssalOresDist'  displayState='shown' displayGroup='groupRailCraft'>
+                    <Description> Controls how Abyssal Ores is generated </Description>
+                    <DisplayName>RailCraft Abyssal Ores</DisplayName>
+                    <Choice value='Geode' displayValue='Geode'>
                         <Description>
-                            This mimics vanilla ore generation.
+                            Multi-layered deposit in a spherical shape.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='Size' avg=':= 3 * 1 * rlcrPoorCopperSize * _default_'/>
-                        <Setting name='Height' avg=':= 32' range=':= 32' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * rlcrPoorCopperFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Poor Copper -->
-                
-                <!-- End Poor Copper Generation --> 
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Abyssal Ores is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='rlcrAbyssalOresFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                    <Description> Frequency multiplier for RailCraft Abyssal Ores distributions </Description>
+                    <DisplayName>RailCraft Abyssal Ores Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='rlcrAbyssalOresSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupRailCraft'>
+                    <Description> Size multiplier for RailCraft Abyssal Ores distributions </Description>
+                    <DisplayName>RailCraft Abyssal Ores Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Abyssal Ores Configuration UI Complete -->
 
-                
-                <!-- Begin Poor Tin Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Poor Tin -->
-                <IfCondition condition=':= rlcrPoorTinDist = "layeredVeins"'>
-                
-                    <Veins name='rlcrPoorTinBaseVeins' block='Railcraft:ore:10'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrPoorTinSize * _default_' range=':= 3 * 1 * rlcrPoorTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrPoorTinSize * _default_' range=':= 3 * 1 * rlcrPoorTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorTinFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Poor Tin Layered Veins) Settings -->
-                    <Veins name='rlcrPoorTinPrefersVeins' block='Railcraft:ore:10'  inherits='rlcrPoorTinBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Poor Tin Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Poor Tin -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Poor Tin -->
-                <IfCondition condition=':= rlcrPoorTinDist = "hugeVeins"'>
-                
-                    <Veins name='rlcrPoorTinBaseVeins' block='Railcraft:ore:10'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrPoorTinSize * _default_' range=':= 3 * 1 * rlcrPoorTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrPoorTinSize * _default_' range=':= 3 * 1 * rlcrPoorTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorTinFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Poor Tin Huge Veins) Settings -->
-                    <Veins name='rlcrPoorTinPrefersVeins' block='Railcraft:ore:10'  inherits='rlcrPoorTinBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Poor Tin Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Poor Tin -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Poor Tin -->
-                <IfCondition condition=':= rlcrPoorTinDist = "strategicCloud"'>
-                
-                    <Cloud name='rlcrPoorTinBaseCloud' block='Railcraft:ore:10' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 3 * 1 * rlcrPoorTinSize * _default_' range=':= 3 * 1 * rlcrPoorTinSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * rlcrPoorTinSize * _default_' range=':= 3 * 1 * rlcrPoorTinSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * 1 * rlcrPoorTinSize * _default_' range=':= 3 * 1 * 1 * rlcrPoorTinSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * rlcrPoorTinFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Poor Tin Strategic Cloud Hint Veins -->
-                        <Veins name='rlcrPoorTinBaseHintVeins' block='Railcraft:ore:10' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Poor Tin Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Poor Tin -->
-                
-                
-                <!-- Begin  Vanilla distribution of Poor Tin -->
-                <IfCondition condition=':= rlcrPoorTinDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='rlcrPoorTinBaseStandard' block='Railcraft:ore:10' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='Size' avg=':= 3 * 1 * rlcrPoorTinSize * _default_'/>
-                        <Setting name='Height' avg=':= 32' range=':= 32' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * rlcrPoorTinFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Poor Tin -->
-                
-                <!-- End Poor Tin Generation --> 
-
-                
-                <!-- Begin Poor Lead Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Poor Lead -->
-                <IfCondition condition=':= rlcrPoorLeadDist = "layeredVeins"'>
-                
-                    <Veins name='rlcrPoorLeadBaseVeins' block='Railcraft:ore:11'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrPoorLeadSize * _default_' range=':= 3 * 1 * rlcrPoorLeadSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrPoorLeadSize * _default_' range=':= 3 * 1 * rlcrPoorLeadSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorLeadFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Poor Lead Layered Veins) Settings -->
-                    <Veins name='rlcrPoorLeadPrefersVeins' block='Railcraft:ore:11'  inherits='rlcrPoorLeadBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Poor Lead Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Poor Lead -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Poor Lead -->
-                <IfCondition condition=':= rlcrPoorLeadDist = "hugeVeins"'>
-                
-                    <Veins name='rlcrPoorLeadBaseVeins' block='Railcraft:ore:11'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrPoorLeadSize * _default_' range=':= 3 * 1 * rlcrPoorLeadSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 43' range=':= 10.5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrPoorLeadSize * _default_' range=':= 3 * 1 * rlcrPoorLeadSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * rlcrPoorLeadFreq * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Poor Lead Huge Veins) Settings -->
-                    <Veins name='rlcrPoorLeadPrefersVeins' block='Railcraft:ore:11'  inherits='rlcrPoorLeadBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                        <BiomeType name='Ocean' weight='-1'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Poor Lead Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Poor Lead -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Poor Lead -->
-                <IfCondition condition=':= rlcrPoorLeadDist = "strategicCloud"'>
-                
-                    <Cloud name='rlcrPoorLeadBaseCloud' block='Railcraft:ore:11' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 3 * 1 * rlcrPoorLeadSize * _default_' range=':= 3 * 1 * rlcrPoorLeadSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * rlcrPoorLeadSize * _default_' range=':= 3 * 1 * rlcrPoorLeadSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 32' range=':= 32' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * 1 * rlcrPoorLeadSize * _default_' range=':= 3 * 1 * 1 * rlcrPoorLeadSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * rlcrPoorLeadFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Poor Lead Strategic Cloud Hint Veins -->
-                        <Veins name='rlcrPoorLeadBaseHintVeins' block='Railcraft:ore:11' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60818EBE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Poor Lead Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Poor Lead -->
-                
-                
-                <!-- Begin  Vanilla distribution of Poor Lead -->
-                <IfCondition condition=':= rlcrPoorLeadDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='rlcrPoorLeadBaseStandard' block='Railcraft:ore:11' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='Size' avg=':= 3 * 1 * rlcrPoorLeadSize * _default_'/>
-                        <Setting name='Height' avg=':= 32' range=':= 32' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * rlcrPoorLeadFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Poor Lead -->
-                
-                <!-- End Poor Lead Generation --> 
-
-                
-                <!-- Begin Saltpeter Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Saltpeter -->
-                <IfCondition condition=':= rlcrSaltpeterDist = "layeredVeins"'>
-                
-                    <Veins name='rlcrSaltpeterBaseVeins' block='Railcraft:ore:1'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CED0BA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 2.3 * rlcrSaltpeterSize * _default_' range=':= 1 * 2.3 * rlcrSaltpeterSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 2.3 * rlcrSaltpeterSize * _default_' range=':= 1 * 2.3 * rlcrSaltpeterSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.04 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.03 * rlcrSaltpeterFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.03 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 180/_default_ * _default_' range=':= 90/_default_ * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 1000'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.75'/>
-                        <BiomeType name='Desert'/>
-                        <Replaces block='minecraft:sandstone'/>
-                        <Replaces block='minecraft:sand'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Saltpeter -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Saltpeter -->
-                <IfCondition condition=':= rlcrSaltpeterDist = "hugeVeins"'>
-                
-                    <Veins name='rlcrSaltpeterBaseVeins' block='Railcraft:ore:1'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CED0BA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 2.3 * rlcrSaltpeterSize * _default_' range=':= 1 * 2.3 * rlcrSaltpeterSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 5' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 2.3 * rlcrSaltpeterSize * _default_' range=':= 1 * 2.3 * rlcrSaltpeterSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.04 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.03 * rlcrSaltpeterFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.03 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 180/_default_ * _default_' range=':= 90/_default_ * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 1000'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.75'/>
-                        <BiomeType name='Desert'/>
-                        <Replaces block='minecraft:sandstone'/>
-                        <Replaces block='minecraft:sand'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Saltpeter -->
-                
-                
-                <!-- Begin  Vanilla distribution of Saltpeter -->
-                <IfCondition condition=':= rlcrSaltpeterDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='rlcrSaltpeterBaseStandard' block='Railcraft:ore:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CED0BA</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 7/8 * rlcrSaltpeterSize * _default_'/>
-                        <Setting name='Height' avg=':= 64' range=':= 5' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.1 * rlcrSaltpeterFreq * _default_'/>
-                        <Replaces block='minecraft:sandstone'/>
-                        <Replaces block='minecraft:sand'/>
-                        <BiomeType name='Desert'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Saltpeter -->
-                
-                <!-- End Saltpeter Generation --> 
-
-                
-                <!-- Begin Abyssal Ores Generation --> 
-                
-                <!-- Begin Geodes distribution of Abyssal Ores -->
-                <IfCondition condition=':= rlcrAbyssalOresDist = "geodes"'>
-                
-                    
-                    <!-- Begin Abyssal Ores Geode Crust -->
-                    <Veins name='rlcrAbyssalOresBaseShell' block='Railcraft:cube:6' inherits='PresetSmallDeposits' seed='0x9668'>
-                        <Description>
-                            The geode's outer shell, composed of the
-                            Pipe material.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60000000</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 3 * 1 * rlcrAbyssalOresSize * _default_' range=':= 3 * 1 * rlcrAbyssalOresSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 8' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='MotherlodeFrequency' avg=':= 0.2 * 1 * rlcrAbyssalOresFreq * _default_'/>
-                        <Replaces block='minecraft:air'/>
-                        <Replaces block='minecraft:water'/>
-                        <Replaces block='minecraft:lava'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Ocean'/>
-                    </Veins>
-                    <!-- End Abyssal Ores Geode Crust -->
-                    
-                    
-                    <!-- Begin Abyssal Ores Geode Crystals -->
-                    <Veins name='rlcrAbyssalOresBaseCrystal' block='Railcraft:ore:2' inherits='PresetSmallDeposits' seed='0x9668'>
-                        <Description>
-                            The geode's inner material, usually some
-                            form of crystal.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60000000</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1.5 * 3 * 1 * rlcrAbyssalOresSize * _default_' range=':= 3 * 1 * rlcrAbyssalOresSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 8' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='OreDensity' avg=':= 0.04 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 0.2 * 1 * rlcrAbyssalOresFreq * _default_'/>
-                        <Replaces block='Railcraft:cube:6'/>
-                        <BiomeType name='Ocean'/>
-                    </Veins>
-                    <!-- End Abyssal Ores Geode Crystals -->
-                    
-                    
-                    <!-- Begin Abyssal Ores Geode Crystals (Railcraft:ore:3) -->
-                    <Veins name='rlcrAbyssalOresBase1Crystal' block='Railcraft:ore:3' inherits='PresetSmallDeposits' seed='0x9668'>
-                        <Description>
-                            The geode's inner material, usually some
-                            form of crystal.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60000000</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1.5 * 3 * 1 * rlcrAbyssalOresSize * _default_' range=':= 3 * 1 * rlcrAbyssalOresSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 8' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='OreDensity' avg=':= 2/3 * 0.04 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 0.2 * 1 * rlcrAbyssalOresFreq * _default_'/>
-                        <Replaces block='Railcraft:ore:2'/>
-                        <BiomeType name='Ocean'/>
-                    </Veins>
-                    <!-- End Abyssal Ores Geode Crystals -->
-                    
-                    
-                    <!-- Begin Abyssal Ores Geode Crystals (Railcraft:ore:4) -->
-                    <Veins name='rlcrAbyssalOresBase2Crystal' block='Railcraft:ore:4' inherits='PresetSmallDeposits' seed='0x9668'>
-                        <Description>
-                            The geode's inner material, usually some
-                            form of crystal.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60000000</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1.5 * 3 * 1 * rlcrAbyssalOresSize * _default_' range=':= 3 * 1 * rlcrAbyssalOresSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 8' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='OreDensity' avg=':= 1/3 * 0.04 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 0.2 * 1 * rlcrAbyssalOresFreq * _default_'/>
-                        <Replaces block='Railcraft:ore:3'/>
-                        <BiomeType name='Ocean'/>
-                    </Veins>
-                    <!-- End Abyssal Ores Geode Crystals -->
-                    
-                    
-                    <!-- Begin Abyssal Ores Geode Air Pocket -->
-                    <Veins name='rlcrAbyssalOresBaseAirBubble' block='minecraft:air' inherits='PresetSmallDeposits' seed='0x9668'>
-                        <Description>
-                            The air pocket within the center of a
-                            geode.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60000000</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * rlcrAbyssalOresSize * _default_' range=':= 3 * 1 * rlcrAbyssalOresSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 8' range=':= 8' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * rlcrAbyssalOresSize * _default_' range=':= 3 * 1 * rlcrAbyssalOresSize * _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 0.2 * 1 * rlcrAbyssalOresFreq * _default_'/>
-                        <Replaces block='Railcraft:ore:2'/>
-                        <Replaces block='Railcraft:cube:6'/>
-                        <BiomeType name='Ocean'/>
-                    </Veins>
-                    <!-- End Abyssal Ores Geode Air Pocket -->
-                    
-                
-                </IfCondition>
-                <!-- End Geodes distribution of Abyssal Ores -->
-                
-                <!-- End Abyssal Ores Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-            <!-- Setup Nether -->
-            <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
-                
-                <!-- Starting Original Nether Ore Removal -->
-                <Substitute name='rlcrNetherOreSubstitute0' block='minecraft:netherrack'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='Railcraft:ore:5' />
-                </Substitute>
-                <!-- Original Nether Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Firestone Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Firestone -->
-                <IfCondition condition=':= rlcrFirestoneDist = "layeredVeins"'>
-                
-                    <Veins name='rlcrFirestoneBaseVeins' block='Railcraft:ore:5'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C64E0D</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * rlcrFirestoneSize * _default_' range=':= 0.5 * 1 * rlcrFirestoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 31' range=':= 2' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 0.5 * 1 * rlcrFirestoneSize * _default_' range=':= 0.5 * 1 * rlcrFirestoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 0.5 * 1 * rlcrFirestoneFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Firestone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Firestone -->
-                <IfCondition condition=':= rlcrFirestoneDist = "hugeVeins"'>
-                
-                    <Veins name='rlcrFirestoneBaseVeins' block='Railcraft:ore:5'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C64E0D</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 0.5 * 1 * rlcrFirestoneSize * _default_' range=':= 0.5 * 1 * rlcrFirestoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 31' range=':= 2' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 0.5 * 1 * rlcrFirestoneSize * _default_' range=':= 0.5 * 1 * rlcrFirestoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 0.5 * 1 * rlcrFirestoneFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Firestone -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Firestone -->
-                <IfCondition condition=':= rlcrFirestoneDist = "strategicCloud"'>
-                
-                    <Cloud name='rlcrFirestoneBaseCloud' block='Railcraft:ore:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C64E0D</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 0.5 * 1 * rlcrFirestoneSize * _default_' range=':= 0.5 * 1 * rlcrFirestoneSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 0.5 * 1 * rlcrFirestoneSize * _default_' range=':= 0.5 * 1 * rlcrFirestoneSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 31' range=':= 2' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 0.5 * 1 * 1 * rlcrFirestoneSize * _default_' range=':= 0.5 * 1 * 1 * rlcrFirestoneSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 0.5 * 1 * rlcrFirestoneFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Firestone Strategic Cloud Hint Veins -->
-                        <Veins name='rlcrFirestoneBaseHintVeins' block='Railcraft:ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60C64E0D</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Firestone Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Firestone -->
-                
-                
-                <!-- Begin  Vanilla distribution of Firestone -->
-                <IfCondition condition=':= rlcrFirestoneDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='rlcrFirestoneBaseStandard' block='Railcraft:ore:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60C64E0D</WireframeColor>
-                        <Setting name='Size' avg=':= 0.5 * 1 * rlcrFirestoneSize * _default_'/>
-                        <Setting name='Height' avg=':= 31' range=':= 2' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 0.5 * 1 * rlcrFirestoneFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Firestone -->
-                
-                <!-- End Firestone Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Nether Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='rlcrOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='Railcraft:cube:6' weight='1.0' />
+                <Replaces block='Railcraft:ore:10' weight='1.0' />
+                <Replaces block='Railcraft:ore:11' weight='1.0' />
+                <Replaces block='Railcraft:ore:2' weight='1.0' />
+                <Replaces block='Railcraft:ore:3' weight='1.0' />
+                <Replaces block='Railcraft:ore:4' weight='1.0' />
+                <Replaces block='Railcraft:ore:7' weight='1.0' />
+                <Replaces block='Railcraft:ore:8' weight='1.0' />
+                <Replaces block='Railcraft:ore:9' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Poor Iron Generation -->
+
+            <!-- Starting LayeredVeins Preset for Poor Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorIronDist = "LayeredVeins"'>
+                    <Veins name='rlcrPoorIronVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:7' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 7.921 * _default_ * rlcrPoorIronFreq ' range=':=  _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.993 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  4 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.993 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.993 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Poor Iron is complete. -->
+
+
+            <!-- Starting Cloud Preset for Poor Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorIronDist = "Cloud"'>
+                    <Cloud name='rlcrPoorIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:7' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 2.313 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 2.313 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 5.351  * _default_ * rlcrPoorIronFreq ' range=':=  _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  4 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='rlcrPoorIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Railcraft:ore:7' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Poor Iron is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Poor Iron. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorIronDist = "Vanilla"'>
+                    <StandardGen name='rlcrPoorIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:7' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 16 * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 32 * rlcrPoorIronFreq ' range=':=  _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 40 ' range=':=  4 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Poor Iron is complete. -->
+
+            <!-- End Poor Iron Generation -->
+
+
+            <!-- Begin Poor Gold Generation -->
+
+            <!-- Starting LayeredVeins Preset for Poor Gold. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorGoldDist = "LayeredVeins"'>
+                    <Veins name='rlcrPoorGoldVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:8' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.980 * _default_ * rlcrPoorGoldFreq ' range=':=  _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.256 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 15 ' range=':=  1 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.256 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.256 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Poor Gold is complete. -->
+
+
+            <!-- Starting Cloud Preset for Poor Gold. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorGoldDist = "Cloud"'>
+                    <Cloud name='rlcrPoorGoldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:8' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.157 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.157 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * rlcrPoorGoldFreq ' range=':=  _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 15 ' range=':=  1 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='rlcrPoorGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Railcraft:ore:8' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Poor Gold is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Poor Gold. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorGoldDist = "Vanilla"'>
+                    <StandardGen name='rlcrPoorGoldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:8' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 1 * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 32 * rlcrPoorGoldFreq ' range=':=  _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 15 ' range=':=  1 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Poor Gold is complete. -->
+
+            <!-- End Poor Gold Generation -->
+
+
+            <!-- Begin Poor Copper Generation -->
+
+            <!-- Starting LayeredVeins Preset for Poor Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorCopperDist = "LayeredVeins"'>
+                    <Veins name='rlcrPoorCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:9' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 5.601 * _default_ * rlcrPoorCopperFreq ' range=':=  _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.776 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 60 ' range=':=  3 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.776 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.776 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Poor Copper is complete. -->
+
+
+            <!-- Starting Cloud Preset for Poor Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorCopperDist = "Cloud"'>
+                    <Cloud name='rlcrPoorCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:9' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.945 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.945 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 3.784  * _default_ * rlcrPoorCopperFreq ' range=':=  _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 60 ' range=':=  3 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='rlcrPoorCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Railcraft:ore:9' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Poor Copper is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Poor Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorCopperDist = "Vanilla"'>
+                    <StandardGen name='rlcrPoorCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:9' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 32 * rlcrPoorCopperFreq ' range=':=  _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 60 ' range=':=  3 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Poor Copper is complete. -->
+
+            <!-- End Poor Copper Generation -->
+
+
+            <!-- Begin Poor Tin Generation -->
+
+            <!-- Starting LayeredVeins Preset for Poor Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorTinDist = "LayeredVeins"'>
+                    <Veins name='rlcrPoorTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:10' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.801 * _default_ * rlcrPoorTinFreq ' range=':=  _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.410 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 50 ' range=':=  2 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.410 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.410 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Poor Tin is complete. -->
+
+
+            <!-- Starting Cloud Preset for Poor Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorTinDist = "Cloud"'>
+                    <Cloud name='rlcrPoorTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:10' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.375 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.375 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * rlcrPoorTinFreq ' range=':=  _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 50 ' range=':=  2 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='rlcrPoorTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Railcraft:ore:10' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Poor Tin is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Poor Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorTinDist = "Vanilla"'>
+                    <StandardGen name='rlcrPoorTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:10' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 2 * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 32 * rlcrPoorTinFreq ' range=':=  _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 50 ' range=':=  2 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Poor Tin is complete. -->
+
+            <!-- End Poor Tin Generation -->
+
+
+            <!-- Begin Poor Lead Generation -->
+
+            <!-- Starting LayeredVeins Preset for Poor Lead. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorLeadDist = "LayeredVeins"'>
+                    <Veins name='rlcrPoorLeadVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:11' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 4.851 * _default_ * rlcrPoorLeadFreq ' range=':=  _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.693 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 30 ' range=':=  3 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.693 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.693 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Poor Lead is complete. -->
+
+
+            <!-- Starting Cloud Preset for Poor Lead. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorLeadDist = "Cloud"'>
+                    <Cloud name='rlcrPoorLeadCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:11' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.810 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.810 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 3.277  * _default_ * rlcrPoorLeadFreq ' range=':=  _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 30 ' range=':=  3 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='rlcrPoorLeadHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Railcraft:ore:11' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Poor Lead is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Poor Lead. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrPoorLeadDist = "Vanilla"'>
+                    <StandardGen name='rlcrPoorLeadStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:11' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 32 * rlcrPoorLeadFreq ' range=':=  _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 30 ' range=':=  3 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Poor Lead is complete. -->
+
+            <!-- End Poor Lead Generation -->
+
+
+            <!-- Begin Abyssal Ores Generation -->
+
+            <!-- Starting Geode Preset for Abyssal Ores. -->
+            <ConfigSection>
+                <IfCondition condition=':= rlcrAbyssalOresDist = "Geode"'>
+                    <Veins name='rlcrAbyssalOresGeodeShell'  inherits='PresetSmallDeposits' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
+                        <Description>
+                            Multi-layered deposit.  On the  outside is
+                            a shell, usually made of  some form of
+                            stone.  Within this  shell is sprinkled
+                            ores.  Inside both  is an air pocket from
+                            which the  enterprising miner can look for
+                            the  contained ores.
+                        </Description>
+                        <OreBlock block='Railcraft:cube:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='Ocean'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.5 * rlcrAbyssalOresFreq ' range=':=  _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= _default_ * rlcrAbyssalOresSize  * 3 ' range=':=  _default_ * rlcrAbyssalOresSize  * 3 ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  4 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                    <Veins name='rlcrAbyssalOresGeodeOre'  inherits='rlcrAbyssalOresGeodeShell' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
+                        <Description>
+                            Multi-layered deposit.  On the  outside is
+                            a shell, usually made of  some form of
+                            stone.  Within this  shell is sprinkled
+                            ores.  Inside both  is an air pocket from
+                            which the  enterprising miner can look for
+                            the  contained ores.
+                        </Description>
+                        <OreBlock block='Railcraft:ore:2' weight='0.05' />
+                        <OreBlock block='Railcraft:ore:3' weight='0.05' />
+                        <OreBlock block='Railcraft:ore:4' weight='0.15' />
+                        <Replaces block='Railcraft:cube:6' weight='1.0' />
+                        <Biome name='Ocean'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.5 * rlcrAbyssalOresFreq ' range=':=  _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= _default_ * rlcrAbyssalOresSize  * 0.5 ' range=':=  _default_ * rlcrAbyssalOresSize  * 0.5 ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  4 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                    <Veins name='rlcrAbyssalOresGeodeBubble'  inherits='rlcrAbyssalOresGeodeOre' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
+                        <Description>
+                            Multi-layered deposit.  On the  outside is
+                            a shell, usually made of  some form of
+                            stone.  Within this  shell is sprinkled
+                            ores.  Inside both  is an air pocket from
+                            which the  enterprising miner can look for
+                            the  contained ores.
+                        </Description>
+                        <OreBlock block='minecraft:air' weight='1.0' />
+                        <Replaces block='Railcraft:cube:6' weight='1.0' />
+                        <Replaces block='Railcraft:ore:2' weight='1.0' />
+                        <Replaces block='Railcraft:ore:3' weight='1.0' />
+                        <Replaces block='Railcraft:ore:4' weight='1.0' />
+                        <Biome name='Ocean'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.5 * rlcrAbyssalOresFreq ' range=':=  _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= _default_ * rlcrAbyssalOresSize  * 0.5 ' range=':=  _default_ * rlcrAbyssalOresSize  * 0.5 ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  4 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                </IfCondition>
+            </ConfigSection>
+            <!-- Geode Preset for Abyssal Ores is complete. -->
+
+            <!-- End Abyssal Ores Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "RailCraft" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -30,10 +30,15 @@
                     Distribution options for ReactorCraft Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableReactorCraft' displayName='Handle ReactorCraft Setup?' default='true' displayState='shown_dynamic' displayGroup='groupReactorCraft'>
+                <Description> Should Custom Ore Generation handle ReactorCraft ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle ReactorCraft ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='ReactorCraft ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Pitchblende Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrPitchblendeDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrPitchblendeDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Pitchblende is generated </Description>
                     <DisplayName>ReactorCraft Pitchblende</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -53,11 +58,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Pitchblende is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrPitchblendeFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrPitchblendeFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Pitchblende distributions </Description>
                     <DisplayName>ReactorCraft Pitchblende Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrPitchblendeSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrPitchblendeSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Pitchblende distributions </Description>
                     <DisplayName>ReactorCraft Pitchblende Size</DisplayName>
                 </OptionNumeric>
@@ -67,7 +72,7 @@
 
             <!-- Cadmium Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrCadmiumDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrCadmiumDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Cadmium is generated </Description>
                     <DisplayName>ReactorCraft Cadmium</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -87,11 +92,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Cadmium is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrCadmiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrCadmiumFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Cadmium distributions </Description>
                     <DisplayName>ReactorCraft Cadmium Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrCadmiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrCadmiumSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Cadmium distributions </Description>
                     <DisplayName>ReactorCraft Cadmium Size</DisplayName>
                 </OptionNumeric>
@@ -101,7 +106,7 @@
 
             <!-- Indium Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrIndiumDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrIndiumDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Indium is generated </Description>
                     <DisplayName>ReactorCraft Indium</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -121,11 +126,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Indium is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrIndiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrIndiumFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Indium distributions </Description>
                     <DisplayName>ReactorCraft Indium Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrIndiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrIndiumSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Indium distributions </Description>
                     <DisplayName>ReactorCraft Indium Size</DisplayName>
                 </OptionNumeric>
@@ -135,7 +140,7 @@
 
             <!-- Silver Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrSilverDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrSilverDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Silver is generated </Description>
                     <DisplayName>ReactorCraft Silver</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -155,11 +160,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrSilverFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Silver distributions </Description>
                     <DisplayName>ReactorCraft Silver Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrSilverSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Silver distributions </Description>
                     <DisplayName>ReactorCraft Silver Size</DisplayName>
                 </OptionNumeric>
@@ -169,7 +174,7 @@
 
             <!-- End Pitchblende Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrEndPitchblendeDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrEndPitchblendeDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how End Pitchblende is generated </Description>
                     <DisplayName>ReactorCraft End Pitchblende</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -189,11 +194,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='End Pitchblende is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrEndPitchblendeFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrEndPitchblendeFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft End Pitchblende distributions </Description>
                     <DisplayName>ReactorCraft End Pitchblende Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrEndPitchblendeSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrEndPitchblendeSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft End Pitchblende distributions </Description>
                     <DisplayName>ReactorCraft End Pitchblende Size</DisplayName>
                 </OptionNumeric>
@@ -203,7 +208,7 @@
 
             <!-- Ammonium Chloride Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrAmmoniumChlorideDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrAmmoniumChlorideDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Ammonium Chloride is generated </Description>
                     <DisplayName>ReactorCraft Ammonium Chloride</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -223,11 +228,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Ammonium Chloride is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrAmmoniumChlorideFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrAmmoniumChlorideFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Ammonium Chloride distributions </Description>
                     <DisplayName>ReactorCraft Ammonium Chloride Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrAmmoniumChlorideSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrAmmoniumChlorideSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Ammonium Chloride distributions </Description>
                     <DisplayName>ReactorCraft Ammonium Chloride Size</DisplayName>
                 </OptionNumeric>
@@ -237,7 +242,7 @@
 
             <!-- Calcite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrCalciteDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrCalciteDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Calcite is generated </Description>
                     <DisplayName>ReactorCraft Calcite</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -257,11 +262,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Calcite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrCalciteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrCalciteFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Calcite distributions </Description>
                     <DisplayName>ReactorCraft Calcite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrCalciteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrCalciteSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Calcite distributions </Description>
                     <DisplayName>ReactorCraft Calcite Size</DisplayName>
                 </OptionNumeric>
@@ -271,7 +276,7 @@
 
             <!-- Magnetite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrMagnetiteDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrMagnetiteDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Magnetite is generated </Description>
                     <DisplayName>ReactorCraft Magnetite</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -291,11 +296,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Magnetite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrMagnetiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrMagnetiteFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Magnetite distributions </Description>
                     <DisplayName>ReactorCraft Magnetite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrMagnetiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrMagnetiteSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Magnetite distributions </Description>
                     <DisplayName>ReactorCraft Magnetite Size</DisplayName>
                 </OptionNumeric>
@@ -305,7 +310,7 @@
 
             <!-- Thorite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrThoriteDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrThoriteDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Thorite is generated </Description>
                     <DisplayName>ReactorCraft Thorite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -325,11 +330,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Thorite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrThoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrThoriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Thorite distributions </Description>
                     <DisplayName>ReactorCraft Thorite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrThoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrThoriteSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Thorite distributions </Description>
                     <DisplayName>ReactorCraft Thorite Size</DisplayName>
                 </OptionNumeric>
@@ -339,7 +344,7 @@
 
             <!-- Blue Fluorite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrBlueFluoriteDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrBlueFluoriteDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Blue Fluorite is generated </Description>
                     <DisplayName>ReactorCraft Blue Fluorite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -359,11 +364,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Blue Fluorite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrBlueFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrBlueFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Blue Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Blue Fluorite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrBlueFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrBlueFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Blue Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Blue Fluorite Size</DisplayName>
                 </OptionNumeric>
@@ -373,7 +378,7 @@
 
             <!-- Pink Fluorite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrPinkFluoriteDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrPinkFluoriteDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Pink Fluorite is generated </Description>
                     <DisplayName>ReactorCraft Pink Fluorite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -393,11 +398,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Pink Fluorite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrPinkFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrPinkFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Pink Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Pink Fluorite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrPinkFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrPinkFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Pink Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Pink Fluorite Size</DisplayName>
                 </OptionNumeric>
@@ -407,7 +412,7 @@
 
             <!-- Orange Fluorite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrOrangeFluoriteDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrOrangeFluoriteDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Orange Fluorite is generated </Description>
                     <DisplayName>ReactorCraft Orange Fluorite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -427,11 +432,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Orange Fluorite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrOrangeFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrOrangeFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Orange Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Orange Fluorite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrOrangeFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrOrangeFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Orange Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Orange Fluorite Size</DisplayName>
                 </OptionNumeric>
@@ -441,7 +446,7 @@
 
             <!-- Magenta Fluorite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrMagentaFluoriteDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrMagentaFluoriteDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Magenta Fluorite is generated </Description>
                     <DisplayName>ReactorCraft Magenta Fluorite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -461,11 +466,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Magenta Fluorite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrMagentaFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrMagentaFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Magenta Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Magenta Fluorite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrMagentaFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrMagentaFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Magenta Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Magenta Fluorite Size</DisplayName>
                 </OptionNumeric>
@@ -475,7 +480,7 @@
 
             <!-- Green Fluorite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrGreenFluoriteDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrGreenFluoriteDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Green Fluorite is generated </Description>
                     <DisplayName>ReactorCraft Green Fluorite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -495,11 +500,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Green Fluorite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrGreenFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrGreenFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Green Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Green Fluorite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrGreenFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrGreenFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Green Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Green Fluorite Size</DisplayName>
                 </OptionNumeric>
@@ -509,7 +514,7 @@
 
             <!-- Red Fluorite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrRedFluoriteDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrRedFluoriteDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Red Fluorite is generated </Description>
                     <DisplayName>ReactorCraft Red Fluorite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -529,11 +534,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Red Fluorite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrRedFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrRedFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Red Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Red Fluorite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrRedFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrRedFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Red Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Red Fluorite Size</DisplayName>
                 </OptionNumeric>
@@ -543,7 +548,7 @@
 
             <!-- White Fluorite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrWhiteFluoriteDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrWhiteFluoriteDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how White Fluorite is generated </Description>
                     <DisplayName>ReactorCraft White Fluorite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -563,11 +568,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='White Fluorite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrWhiteFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrWhiteFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft White Fluorite distributions </Description>
                     <DisplayName>ReactorCraft White Fluorite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrWhiteFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrWhiteFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft White Fluorite distributions </Description>
                     <DisplayName>ReactorCraft White Fluorite Size</DisplayName>
                 </OptionNumeric>
@@ -577,7 +582,7 @@
 
             <!-- Yellow Fluorite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='recrYellowFluoriteDist'  displayState='shown' displayGroup='groupReactorCraft'>
+                <OptionChoice name='recrYellowFluoriteDist'  displayState=':= if(?enableReactorCraft, "shown", "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Controls how Yellow Fluorite is generated </Description>
                     <DisplayName>ReactorCraft Yellow Fluorite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -597,11 +602,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Yellow Fluorite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='recrYellowFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrYellowFluoriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Frequency multiplier for ReactorCraft Yellow Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Yellow Fluorite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='recrYellowFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupReactorCraft'>
+                <OptionNumeric name='recrYellowFluoriteSize' default='1'  min='0' max='5' displayState=':= if(?enableReactorCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupReactorCraft'>
                     <Description> Size multiplier for ReactorCraft Yellow Fluorite distributions </Description>
                     <DisplayName>ReactorCraft Yellow Fluorite Size</DisplayName>
                 </OptionNumeric>
@@ -611,2132 +616,2193 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableReactorCraft'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='recrOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Pitchblende Generation -->
-
-            <!-- Starting SparseVeins Preset for Pitchblende. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrPitchblendeDist = "SparseVeins"'>
-                    <Veins name='recrPitchblendeVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='recrOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Mushroom'  />
-                        <BiomeType name='Ocean'  />
-                        <BiomeType name='River'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrPitchblendeFreq ' range=':=  1 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrPitchblendeSize ' range=':=  1 * _default_ * recrPitchblendeSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrPitchblendeSize ' range=':=  1 * _default_ * recrPitchblendeSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Pitchblende is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Vanilla Preset for Pitchblende. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrPitchblendeDist = "Vanilla"'>
-                    <StandardGen name='recrPitchblendeStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Mushroom'  />
-                        <BiomeType name='Ocean'  />
-                        <BiomeType name='River'  />
-                        <Setting name='Size' avg=':= 16 * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * recrPitchblendeFreq ' range=':=  _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 16 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Pitchblende is complete. -->
+                <!-- Adding blocks -->
 
+                <!-- Begin Pitchblende Generation -->
 
-            <!-- Starting Cloud Preset for Pitchblende. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrPitchblendeDist = "Cloud"'>
-                    <Cloud name='recrPitchblendeCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Mushroom'  />
-                        <BiomeType name='Ocean'  />
-                        <BiomeType name='River'  />
-                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrPitchblendeFreq ' range=':=  _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 16 ' range=':=  8 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrPitchblendeHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
+                <!-- Starting SparseVeins Preset for Pitchblende. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrPitchblendeDist = "SparseVeins"'>
+                        <Veins name='recrPitchblendeVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Mushroom'  />
+                            <BiomeType name='Ocean'  />
+                            <BiomeType name='River'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrPitchblendeFreq ' range=':=  1 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrPitchblendeSize ' range=':=  1 * _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrPitchblendeSize ' range=':=  1 * _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Pitchblende is complete. -->
-
-            <!-- End Pitchblende Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Pitchblende is complete. -->
 
 
-            <!-- Begin Cadmium Generation -->
-
-            <!-- Starting LayeredVeins Preset for Cadmium. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrCadmiumDist = "LayeredVeins"'>
-                    <Veins name='recrCadmiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607184A4' drawBoundBox='false' boundBoxColor='0x607184A4'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.615 * _default_ * recrCadmiumFreq ' range=':=  1 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.851 * _default_ * recrCadmiumSize ' range=':=  1 * _default_ * recrCadmiumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 22 ' range=':=  10 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.851 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.851 * _default_ * recrCadmiumSize ' range=':=  1 * _default_ * recrCadmiumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Cadmium is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Cadmium. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrCadmiumDist = "Vanilla"'>
-                    <StandardGen name='recrCadmiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607184A4' drawBoundBox='false' boundBoxColor='0x607184A4'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 9 * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * recrCadmiumFreq ' range=':=  _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 22 ' range=':=  10 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Cadmium is complete. -->
-
-
-            <!-- Starting Cloud Preset for Cadmium. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrCadmiumDist = "Cloud"'>
-                    <Cloud name='recrCadmiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607184A4' drawBoundBox='false' boundBoxColor='0x607184A4'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.109 * _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.109 * _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.229  * _default_ * recrCadmiumFreq ' range=':=  _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 22 ' range=':=  10 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrCadmiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607184A4' drawBoundBox='false' boundBoxColor='0x607184A4'>
+                <!-- Starting Vanilla Preset for Pitchblende. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrPitchblendeDist = "Vanilla"'>
+                        <StandardGen name='recrPitchblendeStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Cadmium is complete. -->
-
-            <!-- End Cadmium Generation -->
-
-
-            <!-- Begin Indium Generation -->
-
-            <!-- Starting LayeredVeins Preset for Indium. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrIndiumDist = "LayeredVeins"'>
-                    <Veins name='recrIndiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607A7C89' drawBoundBox='false' boundBoxColor='0x607A7C89'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.443 * _default_ * recrIndiumFreq ' range=':=  1 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.762 * _default_ * recrIndiumSize ' range=':=  1 * _default_ * recrIndiumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.762 * _default_ * recrIndiumSize ' range=':=  1 * _default_ * recrIndiumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Indium is complete. -->
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Mushroom'  />
+                            <BiomeType name='Ocean'  />
+                            <BiomeType name='River'  />
+                            <Setting name='Size' avg=':= 16 * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * recrPitchblendeFreq ' range=':=  _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Pitchblende is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Indium. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrIndiumDist = "Vanilla"'>
-                    <StandardGen name='recrIndiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607A7C89' drawBoundBox='false' boundBoxColor='0x607A7C89'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 7 * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * recrIndiumFreq ' range=':=  _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 11 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Indium is complete. -->
-
-
-            <!-- Starting Cloud Preset for Indium. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrIndiumDist = "Cloud"'>
-                    <Cloud name='recrIndiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607A7C89' drawBoundBox='false' boundBoxColor='0x607A7C89'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.941 * _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.941 * _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.885  * _default_ * recrIndiumFreq ' range=':=  _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 11 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrIndiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607A7C89' drawBoundBox='false' boundBoxColor='0x607A7C89'>
+                <!-- Starting Cloud Preset for Pitchblende. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrPitchblendeDist = "Cloud"'>
+                        <Cloud name='recrPitchblendeCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Indium is complete. -->
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Mushroom'  />
+                            <BiomeType name='Ocean'  />
+                            <BiomeType name='River'  />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrPitchblendeFreq ' range=':=  _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':=  8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrPitchblendeHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Pitchblende is complete. -->
 
-            <!-- End Indium Generation -->
-
-
-            <!-- Begin Silver Generation -->
-
-            <!-- Starting LayeredVeins Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrSilverDist = "LayeredVeins"'>
-                    <Veins name='recrSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * recrSilverFreq ' range=':=  1 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * recrSilverSize ' range=':=  1 * _default_ * recrSilverSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 28 ' range=':=  12 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * recrSilverSize ' range=':=  1 * _default_ * recrSilverSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Silver is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrSilverDist = "Vanilla"'>
-                    <StandardGen name='recrSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 9 * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * recrSilverFreq ' range=':=  _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 28 ' range=':=  12 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Silver is complete. -->
+                <!-- End Pitchblende Generation -->
 
 
-            <!-- Starting Cloud Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrSilverDist = "Cloud"'>
-                    <Cloud name='recrSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.002 * _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.002 * _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * recrSilverFreq ' range=':=  _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 28 ' range=':=  12 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                <!-- Begin Cadmium Generation -->
+
+                <!-- Starting LayeredVeins Preset for Cadmium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrCadmiumDist = "LayeredVeins"'>
+                        <Veins name='recrCadmiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607184A4' drawBoundBox='false' boundBoxColor='0x607184A4'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.615 * _default_ * recrCadmiumFreq ' range=':=  1 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.851 * _default_ * recrCadmiumSize ' range=':=  1 * _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':=  10 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.851 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.851 * _default_ * recrCadmiumSize ' range=':=  1 * _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Silver is complete. -->
-
-            <!-- End Silver Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Cadmium is complete. -->
 
 
-            <!-- Begin Calcite Generation -->
-
-            <!-- Starting SparseVeins Preset for Calcite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrCalciteDist = "SparseVeins"'>
-                    <Veins name='recrCalciteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrCalciteFreq ' range=':=  1 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrCalciteSize ' range=':=  1 * _default_ * recrCalciteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrCalciteSize ' range=':=  1 * _default_ * recrCalciteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Calcite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Calcite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrCalciteDist = "Vanilla"'>
-                    <StandardGen name='recrCalciteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * recrCalciteFreq ' range=':=  _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Calcite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Calcite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrCalciteDist = "Cloud"'>
-                    <Cloud name='recrCalciteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrCalciteFreq ' range=':=  _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrCalciteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
+                <!-- Starting Vanilla Preset for Cadmium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrCadmiumDist = "Vanilla"'>
+                        <StandardGen name='recrCadmiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607184A4' drawBoundBox='false' boundBoxColor='0x607184A4'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Calcite is complete. -->
-
-            <!-- End Calcite Generation -->
-
-
-            <!-- Begin Magnetite Generation -->
-
-            <!-- Starting SparseVeins Preset for Magnetite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrMagnetiteDist = "SparseVeins"'>
-                    <Veins name='recrMagnetiteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 3.705 * _default_ * recrMagnetiteFreq ' range=':=  1 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.547 * _default_ * recrMagnetiteSize ' range=':=  1 * _default_ * recrMagnetiteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.547 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.547 * _default_ * recrMagnetiteSize ' range=':=  1 * _default_ * recrMagnetiteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Magnetite is complete. -->
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 9 * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * recrCadmiumFreq ' range=':=  _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 22 ' range=':=  10 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Cadmium is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Magnetite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrMagnetiteDist = "Vanilla"'>
-                    <StandardGen name='recrMagnetiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 16 * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 7 * recrMagnetiteFreq ' range=':=  _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Magnetite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Magnetite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrMagnetiteDist = "Cloud"'>
-                    <Cloud name='recrMagnetiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.582 * _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.582 * _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.503  * _default_ * recrMagnetiteFreq ' range=':=  _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrMagnetiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
+                <!-- Starting Cloud Preset for Cadmium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrCadmiumDist = "Cloud"'>
+                        <Cloud name='recrCadmiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607184A4' drawBoundBox='false' boundBoxColor='0x607184A4'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Magnetite is complete. -->
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.109 * _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.109 * _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.229  * _default_ * recrCadmiumFreq ' range=':=  _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 22 ' range=':=  10 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrCadmiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607184A4' drawBoundBox='false' boundBoxColor='0x607184A4'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Cadmium is complete. -->
 
-            <!-- End Magnetite Generation -->
-
-
-            <!-- Begin Blue Fluorite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Blue Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrBlueFluoriteDist = "LayeredVeins"'>
-                    <Veins name='recrBlueFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60283270' drawBoundBox='false' boundBoxColor='0x60283270'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrBlueFluoriteFreq ' range=':=  1 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrBlueFluoriteSize ' range=':=  1 * _default_ * recrBlueFluoriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrBlueFluoriteSize ' range=':=  1 * _default_ * recrBlueFluoriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Blue Fluorite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Blue Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrBlueFluoriteDist = "Vanilla"'>
-                    <StandardGen name='recrBlueFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60283270' drawBoundBox='false' boundBoxColor='0x60283270'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1.5 * recrBlueFluoriteFreq ' range=':=  _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Blue Fluorite is complete. -->
+                <!-- End Cadmium Generation -->
 
 
-            <!-- Starting Cloud Preset for Blue Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrBlueFluoriteDist = "Cloud"'>
-                    <Cloud name='recrBlueFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60283270' drawBoundBox='false' boundBoxColor='0x60283270'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrBlueFluoriteFreq ' range=':=  _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrBlueFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60283270' drawBoundBox='false' boundBoxColor='0x60283270'>
+                <!-- Begin Indium Generation -->
+
+                <!-- Starting LayeredVeins Preset for Indium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrIndiumDist = "LayeredVeins"'>
+                        <Veins name='recrIndiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607A7C89' drawBoundBox='false' boundBoxColor='0x607A7C89'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.443 * _default_ * recrIndiumFreq ' range=':=  1 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.762 * _default_ * recrIndiumSize ' range=':=  1 * _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.762 * _default_ * recrIndiumSize ' range=':=  1 * _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Blue Fluorite is complete. -->
-
-            <!-- End Blue Fluorite Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Indium is complete. -->
 
 
-            <!-- Begin Pink Fluorite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Pink Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrPinkFluoriteDist = "LayeredVeins"'>
-                    <Veins name='recrPinkFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607A5970' drawBoundBox='false' boundBoxColor='0x607A5970'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrPinkFluoriteFreq ' range=':=  1 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrPinkFluoriteSize ' range=':=  1 * _default_ * recrPinkFluoriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrPinkFluoriteSize ' range=':=  1 * _default_ * recrPinkFluoriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Pink Fluorite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Pink Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrPinkFluoriteDist = "Vanilla"'>
-                    <StandardGen name='recrPinkFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607A5970' drawBoundBox='false' boundBoxColor='0x607A5970'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1.5 * recrPinkFluoriteFreq ' range=':=  _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Pink Fluorite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Pink Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrPinkFluoriteDist = "Cloud"'>
-                    <Cloud name='recrPinkFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607A5970' drawBoundBox='false' boundBoxColor='0x607A5970'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrPinkFluoriteFreq ' range=':=  _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrPinkFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607A5970' drawBoundBox='false' boundBoxColor='0x607A5970'>
+                <!-- Starting Vanilla Preset for Indium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrIndiumDist = "Vanilla"'>
+                        <StandardGen name='recrIndiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607A7C89' drawBoundBox='false' boundBoxColor='0x607A7C89'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Pink Fluorite is complete. -->
-
-            <!-- End Pink Fluorite Generation -->
-
-
-            <!-- Begin Orange Fluorite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Orange Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrOrangeFluoriteDist = "LayeredVeins"'>
-                    <Veins name='recrOrangeFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607A5927' drawBoundBox='false' boundBoxColor='0x607A5927'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrOrangeFluoriteFreq ' range=':=  1 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrOrangeFluoriteSize ' range=':=  1 * _default_ * recrOrangeFluoriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrOrangeFluoriteSize ' range=':=  1 * _default_ * recrOrangeFluoriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Orange Fluorite is complete. -->
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 7 * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * recrIndiumFreq ' range=':=  _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Indium is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Orange Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrOrangeFluoriteDist = "Vanilla"'>
-                    <StandardGen name='recrOrangeFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607A5927' drawBoundBox='false' boundBoxColor='0x607A5927'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1.5 * recrOrangeFluoriteFreq ' range=':=  _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Orange Fluorite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Orange Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrOrangeFluoriteDist = "Cloud"'>
-                    <Cloud name='recrOrangeFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607A5927' drawBoundBox='false' boundBoxColor='0x607A5927'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrOrangeFluoriteFreq ' range=':=  _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrOrangeFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607A5927' drawBoundBox='false' boundBoxColor='0x607A5927'>
+                <!-- Starting Cloud Preset for Indium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrIndiumDist = "Cloud"'>
+                        <Cloud name='recrIndiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607A7C89' drawBoundBox='false' boundBoxColor='0x607A7C89'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Orange Fluorite is complete. -->
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.941 * _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.941 * _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.885  * _default_ * recrIndiumFreq ' range=':=  _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrIndiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607A7C89' drawBoundBox='false' boundBoxColor='0x607A7C89'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Indium is complete. -->
 
-            <!-- End Orange Fluorite Generation -->
-
-
-            <!-- Begin Magenta Fluorite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Magenta Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrMagentaFluoriteDist = "LayeredVeins"'>
-                    <Veins name='recrMagentaFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60602774' drawBoundBox='false' boundBoxColor='0x60602774'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrMagentaFluoriteFreq ' range=':=  1 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrMagentaFluoriteSize ' range=':=  1 * _default_ * recrMagentaFluoriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrMagentaFluoriteSize ' range=':=  1 * _default_ * recrMagentaFluoriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Magenta Fluorite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Magenta Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrMagentaFluoriteDist = "Vanilla"'>
-                    <StandardGen name='recrMagentaFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60602774' drawBoundBox='false' boundBoxColor='0x60602774'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1.5 * recrMagentaFluoriteFreq ' range=':=  _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Magenta Fluorite is complete. -->
+                <!-- End Indium Generation -->
 
 
-            <!-- Starting Cloud Preset for Magenta Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrMagentaFluoriteDist = "Cloud"'>
-                    <Cloud name='recrMagentaFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60602774' drawBoundBox='false' boundBoxColor='0x60602774'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrMagentaFluoriteFreq ' range=':=  _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrMagentaFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60602774' drawBoundBox='false' boundBoxColor='0x60602774'>
+                <!-- Begin Silver Generation -->
+
+                <!-- Starting LayeredVeins Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrSilverDist = "LayeredVeins"'>
+                        <Veins name='recrSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * recrSilverFreq ' range=':=  1 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * recrSilverSize ' range=':=  1 * _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 28 ' range=':=  12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * recrSilverSize ' range=':=  1 * _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Magenta Fluorite is complete. -->
-
-            <!-- End Magenta Fluorite Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Silver is complete. -->
 
 
-            <!-- Begin Green Fluorite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Green Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrGreenFluoriteDist = "LayeredVeins"'>
-                    <Veins name='recrGreenFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60347D3B' drawBoundBox='false' boundBoxColor='0x60347D3B'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrGreenFluoriteFreq ' range=':=  1 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrGreenFluoriteSize ' range=':=  1 * _default_ * recrGreenFluoriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrGreenFluoriteSize ' range=':=  1 * _default_ * recrGreenFluoriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Green Fluorite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Green Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrGreenFluoriteDist = "Vanilla"'>
-                    <StandardGen name='recrGreenFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60347D3B' drawBoundBox='false' boundBoxColor='0x60347D3B'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1.5 * recrGreenFluoriteFreq ' range=':=  _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Green Fluorite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Green Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrGreenFluoriteDist = "Cloud"'>
-                    <Cloud name='recrGreenFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60347D3B' drawBoundBox='false' boundBoxColor='0x60347D3B'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrGreenFluoriteFreq ' range=':=  _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrGreenFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60347D3B' drawBoundBox='false' boundBoxColor='0x60347D3B'>
+                <!-- Starting Vanilla Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrSilverDist = "Vanilla"'>
+                        <StandardGen name='recrSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Green Fluorite is complete. -->
-
-            <!-- End Green Fluorite Generation -->
-
-
-            <!-- Begin Red Fluorite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Red Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrRedFluoriteDist = "LayeredVeins"'>
-                    <Veins name='recrRedFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60974747' drawBoundBox='false' boundBoxColor='0x60974747'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrRedFluoriteFreq ' range=':=  1 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrRedFluoriteSize ' range=':=  1 * _default_ * recrRedFluoriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrRedFluoriteSize ' range=':=  1 * _default_ * recrRedFluoriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Red Fluorite is complete. -->
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 9 * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * recrSilverFreq ' range=':=  _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 28 ' range=':=  12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Silver is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Red Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrRedFluoriteDist = "Vanilla"'>
-                    <StandardGen name='recrRedFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60974747' drawBoundBox='false' boundBoxColor='0x60974747'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1.5 * recrRedFluoriteFreq ' range=':=  _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Red Fluorite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Red Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrRedFluoriteDist = "Cloud"'>
-                    <Cloud name='recrRedFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60974747' drawBoundBox='false' boundBoxColor='0x60974747'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrRedFluoriteFreq ' range=':=  _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrRedFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60974747' drawBoundBox='false' boundBoxColor='0x60974747'>
+                <!-- Starting Cloud Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrSilverDist = "Cloud"'>
+                        <Cloud name='recrSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Red Fluorite is complete. -->
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * recrSilverFreq ' range=':=  _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 28 ' range=':=  12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Silver is complete. -->
 
-            <!-- End Red Fluorite Generation -->
-
-
-            <!-- Begin White Fluorite Generation -->
-
-            <!-- Starting LayeredVeins Preset for White Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrWhiteFluoriteDist = "LayeredVeins"'>
-                    <Veins name='recrWhiteFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60969696' drawBoundBox='false' boundBoxColor='0x60969696'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrWhiteFluoriteFreq ' range=':=  1 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrWhiteFluoriteSize ' range=':=  1 * _default_ * recrWhiteFluoriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrWhiteFluoriteSize ' range=':=  1 * _default_ * recrWhiteFluoriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for White Fluorite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for White Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrWhiteFluoriteDist = "Vanilla"'>
-                    <StandardGen name='recrWhiteFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60969696' drawBoundBox='false' boundBoxColor='0x60969696'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1.5 * recrWhiteFluoriteFreq ' range=':=  _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for White Fluorite is complete. -->
+                <!-- End Silver Generation -->
 
 
-            <!-- Starting Cloud Preset for White Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrWhiteFluoriteDist = "Cloud"'>
-                    <Cloud name='recrWhiteFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60969696' drawBoundBox='false' boundBoxColor='0x60969696'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrWhiteFluoriteFreq ' range=':=  _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrWhiteFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60969696' drawBoundBox='false' boundBoxColor='0x60969696'>
+                <!-- Begin Calcite Generation -->
+
+                <!-- Starting SparseVeins Preset for Calcite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrCalciteDist = "SparseVeins"'>
+                        <Veins name='recrCalciteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrCalciteFreq ' range=':=  1 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrCalciteSize ' range=':=  1 * _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrCalciteSize ' range=':=  1 * _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for White Fluorite is complete. -->
-
-            <!-- End White Fluorite Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Calcite is complete. -->
 
 
-            <!-- Begin Yellow Fluorite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Yellow Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrYellowFluoriteDist = "LayeredVeins"'>
-                    <Veins name='recrYellowFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60978834' drawBoundBox='false' boundBoxColor='0x60978834'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrYellowFluoriteFreq ' range=':=  1 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrYellowFluoriteSize ' range=':=  1 * _default_ * recrYellowFluoriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrYellowFluoriteSize ' range=':=  1 * _default_ * recrYellowFluoriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Yellow Fluorite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Yellow Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrYellowFluoriteDist = "Vanilla"'>
-                    <StandardGen name='recrYellowFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60978834' drawBoundBox='false' boundBoxColor='0x60978834'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1.5 * recrYellowFluoriteFreq ' range=':=  _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Yellow Fluorite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Yellow Fluorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrYellowFluoriteDist = "Cloud"'>
-                    <Cloud name='recrYellowFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60978834' drawBoundBox='false' boundBoxColor='0x60978834'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrYellowFluoriteFreq ' range=':=  _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrYellowFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60978834' drawBoundBox='false' boundBoxColor='0x60978834'>
+                <!-- Starting Vanilla Preset for Calcite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrCalciteDist = "Vanilla"'>
+                        <StandardGen name='recrCalciteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12 * recrCalciteFreq ' range=':=  _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Calcite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Calcite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrCalciteDist = "Cloud"'>
+                        <Cloud name='recrCalciteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrCalciteFreq ' range=':=  _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrCalciteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Calcite is complete. -->
+
+                <!-- End Calcite Generation -->
+
+
+                <!-- Begin Magnetite Generation -->
+
+                <!-- Starting SparseVeins Preset for Magnetite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrMagnetiteDist = "SparseVeins"'>
+                        <Veins name='recrMagnetiteVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.705 * _default_ * recrMagnetiteFreq ' range=':=  1 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.547 * _default_ * recrMagnetiteSize ' range=':=  1 * _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.547 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.547 * _default_ * recrMagnetiteSize ' range=':=  1 * _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Magnetite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Magnetite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrMagnetiteDist = "Vanilla"'>
+                        <StandardGen name='recrMagnetiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 16 * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 7 * recrMagnetiteFreq ' range=':=  _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Magnetite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Magnetite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrMagnetiteDist = "Cloud"'>
+                        <Cloud name='recrMagnetiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.582 * _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.582 * _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.503  * _default_ * recrMagnetiteFreq ' range=':=  _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrMagnetiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Magnetite is complete. -->
+
+                <!-- End Magnetite Generation -->
+
+
+                <!-- Begin Blue Fluorite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Blue Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrBlueFluoriteDist = "LayeredVeins"'>
+                        <Veins name='recrBlueFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60283270' drawBoundBox='false' boundBoxColor='0x60283270'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrBlueFluoriteFreq ' range=':=  1 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrBlueFluoriteSize ' range=':=  1 * _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrBlueFluoriteSize ' range=':=  1 * _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Blue Fluorite is
+                     complete. -->
+
+
+                <!-- Starting Vanilla Preset for Blue Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrBlueFluoriteDist = "Vanilla"'>
+                        <StandardGen name='recrBlueFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60283270' drawBoundBox='false' boundBoxColor='0x60283270'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrBlueFluoriteFreq ' range=':=  _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Blue Fluorite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Blue Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrBlueFluoriteDist = "Cloud"'>
+                        <Cloud name='recrBlueFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60283270' drawBoundBox='false' boundBoxColor='0x60283270'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrBlueFluoriteFreq ' range=':=  _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrBlueFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60283270' drawBoundBox='false' boundBoxColor='0x60283270'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Blue Fluorite is complete. -->
+
+                <!-- End Blue Fluorite Generation -->
+
+
+                <!-- Begin Pink Fluorite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Pink Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrPinkFluoriteDist = "LayeredVeins"'>
+                        <Veins name='recrPinkFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607A5970' drawBoundBox='false' boundBoxColor='0x607A5970'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrPinkFluoriteFreq ' range=':=  1 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrPinkFluoriteSize ' range=':=  1 * _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrPinkFluoriteSize ' range=':=  1 * _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Pink Fluorite is
+                     complete. -->
+
+
+                <!-- Starting Vanilla Preset for Pink Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrPinkFluoriteDist = "Vanilla"'>
+                        <StandardGen name='recrPinkFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607A5970' drawBoundBox='false' boundBoxColor='0x607A5970'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrPinkFluoriteFreq ' range=':=  _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Pink Fluorite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Pink Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrPinkFluoriteDist = "Cloud"'>
+                        <Cloud name='recrPinkFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607A5970' drawBoundBox='false' boundBoxColor='0x607A5970'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrPinkFluoriteFreq ' range=':=  _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrPinkFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607A5970' drawBoundBox='false' boundBoxColor='0x607A5970'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Pink Fluorite is complete. -->
+
+                <!-- End Pink Fluorite Generation -->
+
+
+                <!-- Begin Orange Fluorite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Orange Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrOrangeFluoriteDist = "LayeredVeins"'>
+                        <Veins name='recrOrangeFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607A5927' drawBoundBox='false' boundBoxColor='0x607A5927'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrOrangeFluoriteFreq ' range=':=  1 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrOrangeFluoriteSize ' range=':=  1 * _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrOrangeFluoriteSize ' range=':=  1 * _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Orange Fluorite is
+                     complete. -->
+
+
+                <!-- Starting Vanilla Preset for Orange Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrOrangeFluoriteDist = "Vanilla"'>
+                        <StandardGen name='recrOrangeFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607A5927' drawBoundBox='false' boundBoxColor='0x607A5927'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrOrangeFluoriteFreq ' range=':=  _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Orange Fluorite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Orange Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrOrangeFluoriteDist = "Cloud"'>
+                        <Cloud name='recrOrangeFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607A5927' drawBoundBox='false' boundBoxColor='0x607A5927'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrOrangeFluoriteFreq ' range=':=  _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrOrangeFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607A5927' drawBoundBox='false' boundBoxColor='0x607A5927'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Orange Fluorite is complete. -->
+
+                <!-- End Orange Fluorite Generation -->
+
+
+                <!-- Begin Magenta Fluorite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Magenta
+                     Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrMagentaFluoriteDist = "LayeredVeins"'>
+                        <Veins name='recrMagentaFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60602774' drawBoundBox='false' boundBoxColor='0x60602774'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrMagentaFluoriteFreq ' range=':=  1 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrMagentaFluoriteSize ' range=':=  1 * _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrMagentaFluoriteSize ' range=':=  1 * _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Magenta Fluorite is
+                     complete. -->
+
+
+                <!-- Starting Vanilla Preset for Magenta Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrMagentaFluoriteDist = "Vanilla"'>
+                        <StandardGen name='recrMagentaFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60602774' drawBoundBox='false' boundBoxColor='0x60602774'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrMagentaFluoriteFreq ' range=':=  _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Magenta Fluorite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Magenta Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrMagentaFluoriteDist = "Cloud"'>
+                        <Cloud name='recrMagentaFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60602774' drawBoundBox='false' boundBoxColor='0x60602774'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrMagentaFluoriteFreq ' range=':=  _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrMagentaFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60602774' drawBoundBox='false' boundBoxColor='0x60602774'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Magenta Fluorite is complete. -->
+
+                <!-- End Magenta Fluorite Generation -->
+
+
+                <!-- Begin Green Fluorite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Green Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrGreenFluoriteDist = "LayeredVeins"'>
+                        <Veins name='recrGreenFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60347D3B' drawBoundBox='false' boundBoxColor='0x60347D3B'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrGreenFluoriteFreq ' range=':=  1 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrGreenFluoriteSize ' range=':=  1 * _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrGreenFluoriteSize ' range=':=  1 * _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Green Fluorite is
+                     complete. -->
+
+
+                <!-- Starting Vanilla Preset for Green Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrGreenFluoriteDist = "Vanilla"'>
+                        <StandardGen name='recrGreenFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60347D3B' drawBoundBox='false' boundBoxColor='0x60347D3B'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrGreenFluoriteFreq ' range=':=  _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Green Fluorite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Green Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrGreenFluoriteDist = "Cloud"'>
+                        <Cloud name='recrGreenFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60347D3B' drawBoundBox='false' boundBoxColor='0x60347D3B'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrGreenFluoriteFreq ' range=':=  _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrGreenFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60347D3B' drawBoundBox='false' boundBoxColor='0x60347D3B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Green Fluorite is complete. -->
+
+                <!-- End Green Fluorite Generation -->
+
+
+                <!-- Begin Red Fluorite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Red Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrRedFluoriteDist = "LayeredVeins"'>
+                        <Veins name='recrRedFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60974747' drawBoundBox='false' boundBoxColor='0x60974747'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrRedFluoriteFreq ' range=':=  1 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrRedFluoriteSize ' range=':=  1 * _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrRedFluoriteSize ' range=':=  1 * _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Red Fluorite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Red Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrRedFluoriteDist = "Vanilla"'>
+                        <StandardGen name='recrRedFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60974747' drawBoundBox='false' boundBoxColor='0x60974747'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrRedFluoriteFreq ' range=':=  _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Red Fluorite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Red Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrRedFluoriteDist = "Cloud"'>
+                        <Cloud name='recrRedFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60974747' drawBoundBox='false' boundBoxColor='0x60974747'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrRedFluoriteFreq ' range=':=  _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrRedFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60974747' drawBoundBox='false' boundBoxColor='0x60974747'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Red Fluorite is complete. -->
+
+                <!-- End Red Fluorite Generation -->
+
+
+                <!-- Begin White Fluorite Generation -->
+
+                <!-- Starting LayeredVeins Preset for White Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrWhiteFluoriteDist = "LayeredVeins"'>
+                        <Veins name='recrWhiteFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60969696' drawBoundBox='false' boundBoxColor='0x60969696'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrWhiteFluoriteFreq ' range=':=  1 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrWhiteFluoriteSize ' range=':=  1 * _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrWhiteFluoriteSize ' range=':=  1 * _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for White Fluorite is
+                     complete. -->
+
+
+                <!-- Starting Vanilla Preset for White Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrWhiteFluoriteDist = "Vanilla"'>
+                        <StandardGen name='recrWhiteFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60969696' drawBoundBox='false' boundBoxColor='0x60969696'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrWhiteFluoriteFreq ' range=':=  _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for White Fluorite is complete. -->
+
+
+                <!-- Starting Cloud Preset for White Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrWhiteFluoriteDist = "Cloud"'>
+                        <Cloud name='recrWhiteFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60969696' drawBoundBox='false' boundBoxColor='0x60969696'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrWhiteFluoriteFreq ' range=':=  _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrWhiteFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60969696' drawBoundBox='false' boundBoxColor='0x60969696'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for White Fluorite is complete. -->
+
+                <!-- End White Fluorite Generation -->
+
+
+                <!-- Begin Yellow Fluorite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Yellow Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrYellowFluoriteDist = "LayeredVeins"'>
+                        <Veins name='recrYellowFluoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60978834' drawBoundBox='false' boundBoxColor='0x60978834'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrYellowFluoriteFreq ' range=':=  1 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrYellowFluoriteSize ' range=':=  1 * _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrYellowFluoriteSize ' range=':=  1 * _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Yellow Fluorite is
+                     complete. -->
+
+
+                <!-- Starting Vanilla Preset for Yellow Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrYellowFluoriteDist = "Vanilla"'>
+                        <StandardGen name='recrYellowFluoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60978834' drawBoundBox='false' boundBoxColor='0x60978834'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrYellowFluoriteFreq ' range=':=  _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Yellow Fluorite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Yellow Fluorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrYellowFluoriteDist = "Cloud"'>
+                        <Cloud name='recrYellowFluoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60978834' drawBoundBox='false' boundBoxColor='0x60978834'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrYellowFluoriteFreq ' range=':=  _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrYellowFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60978834' drawBoundBox='false' boundBoxColor='0x60978834'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Yellow Fluorite is complete. -->
+
+                <!-- End Yellow Fluorite Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
+
+
+
+            <!-- Nether Setup Beginning -->
+
+            <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
+
+                <!-- Starting Original "Nether" Block Removal -->
+
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='recrNetherBlockSubstitute0' block='minecraft:stone'>
+                        <Description>
+                            Replace vanilla-generated ore clusters.
+                        </Description>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Yellow Fluorite is complete. -->
 
-            <!-- End Yellow Fluorite Generation -->
+                <!-- Original "Nether" Block Removal Complete -->
 
-            <!-- Finished adding blocks -->
+                <!-- Adding blocks -->
+
+                <!-- Begin Ammonium Chloride Generation -->
+
+                <!-- Starting SparseVeins Preset for Ammonium
+                     Chloride. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrAmmoniumChlorideDist = "SparseVeins"'>
+                        <Veins name='recrAmmoniumChlorideVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrAmmoniumChlorideFreq ' range=':=  1 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrAmmoniumChlorideSize ' range=':=  1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  0 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrAmmoniumChlorideSize ' range=':=  1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Ammonium Chloride is
+                     complete. -->
+
+
+                <!-- Starting Vanilla Preset for Ammonium Chloride. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrAmmoniumChlorideDist = "Vanilla"'>
+                        <StandardGen name='recrAmmoniumChlorideStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * recrAmmoniumChlorideFreq ' range=':=  _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':=  0 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Ammonium Chloride is complete. -->
+
+
+                <!-- Starting Cloud Preset for Ammonium Chloride. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrAmmoniumChlorideDist = "Cloud"'>
+                        <Cloud name='recrAmmoniumChlorideCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrAmmoniumChlorideFreq ' range=':=  _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':=  0 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrAmmoniumChlorideHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Ammonium Chloride is complete. -->
+
+                <!-- End Ammonium Chloride Generation -->
+
+
+                <!-- Begin Thorite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Thorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrThoriteDist = "LayeredVeins"'>
+                        <Veins name='recrThoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.715 * _default_ * recrThoriteFreq ' range=':=  1 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * recrThoriteSize ' range=':=  1 * _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 18.5 ' range=':=  13.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * recrThoriteSize ' range=':=  1 * _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Thorite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Thorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrThoriteDist = "Vanilla"'>
+                        <StandardGen name='recrThoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 24 * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * recrThoriteFreq ' range=':=  _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 18.5 ' range=':=  13.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Thorite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Thorite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrThoriteDist = "Cloud"'>
+                        <Cloud name='recrThoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * recrThoriteFreq ' range=':=  _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 18.5 ' range=':=  13.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrThoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Thorite is complete. -->
+
+                <!-- End Thorite Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Nether Setup Complete -->
+
+
+
+
+
+            <!-- End Setup Beginning -->
+
+            <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
+
+                <!-- Starting Original "End" Block Removal -->
+
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='recrEndBlockSubstitute0' block='minecraft:stone'>
+                        <Description>
+                            Replace vanilla-generated ore clusters.
+                        </Description>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
+                    </Substitute>
+                </IfCondition>
+
+                <!-- Original "End" Block Removal Complete -->
+
+                <!-- Adding blocks -->
+
+                <!-- Begin End Pitchblende Generation -->
+
+                <!-- Starting SparseVeins Preset for End Pitchblende. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrEndPitchblendeDist = "SparseVeins"'>
+                        <Veins name='recrEndPitchblendeVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.430 * _default_ * recrEndPitchblendeFreq ' range=':=  1 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.508 * _default_ * recrEndPitchblendeSize ' range=':=  1 * _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 34.5 ' range=':=  29.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.508 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.508 * _default_ * recrEndPitchblendeSize ' range=':=  1 * _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for End Pitchblende is
+                     complete. -->
+
+
+                <!-- Starting Vanilla Preset for End Pitchblende. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrEndPitchblendeDist = "Vanilla"'>
+                        <StandardGen name='recrEndPitchblendeStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 16 * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * recrEndPitchblendeFreq ' range=':=  _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 34.5 ' range=':=  29.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for End Pitchblende is complete. -->
+
+
+                <!-- Starting Cloud Preset for End Pitchblende. -->
+                <ConfigSection>
+                    <IfCondition condition=':= recrEndPitchblendeDist = "Cloud"'>
+                        <Cloud name='recrEndPitchblendeCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.522 * _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.522 * _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * recrEndPitchblendeFreq ' range=':=  _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 34.5 ' range=':=  29.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='recrEndPitchblendeHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for End Pitchblende is complete. -->
+
+                <!-- End End Pitchblende Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- End Setup Complete -->
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
-
-
-        <!-- Nether Setup Beginning -->
-
-        <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
-
-            <!-- Starting Original "Nether" Block Removal -->
-
-            <Substitute name='recrNetherBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
-                <Replaces block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Nether" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Ammonium Chloride Generation -->
-
-            <!-- Starting SparseVeins Preset for Ammonium Chloride. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrAmmoniumChlorideDist = "SparseVeins"'>
-                    <Veins name='recrAmmoniumChlorideVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrAmmoniumChlorideFreq ' range=':=  1 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrAmmoniumChlorideSize ' range=':=  1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  0 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrAmmoniumChlorideSize ' range=':=  1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Ammonium Chloride is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Ammonium Chloride. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrAmmoniumChlorideDist = "Vanilla"'>
-                    <StandardGen name='recrAmmoniumChlorideStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 6 * recrAmmoniumChlorideFreq ' range=':=  _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 32 ' range=':=  0 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Ammonium Chloride is complete. -->
-
-
-            <!-- Starting Cloud Preset for Ammonium Chloride. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrAmmoniumChlorideDist = "Cloud"'>
-                    <Cloud name='recrAmmoniumChlorideCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrAmmoniumChlorideFreq ' range=':=  _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 32 ' range=':=  0 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrAmmoniumChlorideHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Ammonium Chloride is complete. -->
-
-            <!-- End Ammonium Chloride Generation -->
-
-
-            <!-- Begin Thorite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Thorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrThoriteDist = "LayeredVeins"'>
-                    <Veins name='recrThoriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.715 * _default_ * recrThoriteFreq ' range=':=  1 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * recrThoriteSize ' range=':=  1 * _default_ * recrThoriteSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 18.5 ' range=':=  13.5 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * recrThoriteSize ' range=':=  1 * _default_ * recrThoriteSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Thorite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Thorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrThoriteDist = "Vanilla"'>
-                    <StandardGen name='recrThoriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 24 * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * recrThoriteFreq ' range=':=  _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 18.5 ' range=':=  13.5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Thorite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Thorite. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrThoriteDist = "Cloud"'>
-                    <Cloud name='recrThoriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.076 * _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.076 * _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * recrThoriteFreq ' range=':=  _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 18.5 ' range=':=  13.5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrThoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Thorite is complete. -->
-
-            <!-- End Thorite Generation -->
-
-            <!-- Finished adding blocks -->
-
-        </IfCondition>
-        <!-- Nether Setup Complete -->
-
-
-
-
-
-        <!-- End Setup Beginning -->
-
-        <IfCondition condition=':= dimension.generator = "EndRandomLevelSource"'>
-
-            <!-- Starting Original "End" Block Removal -->
-
-            <Substitute name='recrEndBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "End" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin End Pitchblende Generation -->
-
-            <!-- Starting SparseVeins Preset for End Pitchblende. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrEndPitchblendeDist = "SparseVeins"'>
-                    <Veins name='recrEndPitchblendeVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 3.430 * _default_ * recrEndPitchblendeFreq ' range=':=  1 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.508 * _default_ * recrEndPitchblendeSize ' range=':=  1 * _default_ * recrEndPitchblendeSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 34.5 ' range=':=  29.5 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.508 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.508 * _default_ * recrEndPitchblendeSize ' range=':=  1 * _default_ * recrEndPitchblendeSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for End Pitchblende is complete. -->
-
-
-            <!-- Starting Vanilla Preset for End Pitchblende. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrEndPitchblendeDist = "Vanilla"'>
-                    <StandardGen name='recrEndPitchblendeStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 16 * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 6 * recrEndPitchblendeFreq ' range=':=  _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 34.5 ' range=':=  29.5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for End Pitchblende is complete. -->
-
-
-            <!-- Starting Cloud Preset for End Pitchblende. -->
-            <ConfigSection>
-                <IfCondition condition=':= recrEndPitchblendeDist = "Cloud"'>
-                    <Cloud name='recrEndPitchblendeCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.522 * _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.522 * _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * recrEndPitchblendeFreq ' range=':=  _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 34.5 ' range=':=  29.5 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='recrEndPitchblendeHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for End Pitchblende is complete. -->
-
-            <!-- End End Pitchblende Generation -->
-
-            <!-- Finished adding blocks -->
-
-        </IfCondition>
-        <!-- End Setup Complete -->
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -7,6 +7,8 @@
      ================================================================= -->
 
 
+<!-- An expansion to RotaryCraft, this mod adds oregen necessary for
+     managing nuclear reactions in various useful ways. -->
 
 
 
@@ -668,19 +670,19 @@
                         <BiomeType name='Mushroom'  />
                         <BiomeType name='Ocean'  />
                         <BiomeType name='River'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.418 * _default_ * recrPitchblendeFreq ' range=':=  1 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.342 * _default_ * recrPitchblendeSize ' range=':=  1 * _default_ * recrPitchblendeSize ' type='normal' />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrPitchblendeFreq ' range=':=  1 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrPitchblendeSize ' range=':=  1 * _default_ * recrPitchblendeSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  8 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.342 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.342 * _default_ * recrPitchblendeSize ' range=':=  1 * _default_ * recrPitchblendeSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrPitchblendeSize ' range=':=  1 * _default_ * recrPitchblendeSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
@@ -702,8 +704,8 @@
                         <BiomeType name='Mushroom'  />
                         <BiomeType name='Ocean'  />
                         <BiomeType name='River'  />
-                        <Setting name='Size' avg=':= 16 * recrPitchblendeSize ' range=':=  2 * recrPitchblendeSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * recrPitchblendeFreq ' range=':=  1 * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 16 * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * recrPitchblendeFreq ' range=':=  _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 16 ' range=':=  8 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -734,9 +736,9 @@
                         <BiomeType name='Mushroom'  />
                         <BiomeType name='Ocean'  />
                         <BiomeType name='River'  />
-                        <Setting name='CloudRadius' avg=':= 0.757 * _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.757 * _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.572  * _default_ * recrPitchblendeFreq ' range=':=  _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrPitchblendeFreq ' range=':=  _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 16 ' range=':=  8 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -789,7 +791,7 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.616 * _default_ * recrCadmiumFreq ' range=':=  1 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.615 * _default_ * recrCadmiumFreq ' range=':=  1 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeSize' avg=':= 0.851 * _default_ * recrCadmiumSize ' range=':=  1 * _default_ * recrCadmiumSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 22 ' range=':=  10 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -821,8 +823,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 9 * recrCadmiumSize ' range=':=  2 * recrCadmiumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * recrCadmiumFreq ' range=':=  1 * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 9 * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * recrCadmiumFreq ' range=':=  _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 22 ' range=':=  10 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -851,9 +853,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.382 * _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.382 * _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.146  * _default_ * recrCadmiumFreq ' range=':=  _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.109 * _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.109 * _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.229  * _default_ * recrCadmiumFreq ' range=':=  _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 22 ' range=':=  10 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -907,18 +909,18 @@
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
                         <Setting name='MotherlodeFrequency' avg=':= 0.443 * _default_ * recrIndiumFreq ' range=':=  1 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.763 * _default_ * recrIndiumSize ' range=':=  1 * _default_ * recrIndiumSize ' type='normal' />
+                        <Setting name='MotherlodeSize' avg=':= 0.762 * _default_ * recrIndiumSize ' range=':=  1 * _default_ * recrIndiumSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  16 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.763 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.763 * _default_ * recrIndiumSize ' range=':=  1 * _default_ * recrIndiumSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.762 * _default_ * recrIndiumSize ' range=':=  1 * _default_ * recrIndiumSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
@@ -938,8 +940,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 7 * recrIndiumSize ' range=':=  2 * recrIndiumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * recrIndiumFreq ' range=':=  1 * recrIndiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 7 * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * recrIndiumFreq ' range=':=  _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 11 ' range=':=  16 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -968,9 +970,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.324 * _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.324 * _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.105  * _default_ * recrIndiumFreq ' range=':=  _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 0.941 * _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.941 * _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.885  * _default_ * recrIndiumFreq ' range=':=  _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 11 ' range=':=  16 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1055,8 +1057,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 9 * recrSilverSize ' range=':=  2 * recrSilverSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * recrSilverFreq ' range=':=  1 * recrSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 9 * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * recrSilverFreq ' range=':=  _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 28 ' range=':=  12 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -1085,9 +1087,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.345 * _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.345 * _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.119  * _default_ * recrSilverFreq ' range=':=  _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.002 * _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.002 * _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * recrSilverFreq ' range=':=  _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 28 ' range=':=  12 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1146,19 +1148,19 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.418 * _default_ * recrCalciteFreq ' range=':=  1 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.342 * _default_ * recrCalciteSize ' range=':=  1 * _default_ * recrCalciteSize ' type='normal' />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrCalciteFreq ' range=':=  1 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrCalciteSize ' range=':=  1 * _default_ * recrCalciteSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.342 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.342 * _default_ * recrCalciteSize ' range=':=  1 * _default_ * recrCalciteSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrCalciteSize ' range=':=  1 * _default_ * recrCalciteSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
@@ -1178,8 +1180,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * recrCalciteSize ' range=':=  2 * recrCalciteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * recrCalciteFreq ' range=':=  1 * recrCalciteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 4 * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 12 * recrCalciteFreq ' range=':=  _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -1208,9 +1210,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.757 * _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.757 * _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.572  * _default_ * recrCalciteFreq ' range=':=  _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrCalciteFreq ' range=':=  _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1269,19 +1271,19 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 3.694 * _default_ * recrMagnetiteFreq ' range=':=  1 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.546 * _default_ * recrMagnetiteSize ' range=':=  1 * _default_ * recrMagnetiteSize ' type='normal' />
+                        <Setting name='MotherlodeFrequency' avg=':= 3.705 * _default_ * recrMagnetiteFreq ' range=':=  1 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.547 * _default_ * recrMagnetiteSize ' range=':=  1 * _default_ * recrMagnetiteSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.546 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.547 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.546 * _default_ * recrMagnetiteSize ' range=':=  1 * _default_ * recrMagnetiteSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.547 * _default_ * recrMagnetiteSize ' range=':=  1 * _default_ * recrMagnetiteSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
@@ -1301,8 +1303,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 16 * recrMagnetiteSize ' range=':=  2 * recrMagnetiteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 7 * recrMagnetiteFreq ' range=':=  1 * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 16 * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 7 * recrMagnetiteFreq ' range=':=  _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -1331,9 +1333,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.935 * _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.935 * _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.874  * _default_ * recrMagnetiteFreq ' range=':=  _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.582 * _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.582 * _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.503  * _default_ * recrMagnetiteFreq ' range=':=  _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1418,8 +1420,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * recrBlueFluoriteSize ' range=':=  2 * recrBlueFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * recrBlueFluoriteFreq ' range=':=  1 * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 1 * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1.5 * recrBlueFluoriteFreq ' range=':=  _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -1448,9 +1450,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.312 * _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.312 * _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.097  * _default_ * recrBlueFluoriteFreq ' range=':=  _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrBlueFluoriteFreq ' range=':=  _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1535,8 +1537,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * recrPinkFluoriteSize ' range=':=  2 * recrPinkFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * recrPinkFluoriteFreq ' range=':=  1 * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 1 * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1.5 * recrPinkFluoriteFreq ' range=':=  _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -1565,9 +1567,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.312 * _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.312 * _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.097  * _default_ * recrPinkFluoriteFreq ' range=':=  _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrPinkFluoriteFreq ' range=':=  _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1652,8 +1654,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * recrOrangeFluoriteSize ' range=':=  2 * recrOrangeFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * recrOrangeFluoriteFreq ' range=':=  1 * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 1 * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1.5 * recrOrangeFluoriteFreq ' range=':=  _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -1682,9 +1684,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.312 * _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.312 * _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.097  * _default_ * recrOrangeFluoriteFreq ' range=':=  _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrOrangeFluoriteFreq ' range=':=  _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1769,8 +1771,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * recrMagentaFluoriteSize ' range=':=  2 * recrMagentaFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * recrMagentaFluoriteFreq ' range=':=  1 * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 1 * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1.5 * recrMagentaFluoriteFreq ' range=':=  _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -1799,9 +1801,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.312 * _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.312 * _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.097  * _default_ * recrMagentaFluoriteFreq ' range=':=  _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrMagentaFluoriteFreq ' range=':=  _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1886,8 +1888,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * recrGreenFluoriteSize ' range=':=  2 * recrGreenFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * recrGreenFluoriteFreq ' range=':=  1 * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 1 * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1.5 * recrGreenFluoriteFreq ' range=':=  _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -1916,9 +1918,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.312 * _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.312 * _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.097  * _default_ * recrGreenFluoriteFreq ' range=':=  _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrGreenFluoriteFreq ' range=':=  _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -2003,8 +2005,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * recrRedFluoriteSize ' range=':=  2 * recrRedFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * recrRedFluoriteFreq ' range=':=  1 * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 1 * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1.5 * recrRedFluoriteFreq ' range=':=  _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -2033,9 +2035,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.312 * _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.312 * _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.097  * _default_ * recrRedFluoriteFreq ' range=':=  _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrRedFluoriteFreq ' range=':=  _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -2120,8 +2122,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * recrWhiteFluoriteSize ' range=':=  2 * recrWhiteFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * recrWhiteFluoriteFreq ' range=':=  1 * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 1 * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1.5 * recrWhiteFluoriteFreq ' range=':=  _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -2150,9 +2152,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.312 * _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.312 * _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.097  * _default_ * recrWhiteFluoriteFreq ' range=':=  _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrWhiteFluoriteFreq ' range=':=  _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -2237,8 +2239,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * recrYellowFluoriteSize ' range=':=  2 * recrYellowFluoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * recrYellowFluoriteFreq ' range=':=  1 * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 1 * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1.5 * recrYellowFluoriteFreq ' range=':=  _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -2267,9 +2269,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.312 * _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.312 * _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.097  * _default_ * recrYellowFluoriteFreq ' range=':=  _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrYellowFluoriteFreq ' range=':=  _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -2358,19 +2360,19 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 2.418 * _default_ * recrAmmoniumChlorideFreq ' range=':=  1 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.342 * _default_ * recrAmmoniumChlorideSize ' range=':=  1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                        <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrAmmoniumChlorideFreq ' range=':=  1 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrAmmoniumChlorideSize ' range=':=  1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  0 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.342 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.342 * _default_ * recrAmmoniumChlorideSize ' range=':=  1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrAmmoniumChlorideSize ' range=':=  1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
@@ -2390,8 +2392,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * recrAmmoniumChlorideSize ' range=':=  2 * recrAmmoniumChlorideSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 6 * recrAmmoniumChlorideFreq ' range=':=  1 * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 8 * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 6 * recrAmmoniumChlorideFreq ' range=':=  _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 32 ' range=':=  0 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -2420,9 +2422,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.757 * _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.757 * _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.572  * _default_ * recrAmmoniumChlorideFreq ' range=':=  _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrAmmoniumChlorideFreq ' range=':=  _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 32 ' range=':=  0 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -2475,19 +2477,19 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * recrThoriteFreq ' range=':=  1 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * recrThoriteSize ' range=':=  1 * _default_ * recrThoriteSize ' type='normal' />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.715 * _default_ * recrThoriteFreq ' range=':=  1 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * recrThoriteSize ' range=':=  1 * _default_ * recrThoriteSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 18.5 ' range=':=  13.5 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * recrThoriteSize ' range=':=  1 * _default_ * recrThoriteSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * recrThoriteSize ' range=':=  1 * _default_ * recrThoriteSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
@@ -2507,8 +2509,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 24 * recrThoriteSize ' range=':=  2 * recrThoriteSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * recrThoriteFreq ' range=':=  1 * recrThoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 24 * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * recrThoriteFreq ' range=':=  _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 18.5 ' range=':=  13.5 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -2537,9 +2539,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.371 * _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.371 * _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.137  * _default_ * recrThoriteFreq ' range=':=  _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.076 * _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.076 * _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * recrThoriteFreq ' range=':=  _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 18.5 ' range=':=  13.5 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -2627,19 +2629,19 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 3.420 * _default_ * recrEndPitchblendeFreq ' range=':=  1 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.507 * _default_ * recrEndPitchblendeSize ' range=':=  1 * _default_ * recrEndPitchblendeSize ' type='normal' />
+                        <Setting name='MotherlodeFrequency' avg=':= 3.430 * _default_ * recrEndPitchblendeFreq ' range=':=  1 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.508 * _default_ * recrEndPitchblendeSize ' range=':=  1 * _default_ * recrEndPitchblendeSize ' type='normal' />
                         <Setting name='MotherlodeHeight' avg=':= 34.5 ' range=':=  29.5 ' type='normal' scaleTo='base' />
                         <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.507 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.508 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                         <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                         <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='SegmentLength' avg=':= _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
                         <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.507 * _default_ * recrEndPitchblendeSize ' range=':=  1 * _default_ * recrEndPitchblendeSize ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.508 * _default_ * recrEndPitchblendeSize ' range=':=  1 * _default_ * recrEndPitchblendeSize ' type='normal' />
                         <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </Veins>
@@ -2659,8 +2661,8 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 16 * recrEndPitchblendeSize ' range=':=  2 * recrEndPitchblendeSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 6 * recrEndPitchblendeFreq ' range=':=  1 * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Size' avg=':= 16 * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 6 * recrEndPitchblendeFreq ' range=':=  _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
                         <Setting name='Height' avg=':= 34.5 ' range=':=  29.5 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     </StandardGen>
@@ -2689,9 +2691,9 @@
                         <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
                         <Replaces block='minecraft:stone' weight='1.0' />
                         <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.900 * _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.900 * _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.809  * _default_ * recrEndPitchblendeFreq ' range=':=  _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudRadius' avg=':= 1.522 * _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.522 * _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * recrEndPitchblendeFreq ' range=':=  _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
                         <Setting name='CloudHeight' avg=':= 34.5 ' range=':=  29.5 ' type='normal' scaleTo='base' />
                         <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -27,10 +27,15 @@
                     Distribution options for Simple Ores Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableSimpleOres' displayName='Handle Simple Ores Setup?' default='true' displayState='shown_dynamic' displayGroup='groupSimpleOres'>
+                <Description> Should Custom Ore Generation handle Simple Ores ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Simple Ores ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Simple Ores ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Copper Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='smpoCopperDist'  displayState='shown' displayGroup='groupSimpleOres'>
+                <OptionChoice name='smpoCopperDist'  displayState=':= if(?enableSimpleOres, "shown", "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Controls how Copper is generated </Description>
                     <DisplayName>Simple Ores Copper</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -50,11 +55,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='smpoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                <OptionNumeric name='smpoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?enableSimpleOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Frequency multiplier for Simple Ores Copper distributions </Description>
                     <DisplayName>Simple Ores Copper Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='smpoCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                <OptionNumeric name='smpoCopperSize' default='1'  min='0' max='5' displayState=':= if(?enableSimpleOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Size multiplier for Simple Ores Copper distributions </Description>
                     <DisplayName>Simple Ores Copper Size</DisplayName>
                 </OptionNumeric>
@@ -64,7 +69,7 @@
 
             <!-- Tin Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='smpoTinDist'  displayState='shown' displayGroup='groupSimpleOres'>
+                <OptionChoice name='smpoTinDist'  displayState=':= if(?enableSimpleOres, "shown", "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Controls how Tin is generated </Description>
                     <DisplayName>Simple Ores Tin</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -84,11 +89,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='smpoTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                <OptionNumeric name='smpoTinFreq' default='1'  min='0' max='5' displayState=':= if(?enableSimpleOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Frequency multiplier for Simple Ores Tin distributions </Description>
                     <DisplayName>Simple Ores Tin Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='smpoTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                <OptionNumeric name='smpoTinSize' default='1'  min='0' max='5' displayState=':= if(?enableSimpleOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Size multiplier for Simple Ores Tin distributions </Description>
                     <DisplayName>Simple Ores Tin Size</DisplayName>
                 </OptionNumeric>
@@ -98,7 +103,7 @@
 
             <!-- Mythril Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='smpoMythrilDist'  displayState='shown' displayGroup='groupSimpleOres'>
+                <OptionChoice name='smpoMythrilDist'  displayState=':= if(?enableSimpleOres, "shown", "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Controls how Mythril is generated </Description>
                     <DisplayName>Simple Ores Mythril</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -118,11 +123,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Mythril is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='smpoMythrilFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                <OptionNumeric name='smpoMythrilFreq' default='1'  min='0' max='5' displayState=':= if(?enableSimpleOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Frequency multiplier for Simple Ores Mythril distributions </Description>
                     <DisplayName>Simple Ores Mythril Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='smpoMythrilSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                <OptionNumeric name='smpoMythrilSize' default='1'  min='0' max='5' displayState=':= if(?enableSimpleOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Size multiplier for Simple Ores Mythril distributions </Description>
                     <DisplayName>Simple Ores Mythril Size</DisplayName>
                 </OptionNumeric>
@@ -132,7 +137,7 @@
 
             <!-- Adamantium Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='smpoAdamantiumDist'  displayState='shown' displayGroup='groupSimpleOres'>
+                <OptionChoice name='smpoAdamantiumDist'  displayState=':= if(?enableSimpleOres, "shown", "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Controls how Adamantium is generated </Description>
                     <DisplayName>Simple Ores Adamantium</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -152,11 +157,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Adamantium is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='smpoAdamantiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                <OptionNumeric name='smpoAdamantiumFreq' default='1'  min='0' max='5' displayState=':= if(?enableSimpleOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Frequency multiplier for Simple Ores Adamantium distributions </Description>
                     <DisplayName>Simple Ores Adamantium Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='smpoAdamantiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                <OptionNumeric name='smpoAdamantiumSize' default='1'  min='0' max='5' displayState=':= if(?enableSimpleOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Size multiplier for Simple Ores Adamantium distributions </Description>
                     <DisplayName>Simple Ores Adamantium Size</DisplayName>
                 </OptionNumeric>
@@ -166,7 +171,7 @@
 
             <!-- Onyx Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='smpoOnyxDist'  displayState='shown' displayGroup='groupSimpleOres'>
+                <OptionChoice name='smpoOnyxDist'  displayState=':= if(?enableSimpleOres, "shown", "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Controls how Onyx is generated </Description>
                     <DisplayName>Simple Ores Onyx</DisplayName>
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -186,11 +191,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Onyx is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='smpoOnyxFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                <OptionNumeric name='smpoOnyxFreq' default='1'  min='0' max='5' displayState=':= if(?enableSimpleOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Frequency multiplier for Simple Ores Onyx distributions </Description>
                     <DisplayName>Simple Ores Onyx Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='smpoOnyxSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                <OptionNumeric name='smpoOnyxSize' default='1'  min='0' max='5' displayState=':= if(?enableSimpleOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupSimpleOres'>
                     <Description> Size multiplier for Simple Ores Onyx distributions </Description>
                     <DisplayName>Simple Ores Onyx Size</DisplayName>
                 </OptionNumeric>
@@ -200,663 +205,681 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableSimpleOres'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='smpoOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='simpleores:adamantium_ore' weight='1.0' />
-                <Replaces block='simpleores:copper_ore' weight='1.0' />
-                <Replaces block='simpleores:mythril_ore' weight='1.0' />
-                <Replaces block='simpleores:tin_ore' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Copper Generation -->
-
-            <!-- Starting LayeredVeins Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoCopperDist = "LayeredVeins"'>
-                    <Veins name='smpoCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='smpoOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='simpleores:copper_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.854 * _default_ * smpoCopperFreq ' range=':=  _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.228 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.228 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.228 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <Replaces block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <Replaces block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <Replaces block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <Replaces block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Copper is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoCopperDist = "Cloud"'>
-                    <Cloud name='smpoCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='simpleores:copper_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.924 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.924 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 3.702  * _default_ * smpoCopperFreq ' range=':=  _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='smpoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Copper Generation -->
+
+                <!-- Starting LayeredVeins Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoCopperDist = "LayeredVeins"'>
+                        <Veins name='smpoCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='simpleores:copper_ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.854 * _default_ * smpoCopperFreq ' range=':=  _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.228 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.228 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.228 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Copper is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoCopperDist = "Vanilla"'>
-                    <StandardGen name='smpoCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='simpleores:copper_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 7 * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 35 * smpoCopperFreq ' range=':=  _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Copper is complete. -->
-
-            <!-- End Copper Generation -->
-
-
-            <!-- Begin Tin Generation -->
-
-            <!-- Starting LayeredVeins Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoTinDist = "LayeredVeins"'>
-                    <Veins name='smpoTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='simpleores:tin_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.716 * _default_ * smpoTinFreq ' range=':=  _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Tin is complete. -->
-
-
-            <!-- Starting Cloud Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoTinDist = "Cloud"'>
-                    <Cloud name='smpoTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='simpleores:tin_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.851 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.851 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 3.427  * _default_ * smpoTinFreq ' range=':=  _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='smpoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <!-- Starting Cloud Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoCopperDist = "Cloud"'>
+                        <Cloud name='smpoCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='simpleores:tin_ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Tin is complete. -->
+                            <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.924 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.924 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 3.702  * _default_ * smpoCopperFreq ' range=':=  _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='smpoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoTinDist = "Vanilla"'>
-                    <StandardGen name='smpoTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='simpleores:tin_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 7 * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 30 * smpoTinFreq ' range=':=  _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Tin is complete. -->
-
-            <!-- End Tin Generation -->
-
-
-            <!-- Begin Mythril Generation -->
-
-            <!-- Starting LayeredVeins Preset for Mythril. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoMythrilDist = "LayeredVeins"'>
-                    <Veins name='smpoMythrilVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='simpleores:mythril_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.670 * _default_ * smpoMythrilFreq ' range=':=  _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.875 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  15 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.875 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.875 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Mythril is complete. -->
-
-
-            <!-- Starting Cloud Preset for Mythril. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoMythrilDist = "Cloud"'>
-                    <Cloud name='smpoMythrilCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='simpleores:mythril_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.157 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.157 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * smpoMythrilFreq ' range=':=  _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 20 ' range=':=  15 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='smpoMythrilHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <!-- Starting Vanilla Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoCopperDist = "Vanilla"'>
+                        <StandardGen name='smpoCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='simpleores:mythril_ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Mythril is complete. -->
+                            <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 7 * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 35 * smpoCopperFreq ' range=':=  _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Copper is complete. -->
+
+                <!-- End Copper Generation -->
 
 
-            <!-- Starting Vanilla Preset for Mythril. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoMythrilDist = "Vanilla"'>
-                    <StandardGen name='smpoMythrilStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='simpleores:mythril_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 8 * smpoMythrilFreq ' range=':=  _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 20 ' range=':=  15 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Mythril is complete. -->
+                <!-- Begin Tin Generation -->
 
-            <!-- End Mythril Generation -->
-
-
-            <!-- Begin Adamantium Generation -->
-
-            <!-- Starting LayeredVeins Preset for Adamantium. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoAdamantiumDist = "LayeredVeins"'>
-                    <Veins name='smpoAdamantiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * smpoAdamantiumFreq ' range=':=  _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 13 ' range=':=  7 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Adamantium is complete. -->
-
-
-            <!-- Starting Cloud Preset for Adamantium. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoAdamantiumDist = "Cloud"'>
-                    <Cloud name='smpoAdamantiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * smpoAdamantiumFreq ' range=':=  _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 13 ' range=':=  7 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='smpoAdamantiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <!-- Starting LayeredVeins Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoTinDist = "LayeredVeins"'>
+                        <Veins name='smpoTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.716 * _default_ * smpoTinFreq ' range=':=  _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Adamantium is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Tin is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Adamantium. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoAdamantiumDist = "Vanilla"'>
-                    <StandardGen name='smpoAdamantiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <!-- Starting Cloud Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoTinDist = "Cloud"'>
+                        <Cloud name='smpoTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.851 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.851 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 3.427  * _default_ * smpoTinFreq ' range=':=  _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='smpoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tin is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoTinDist = "Vanilla"'>
+                        <StandardGen name='smpoTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 7 * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 30 * smpoTinFreq ' range=':=  _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tin is complete. -->
+
+                <!-- End Tin Generation -->
+
+
+                <!-- Begin Mythril Generation -->
+
+                <!-- Starting LayeredVeins Preset for Mythril. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoMythrilDist = "LayeredVeins"'>
+                        <Veins name='smpoMythrilVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.670 * _default_ * smpoMythrilFreq ' range=':=  _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.875 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  15 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.875 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.875 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Mythril is complete. -->
+
+
+                <!-- Starting Cloud Preset for Mythril. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoMythrilDist = "Cloud"'>
+                        <Cloud name='smpoMythrilCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.157 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.157 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * smpoMythrilFreq ' range=':=  _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 20 ' range=':=  15 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='smpoMythrilHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Mythril is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Mythril. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoMythrilDist = "Vanilla"'>
+                        <StandardGen name='smpoMythrilStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * smpoMythrilFreq ' range=':=  _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 20 ' range=':=  15 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Mythril is complete. -->
+
+                <!-- End Mythril Generation -->
+
+
+                <!-- Begin Adamantium Generation -->
+
+                <!-- Starting LayeredVeins Preset for Adamantium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoAdamantiumDist = "LayeredVeins"'>
+                        <Veins name='smpoAdamantiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * smpoAdamantiumFreq ' range=':=  _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 13 ' range=':=  7 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Adamantium is complete. -->
+
+
+                <!-- Starting Cloud Preset for Adamantium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoAdamantiumDist = "Cloud"'>
+                        <Cloud name='smpoAdamantiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * smpoAdamantiumFreq ' range=':=  _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 13 ' range=':=  7 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='smpoAdamantiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Adamantium is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Adamantium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoAdamantiumDist = "Vanilla"'>
+                        <StandardGen name='smpoAdamantiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * smpoAdamantiumFreq ' range=':=  _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 13 ' range=':=  7 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Adamantium is complete. -->
+
+                <!-- End Adamantium Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
+
+
+
+            <!-- Nether Setup Beginning -->
+
+            <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
+
+                <!-- Starting Original "Nether" Block Removal -->
+
+                <IfCondition condition=':= ?blockExists("minecraft:netherrack")'>
+                    <Substitute name='smpoNetherBlockSubstitute0' block='minecraft:netherrack'>
                         <Description>
-                            A master preset for standardgen ore
-                            distributions.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 4 * smpoAdamantiumFreq ' range=':=  _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 13 ' range=':=  7 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <Replaces block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Adamantium is complete. -->
 
-            <!-- End Adamantium Generation -->
+                <!-- Original "Nether" Block Removal Complete -->
 
-            <!-- Finished adding blocks -->
+                <!-- Adding blocks -->
+
+                <!-- Begin Onyx Generation -->
+
+                <!-- Starting PipeVeins Preset for Onyx. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoOnyxDist = "PipeVeins"'>
+                        <Veins name='smpoOnyxVeins'  inherits='PresetPipeVeins' seed='0x3996' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * smpoOnyxFreq ' range=':=  _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 72 ' range=':=  56 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='smpoOnyxVeinsPipe'  inherits='smpoOnyxVeins' seed='0x3996' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <OreBlock block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <Replaces block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoOnyxSize  * 0.5 ' range=':=  _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoOnyxSize  * 0.5 ' range=':=  _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Onyx is complete. -->
+
+
+                <!-- Starting Cloud Preset for Onyx. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoOnyxDist = "Cloud"'>
+                        <Cloud name='smpoOnyxCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * smpoOnyxFreq ' range=':=  _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 72 ' range=':=  56 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='smpoOnyxHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Onyx is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Onyx. -->
+                <ConfigSection>
+                    <IfCondition condition=':= smpoOnyxDist = "Vanilla"'>
+                        <StandardGen name='smpoOnyxStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 7 * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * smpoOnyxFreq ' range=':=  _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 72 ' range=':=  56 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Onyx is complete. -->
+
+                <!-- End Onyx Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Nether Setup Complete -->
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
-
-
-        <!-- Nether Setup Beginning -->
-
-        <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
-
-            <!-- Starting Original "Nether" Block Removal -->
-
-            <Substitute name='smpoNetherBlockSubstitute0' block='minecraft:netherrack'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='simpleores:onyx_ore' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Nether" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Onyx Generation -->
-
-            <!-- Starting PipeVeins Preset for Onyx. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoOnyxDist = "PipeVeins"'>
-                    <Veins name='smpoOnyxVeins'  inherits='PresetPipeVeins' seed='0x9EEA' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Short sparsely filled veins sloping  up
-                            from near the bottom of the map.
-                        </Description>
-                        <OreBlock block='simpleores:onyx_ore' weight='1.0' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * smpoOnyxFreq ' range=':=  _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 72 ' range=':=  56 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Configuring contained material. -->
-                    <Veins name='smpoOnyxVeinsPipe'  inherits='smpoOnyxVeins' seed='0x9EEA' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <OreBlock block='minecraft:stone' weight='1.0' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Replaces block='simpleores:onyx_ore' weight='1.0' />
-                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoOnyxSize  * 0.5 ' range=':=  _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoOnyxSize  * 0.5 ' range=':=  _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
-                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- PipeVeins Preset for Onyx is complete. -->
-
-
-            <!-- Starting Cloud Preset for Onyx. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoOnyxDist = "Cloud"'>
-                    <Cloud name='smpoOnyxCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='simpleores:onyx_ore' weight='1.0' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * smpoOnyxFreq ' range=':=  _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 72 ' range=':=  56 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='smpoOnyxHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='simpleores:onyx_ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Onyx is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Onyx. -->
-            <ConfigSection>
-                <IfCondition condition=':= smpoOnyxDist = "Vanilla"'>
-                    <StandardGen name='smpoOnyxStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='simpleores:onyx_ore' weight='1.0' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 7 * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 5 * smpoOnyxFreq ' range=':=  _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 72 ' range=':=  56 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Onyx is complete. -->
-
-            <!-- End Onyx Generation -->
-
-            <!-- Finished adding blocks -->
-
-        </IfCondition>
-        <!-- Nether Setup Complete -->
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -1,1080 +1,877 @@
- <!-- ================================================================
-      Custom Ore Generation "Simple Ores" Module: This configuration
-      covers copper, tin, mythril, adamantium, and onyx.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Simple Ores" Module: This configuration
+     covers copper, tin, mythril, adamantium, and onyx.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="simpleores">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+<!-- This mod provides several "simple ores" to expand Minecraft
+     gameplay. -->
+
+
+
+
+<!-- Is the "Simple Ores" mod on the system?  Let's find out! -->
+<IfModInstalled name="simpleores">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupSimpleOres' displayName='Simple Ores' displayState='shown'>
+                <Description>
+                    Distribution options for Simple Ores Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Copper Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupSimpleOres' displayName='Simple Ores' displayState='shown'> 
-                    <Description>
-                        Distribution options for Simple Ores Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Copper Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='smpoCopperDist'  displayState='shown' displayGroup='groupSimpleOres'> 
-                        <Description> Controls how Copper is generated </Description> 
-                        <DisplayName>Simple Ores Copper</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='smpoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
-                        <Description> Frequency multiplier for Simple Ores Copper distributions </Description>
-                        <DisplayName>Simple Ores Copper Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='smpoCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
-                        <Description> Size multiplier for Simple Ores Copper distributions </Description>
-                        <DisplayName>Simple Ores Copper Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Copper Configuration UI Complete -->
-                
-                
-                <!-- Tin Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='smpoTinDist'  displayState='shown' displayGroup='groupSimpleOres'> 
-                        <Description> Controls how Tin is generated </Description> 
-                        <DisplayName>Simple Ores Tin</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='smpoTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
-                        <Description> Frequency multiplier for Simple Ores Tin distributions </Description>
-                        <DisplayName>Simple Ores Tin Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='smpoTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
-                        <Description> Size multiplier for Simple Ores Tin distributions </Description>
-                        <DisplayName>Simple Ores Tin Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Tin Configuration UI Complete -->
-                
-                
-                <!-- Mythril Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='smpoMythrilDist'  displayState='shown' displayGroup='groupSimpleOres'> 
-                        <Description> Controls how Mythril is generated </Description> 
-                        <DisplayName>Simple Ores Mythril</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Mythril is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='smpoMythrilFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
-                        <Description> Frequency multiplier for Simple Ores Mythril distributions </Description>
-                        <DisplayName>Simple Ores Mythril Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='smpoMythrilSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
-                        <Description> Size multiplier for Simple Ores Mythril distributions </Description>
-                        <DisplayName>Simple Ores Mythril Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Mythril Configuration UI Complete -->
-                
-                
-                <!-- Adamantium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='smpoAdamantiumDist'  displayState='shown' displayGroup='groupSimpleOres'> 
-                        <Description> Controls how Adamantium is generated </Description> 
-                        <DisplayName>Simple Ores Adamantium</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Adamantium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='smpoAdamantiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
-                        <Description> Frequency multiplier for Simple Ores Adamantium distributions </Description>
-                        <DisplayName>Simple Ores Adamantium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='smpoAdamantiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
-                        <Description> Size multiplier for Simple Ores Adamantium distributions </Description>
-                        <DisplayName>Simple Ores Adamantium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Adamantium Configuration UI Complete -->
-                
-                
-                <!-- Onyx Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='smpoOnyxDist'  displayState='shown' displayGroup='groupSimpleOres'> 
-                        <Description> Controls how Onyx is generated </Description> 
-                        <DisplayName>Simple Ores Onyx</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Onyx is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='smpoOnyxFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
-                        <Description> Frequency multiplier for Simple Ores Onyx distributions </Description>
-                        <DisplayName>Simple Ores Onyx Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='smpoOnyxSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
-                        <Description> Size multiplier for Simple Ores Onyx distributions </Description>
-                        <DisplayName>Simple Ores Onyx Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Onyx Configuration UI Complete -->
-                
+                <OptionChoice name='smpoCopperDist'  displayState='shown' displayGroup='groupSimpleOres'>
+                    <Description> Controls how Copper is generated </Description>
+                    <DisplayName>Simple Ores Copper</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='smpoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                    <Description> Frequency multiplier for Simple Ores Copper distributions </Description>
+                    <DisplayName>Simple Ores Copper Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='smpoCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                    <Description> Size multiplier for Simple Ores Copper distributions </Description>
+                    <DisplayName>Simple Ores Copper Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Copper Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='smpoOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='simpleores:copper_ore' />
-                    <Replaces block='simpleores:tin_ore' />
-                    <Replaces block='simpleores:mythril_ore' />
-                    <Replaces block='simpleores:adamantium_ore' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Copper Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Copper -->
-                <IfCondition condition=':= smpoCopperDist = "layeredVeins"'>
-                
-                    <Veins name='smpoCopperBaseVeins' block='simpleores:copper_ore'  inherits='PresetLayeredVeins' >
+            <!-- Tin Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='smpoTinDist'  displayState='shown' displayGroup='groupSimpleOres'>
+                    <Description> Controls how Tin is generated </Description>
+                    <DisplayName>Simple Ores Tin</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * smpoCopperSize * _default_' range=':= 1 * 1 * smpoCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 40' type='uniform' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * smpoCopperSize * _default_' range=':= 1 * 1 * smpoCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.15 * smpoCopperFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.6 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 1.2 * _default_' range=':= 1.2 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 24'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='smpoCopperPrefersVeins' block='simpleores:copper_ore'  inherits='smpoCopperBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Jungle'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Copper -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Copper -->
-                <IfCondition condition=':= smpoCopperDist = "hugeVeins"'>
-                
-                    <Veins name='smpoCopperBaseVeins' block='simpleores:copper_ore'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * smpoCopperSize * _default_' range=':= 1 * 1 * smpoCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 40' type='uniform' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * smpoCopperSize * _default_' range=':= 1 * 1 * smpoCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.15 * smpoCopperFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.6 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 1.2 * _default_' range=':= 1.2 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 24'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                    <Veins name='smpoCopperPrefersVeins' block='simpleores:copper_ore'  inherits='smpoCopperBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Jungle'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Copper -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Copper -->
-                <IfCondition condition=':= smpoCopperDist = "strategicCloud"'>
-                
-                    <Cloud name='smpoCopperBaseCloud' block='simpleores:copper_ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1.1 * smpoCopperSize * _default_' range=':= 1 * 1.1 * smpoCopperSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.1 * smpoCopperSize * _default_' range=':= 1 * 1.1 * smpoCopperSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 50' range=':= 40' type='uniform' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1.1 * 1.1 * smpoCopperSize * _default_' range=':= 1 * 1.1 * 1.1 * smpoCopperSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 3.5 * smpoCopperFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Copper Strategic Cloud Hint Veins -->
-                        <Veins name='smpoCopperBaseHintVeins' block='simpleores:copper_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Copper Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='smpoTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                    <Description> Frequency multiplier for Simple Ores Tin distributions </Description>
+                    <DisplayName>Simple Ores Tin Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='smpoTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                    <Description> Size multiplier for Simple Ores Tin distributions </Description>
+                    <DisplayName>Simple Ores Tin Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Tin Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Copper -->
-                
-                
-                <!-- Begin  Vanilla distribution of Copper -->
-                <IfCondition condition=':= smpoCopperDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='smpoCopperBaseStandard' block='simpleores:copper_ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1.25 * smpoCopperSize * _default_'/>
-                        <Setting name='Height' avg=':= 50' range=':= 40' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.75 * smpoCopperFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Copper -->
-                
-                <!-- End Copper Generation --> 
 
-                
-                <!-- Begin Tin Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Tin -->
-                <IfCondition condition=':= smpoTinDist = "layeredVeins"'>
-                
-                    <Veins name='smpoTinBaseVeins' block='simpleores:tin_ore'  inherits='PresetLayeredVeins' >
+            <!-- Mythril Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='smpoMythrilDist'  displayState='shown' displayGroup='groupSimpleOres'>
+                    <Description> Controls how Mythril is generated </Description>
+                    <DisplayName>Simple Ores Mythril</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * smpoTinSize * _default_' range=':= 1 * 1 * smpoTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 40' type='uniform' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * smpoTinSize * _default_' range=':= 1 * 1 * smpoTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * smpoTinFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.5 * _default_' range=':= 0.5 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 20'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='smpoTinPrefersVeins' block='simpleores:tin_ore'  inherits='smpoTinBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Tin -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Tin -->
-                <IfCondition condition=':= smpoTinDist = "hugeVeins"'>
-                
-                    <Veins name='smpoTinBaseVeins' block='simpleores:tin_ore'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * smpoTinSize * _default_' range=':= 1 * 1 * smpoTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 40' type='uniform' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * smpoTinSize * _default_' range=':= 1 * 1 * smpoTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * smpoTinFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.5 * _default_' range=':= 0.5 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 20'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                    <Veins name='smpoTinPrefersVeins' block='simpleores:tin_ore'  inherits='smpoTinBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Tin -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Tin -->
-                <IfCondition condition=':= smpoTinDist = "strategicCloud"'>
-                
-                    <Cloud name='smpoTinBaseCloud' block='simpleores:tin_ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.9 * smpoTinSize * _default_' range=':= 1 * 0.9 * smpoTinSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.9 * smpoTinSize * _default_' range=':= 1 * 0.9 * smpoTinSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 50' range=':= 40' type='uniform' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.9 * 0.9 * smpoTinSize * _default_' range=':= 1 * 0.9 * 0.9 * smpoTinSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4 * smpoTinFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Tin Strategic Cloud Hint Veins -->
-                        <Veins name='smpoTinBaseHintVeins' block='simpleores:tin_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Tin Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Mythril is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='smpoMythrilFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                    <Description> Frequency multiplier for Simple Ores Mythril distributions </Description>
+                    <DisplayName>Simple Ores Mythril Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='smpoMythrilSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                    <Description> Size multiplier for Simple Ores Mythril distributions </Description>
+                    <DisplayName>Simple Ores Mythril Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Mythril Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Tin -->
-                
-                
-                <!-- Begin  Vanilla distribution of Tin -->
-                <IfCondition condition=':= smpoTinDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='smpoTinBaseStandard' block='simpleores:tin_ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 0.75 * smpoTinSize * _default_'/>
-                        <Setting name='Height' avg=':= 50' range=':= 40' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1.25 * smpoTinFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Tin -->
-                
-                <!-- End Tin Generation --> 
 
-                
-                <!-- Begin Mythril Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Mythril -->
-                <IfCondition condition=':= smpoMythrilDist = "layeredVeins"'>
-                
-                    <Veins name='smpoMythrilBaseVeins' block='simpleores:mythril_ore'  inherits='PresetLayeredVeins' >
+            <!-- Adamantium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='smpoAdamantiumDist'  displayState='shown' displayGroup='groupSimpleOres'>
+                    <Description> Controls how Adamantium is generated </Description>
+                    <DisplayName>Simple Ores Adamantium</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6079AFD2</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * smpoMythrilSize * _default_' range=':= 1 * 0.5 * smpoMythrilSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 19' range=':= 15' type='uniform' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.5 * smpoMythrilSize * _default_' range=':= 1 * 0.5 * smpoMythrilSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 6 * smpoMythrilFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 12/_default_ * _default_' range=':= 6/_default_ * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 20'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Mythril Layered Veins) Settings -->
-                    <Veins name='smpoMythrilPrefersVeins' block='simpleores:mythril_ore'  inherits='smpoMythrilBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6079AFD2</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Mythril Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Mythril -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Mythril -->
-                <IfCondition condition=':= smpoMythrilDist = "hugeVeins"'>
-                
-                    <Veins name='smpoMythrilBaseVeins' block='simpleores:mythril_ore'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6079AFD2</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.5 * smpoMythrilSize * _default_' range=':= 1 * 0.5 * smpoMythrilSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 19' range=':= 15' type='uniform' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.5 * smpoMythrilSize * _default_' range=':= 1 * 0.5 * smpoMythrilSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 6 * smpoMythrilFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 12/_default_ * _default_' range=':= 6/_default_ * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 20'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Mythril Huge Veins) Settings -->
-                    <Veins name='smpoMythrilPrefersVeins' block='simpleores:mythril_ore'  inherits='smpoMythrilBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6079AFD2</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Mythril Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Mythril -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Mythril -->
-                <IfCondition condition=':= smpoMythrilDist = "strategicCloud"'>
-                
-                    <Cloud name='smpoMythrilBaseCloud' block='simpleores:mythril_ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6079AFD2</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.9 * smpoMythrilSize * _default_' range=':= 1 * 0.9 * smpoMythrilSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.9 * smpoMythrilSize * _default_' range=':= 1 * 0.9 * smpoMythrilSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 19' range=':= 15' type='uniform' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.9 * 0.9 * smpoMythrilSize * _default_' range=':= 1 * 0.9 * 0.9 * smpoMythrilSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4 * smpoMythrilFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Mythril Strategic Cloud Hint Veins -->
-                        <Veins name='smpoMythrilBaseHintVeins' block='simpleores:mythril_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6079AFD2</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Mythril Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Adamantium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='smpoAdamantiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                    <Description> Frequency multiplier for Simple Ores Adamantium distributions </Description>
+                    <DisplayName>Simple Ores Adamantium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='smpoAdamantiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                    <Description> Size multiplier for Simple Ores Adamantium distributions </Description>
+                    <DisplayName>Simple Ores Adamantium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Adamantium Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Mythril -->
-                
-                
-                <!-- Begin  Vanilla distribution of Mythril -->
-                <IfCondition condition=':= smpoMythrilDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='smpoMythrilBaseStandard' block='simpleores:mythril_ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6079AFD2</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 0.75 * smpoMythrilSize * _default_'/>
-                        <Setting name='Height' avg=':= 19' range=':= 15' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1.25 * smpoMythrilFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Mythril -->
-                
-                <!-- End Mythril Generation --> 
 
-                
-                <!-- Begin Adamantium Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Adamantium -->
-                <IfCondition condition=':= smpoAdamantiumDist = "layeredVeins"'>
-                
-                    <Veins name='smpoAdamantiumBaseVeins' block='simpleores:adamantium_ore'  inherits='PresetLayeredVeins' >
+            <!-- Onyx Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='smpoOnyxDist'  displayState='shown' displayGroup='groupSimpleOres'>
+                    <Description> Controls how Onyx is generated </Description>
+                    <DisplayName>Simple Ores Onyx</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Short and sparsely filled compound veins containing one material inside another.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60159800</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.2 * smpoAdamantiumSize * _default_' range=':= 1 * 0.2 * smpoAdamantiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 11' range=':= 9' type='uniform' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.2 * smpoAdamantiumSize * _default_' range=':= 1 * 0.2 * smpoAdamantiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * smpoAdamantiumFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 9/_default_ * _default_' range=':= 4/_default_ * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Adamantium Layered Veins) Settings -->
-                    <Veins name='smpoAdamantiumPrefersVeins' block='simpleores:adamantium_ore'  inherits='smpoAdamantiumBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60159800</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Adamantium Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Adamantium -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Adamantium -->
-                <IfCondition condition=':= smpoAdamantiumDist = "hugeVeins"'>
-                
-                    <Veins name='smpoAdamantiumBaseVeins' block='simpleores:adamantium_ore'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60159800</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.2 * smpoAdamantiumSize * _default_' range=':= 1 * 0.2 * smpoAdamantiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 11' range=':= 9' type='uniform' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.2 * smpoAdamantiumSize * _default_' range=':= 1 * 0.2 * smpoAdamantiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1.5 * smpoAdamantiumFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 9/_default_ * _default_' range=':= 4/_default_ * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Adamantium Huge Veins) Settings -->
-                    <Veins name='smpoAdamantiumPrefersVeins' block='simpleores:adamantium_ore'  inherits='smpoAdamantiumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60159800</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Adamantium Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Adamantium -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Adamantium -->
-                <IfCondition condition=':= smpoAdamantiumDist = "strategicCloud"'>
-                
-                    <Cloud name='smpoAdamantiumBaseCloud' block='simpleores:adamantium_ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60159800</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.9 * smpoAdamantiumSize * _default_' range=':= 1 * 0.9 * smpoAdamantiumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.9 * smpoAdamantiumSize * _default_' range=':= 1 * 0.9 * smpoAdamantiumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 11' range=':= 9' type='uniform' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.9 * 0.9 * smpoAdamantiumSize * _default_' range=':= 1 * 0.9 * 0.9 * smpoAdamantiumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4 * smpoAdamantiumFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Adamantium Strategic Cloud Hint Veins -->
-                        <Veins name='smpoAdamantiumBaseHintVeins' block='simpleores:adamantium_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60159800</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Adamantium Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Onyx is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='smpoOnyxFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                    <Description> Frequency multiplier for Simple Ores Onyx distributions </Description>
+                    <DisplayName>Simple Ores Onyx Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='smpoOnyxSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupSimpleOres'>
+                    <Description> Size multiplier for Simple Ores Onyx distributions </Description>
+                    <DisplayName>Simple Ores Onyx Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Onyx Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Adamantium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Adamantium -->
-                <IfCondition condition=':= smpoAdamantiumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='smpoAdamantiumBaseStandard' block='simpleores:adamantium_ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60159800</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 0.75 * smpoAdamantiumSize * _default_'/>
-                        <Setting name='Height' avg=':= 11' range=':= 9' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1.25 * smpoAdamantiumFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Adamantium -->
-                
-                <!-- End Adamantium Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-            <!-- Setup Nether -->
-            <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
-                
-                <!-- Starting Original Nether Ore Removal -->
-                <Substitute name='smpoNetherOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='simpleores:onyx_ore' />
-                </Substitute>
-                <!-- Original Nether Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Onyx Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Onyx -->
-                <IfCondition condition=':= smpoOnyxDist = "layeredVeins"'>
-                
-                    <Veins name='smpoOnyxBaseVeins' block='simpleores:onyx_ore'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60232323</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * smpoOnyxSize * _default_' range=':= 1 * 1 * smpoOnyxSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * smpoOnyxSize * _default_' range=':= 1 * 1 * smpoOnyxSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * smpoOnyxFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Onyx -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Onyx -->
-                <IfCondition condition=':= smpoOnyxDist = "hugeVeins"'>
-                
-                    <Veins name='smpoOnyxBaseVeins' block='simpleores:onyx_ore'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60232323</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * smpoOnyxSize * _default_' range=':= 1 * 1 * smpoOnyxSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * smpoOnyxSize * _default_' range=':= 1 * 1 * smpoOnyxSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * smpoOnyxFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Onyx -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Onyx -->
-                <IfCondition condition=':= smpoOnyxDist = "strategicCloud"'>
-                
-                    <Cloud name='smpoOnyxBaseCloud' block='simpleores:onyx_ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60232323</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * smpoOnyxSize * _default_' range=':= 1 * 1 * smpoOnyxSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * smpoOnyxSize * _default_' range=':= 1 * 1 * smpoOnyxSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * smpoOnyxSize * _default_' range=':= 1 * 1 * 1 * smpoOnyxSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * smpoOnyxFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Onyx Strategic Cloud Hint Veins -->
-                        <Veins name='smpoOnyxBaseHintVeins' block='simpleores:onyx_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60232323</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Onyx Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Onyx -->
-                
-                
-                <!-- Begin  Vanilla distribution of Onyx -->
-                <IfCondition condition=':= smpoOnyxDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='smpoOnyxBaseStandard' block='simpleores:onyx_ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60232323</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * smpoOnyxSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * smpoOnyxFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Onyx -->
-                
-                <!-- End Onyx Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Nether Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='smpoOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='simpleores:adamantium_ore' weight='1.0' />
+                <Replaces block='simpleores:copper_ore' weight='1.0' />
+                <Replaces block='simpleores:mythril_ore' weight='1.0' />
+                <Replaces block='simpleores:tin_ore' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Copper Generation -->
+
+            <!-- Starting LayeredVeins Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoCopperDist = "LayeredVeins"'>
+                    <Veins name='smpoCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='simpleores:copper_ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.854 * _default_ * smpoCopperFreq ' range=':=  _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.228 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.228 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.228 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Copper is complete. -->
+
+
+            <!-- Starting Cloud Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoCopperDist = "Cloud"'>
+                    <Cloud name='smpoCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='simpleores:copper_ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.924 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.924 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 3.702  * _default_ * smpoCopperFreq ' range=':=  _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='smpoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='simpleores:copper_ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Copper is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoCopperDist = "Vanilla"'>
+                    <StandardGen name='smpoCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='simpleores:copper_ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 7 * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 35 * smpoCopperFreq ' range=':=  _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Copper is complete. -->
+
+            <!-- End Copper Generation -->
+
+
+            <!-- Begin Tin Generation -->
+
+            <!-- Starting LayeredVeins Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoTinDist = "LayeredVeins"'>
+                    <Veins name='smpoTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='simpleores:tin_ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.716 * _default_ * smpoTinFreq ' range=':=  _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Tin is complete. -->
+
+
+            <!-- Starting Cloud Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoTinDist = "Cloud"'>
+                    <Cloud name='smpoTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='simpleores:tin_ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.851 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.851 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 3.427  * _default_ * smpoTinFreq ' range=':=  _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='smpoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='simpleores:tin_ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Tin is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoTinDist = "Vanilla"'>
+                    <StandardGen name='smpoTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='simpleores:tin_ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 7 * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 30 * smpoTinFreq ' range=':=  _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Tin is complete. -->
+
+            <!-- End Tin Generation -->
+
+
+            <!-- Begin Mythril Generation -->
+
+            <!-- Starting LayeredVeins Preset for Mythril. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoMythrilDist = "LayeredVeins"'>
+                    <Veins name='smpoMythrilVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='simpleores:mythril_ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.670 * _default_ * smpoMythrilFreq ' range=':=  _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.875 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  15 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.875 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.875 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Mythril is complete. -->
+
+
+            <!-- Starting Cloud Preset for Mythril. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoMythrilDist = "Cloud"'>
+                    <Cloud name='smpoMythrilCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='simpleores:mythril_ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.157 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.157 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * smpoMythrilFreq ' range=':=  _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 20 ' range=':=  15 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='smpoMythrilHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='simpleores:mythril_ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Mythril is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Mythril. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoMythrilDist = "Vanilla"'>
+                    <StandardGen name='smpoMythrilStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='simpleores:mythril_ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 8 * smpoMythrilFreq ' range=':=  _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 20 ' range=':=  15 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Mythril is complete. -->
+
+            <!-- End Mythril Generation -->
+
+
+            <!-- Begin Adamantium Generation -->
+
+            <!-- Starting LayeredVeins Preset for Adamantium. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoAdamantiumDist = "LayeredVeins"'>
+                    <Veins name='smpoAdamantiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * smpoAdamantiumFreq ' range=':=  _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 13 ' range=':=  7 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Adamantium is complete. -->
+
+
+            <!-- Starting Cloud Preset for Adamantium. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoAdamantiumDist = "Cloud"'>
+                    <Cloud name='smpoAdamantiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * smpoAdamantiumFreq ' range=':=  _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 13 ' range=':=  7 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='smpoAdamantiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Adamantium is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Adamantium. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoAdamantiumDist = "Vanilla"'>
+                    <StandardGen name='smpoAdamantiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 4 * smpoAdamantiumFreq ' range=':=  _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 13 ' range=':=  7 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Adamantium is complete. -->
+
+            <!-- End Adamantium Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+
+        <!-- Nether Setup Beginning -->
+
+        <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
+
+            <!-- Starting Original "Nether" Block Removal -->
+
+            <Substitute name='smpoNetherBlockSubstitute0' block='minecraft:netherrack'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='simpleores:onyx_ore' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Nether" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Onyx Generation -->
+
+            <!-- Starting PipeVeins Preset for Onyx. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoOnyxDist = "PipeVeins"'>
+                    <Veins name='smpoOnyxVeins'  inherits='PresetPipeVeins' seed='0x9EEA' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Short sparsely filled veins sloping  up
+                            from near the bottom of the map.
+                        </Description>
+                        <OreBlock block='simpleores:onyx_ore' weight='1.0' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * smpoOnyxFreq ' range=':=  _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 72 ' range=':=  56 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Configuring contained material. -->
+                    <Veins name='smpoOnyxVeinsPipe'  inherits='smpoOnyxVeins' seed='0x9EEA' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <OreBlock block='minecraft:stone' weight='1.0' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Replaces block='simpleores:onyx_ore' weight='1.0' />
+                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoOnyxSize  * 0.5 ' range=':=  _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoOnyxSize  * 0.5 ' range=':=  _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
+                        <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- PipeVeins Preset for Onyx is complete. -->
+
+
+            <!-- Starting Cloud Preset for Onyx. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoOnyxDist = "Cloud"'>
+                    <Cloud name='smpoOnyxCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='simpleores:onyx_ore' weight='1.0' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * smpoOnyxFreq ' range=':=  _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 72 ' range=':=  56 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='smpoOnyxHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='simpleores:onyx_ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Onyx is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Onyx. -->
+            <ConfigSection>
+                <IfCondition condition=':= smpoOnyxDist = "Vanilla"'>
+                    <StandardGen name='smpoOnyxStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='simpleores:onyx_ore' weight='1.0' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 7 * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 5 * smpoOnyxFreq ' range=':=  _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 72 ' range=':=  56 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Onyx is complete. -->
+
+            <!-- End Onyx Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Nether Setup Complete -->
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Simple Ores" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -27,10 +27,15 @@
                     Distribution options for Thaumcraft 4 Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableThaumcraft4' displayName='Handle Thaumcraft 4 Setup?' default='true' displayState='shown_dynamic' displayGroup='groupThaumcraft4'>
+                <Description> Should Custom Ore Generation handle Thaumcraft 4 ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Thaumcraft 4 ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Thaumcraft 4 ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Amber Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thm4AmberDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                <OptionChoice name='thm4AmberDist'  displayState=':= if(?enableThaumcraft4, "shown", "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Controls how Amber is generated </Description>
                     <DisplayName>Thaumcraft 4 Amber</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -50,11 +55,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Amber is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thm4AmberFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4AmberFreq' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Frequency multiplier for Thaumcraft 4 Amber distributions </Description>
                     <DisplayName>Thaumcraft 4 Amber Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thm4AmberSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4AmberSize' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Size multiplier for Thaumcraft 4 Amber distributions </Description>
                     <DisplayName>Thaumcraft 4 Amber Size</DisplayName>
                 </OptionNumeric>
@@ -64,7 +69,7 @@
 
             <!-- Cinnabar Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thm4CinnabarDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                <OptionChoice name='thm4CinnabarDist'  displayState=':= if(?enableThaumcraft4, "shown", "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Controls how Cinnabar is generated </Description>
                     <DisplayName>Thaumcraft 4 Cinnabar</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -84,11 +89,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Cinnabar is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thm4CinnabarFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4CinnabarFreq' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Frequency multiplier for Thaumcraft 4 Cinnabar distributions </Description>
                     <DisplayName>Thaumcraft 4 Cinnabar Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thm4CinnabarSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4CinnabarSize' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Size multiplier for Thaumcraft 4 Cinnabar distributions </Description>
                     <DisplayName>Thaumcraft 4 Cinnabar Size</DisplayName>
                 </OptionNumeric>
@@ -98,7 +103,7 @@
 
             <!-- Air Infused Stone Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thm4AirInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                <OptionChoice name='thm4AirInfusedStoneDist'  displayState=':= if(?enableThaumcraft4, "shown", "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Controls how Air Infused Stone is generated </Description>
                     <DisplayName>Thaumcraft 4 Air Infused Stone</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -118,11 +123,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Air Infused Stone is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thm4AirInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4AirInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Frequency multiplier for Thaumcraft 4 Air Infused Stone distributions </Description>
                     <DisplayName>Thaumcraft 4 Air Infused Stone Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thm4AirInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4AirInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Size multiplier for Thaumcraft 4 Air Infused Stone distributions </Description>
                     <DisplayName>Thaumcraft 4 Air Infused Stone Size</DisplayName>
                 </OptionNumeric>
@@ -132,7 +137,7 @@
 
             <!-- Fire Infused Stone Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thm4FireInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                <OptionChoice name='thm4FireInfusedStoneDist'  displayState=':= if(?enableThaumcraft4, "shown", "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Controls how Fire Infused Stone is generated </Description>
                     <DisplayName>Thaumcraft 4 Fire Infused Stone</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -152,11 +157,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Fire Infused Stone is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thm4FireInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4FireInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Frequency multiplier for Thaumcraft 4 Fire Infused Stone distributions </Description>
                     <DisplayName>Thaumcraft 4 Fire Infused Stone Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thm4FireInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4FireInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Size multiplier for Thaumcraft 4 Fire Infused Stone distributions </Description>
                     <DisplayName>Thaumcraft 4 Fire Infused Stone Size</DisplayName>
                 </OptionNumeric>
@@ -166,7 +171,7 @@
 
             <!-- Water Infused Stone Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thm4WaterInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                <OptionChoice name='thm4WaterInfusedStoneDist'  displayState=':= if(?enableThaumcraft4, "shown", "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Controls how Water Infused Stone is generated </Description>
                     <DisplayName>Thaumcraft 4 Water Infused Stone</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -186,11 +191,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Water Infused Stone is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thm4WaterInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4WaterInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Frequency multiplier for Thaumcraft 4 Water Infused Stone distributions </Description>
                     <DisplayName>Thaumcraft 4 Water Infused Stone Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thm4WaterInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4WaterInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Size multiplier for Thaumcraft 4 Water Infused Stone distributions </Description>
                     <DisplayName>Thaumcraft 4 Water Infused Stone Size</DisplayName>
                 </OptionNumeric>
@@ -200,7 +205,7 @@
 
             <!-- Earth Infused Stone Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thm4EarthInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                <OptionChoice name='thm4EarthInfusedStoneDist'  displayState=':= if(?enableThaumcraft4, "shown", "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Controls how Earth Infused Stone is generated </Description>
                     <DisplayName>Thaumcraft 4 Earth Infused Stone</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -220,11 +225,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Earth Infused Stone is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thm4EarthInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4EarthInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Frequency multiplier for Thaumcraft 4 Earth Infused Stone distributions </Description>
                     <DisplayName>Thaumcraft 4 Earth Infused Stone Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thm4EarthInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4EarthInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Size multiplier for Thaumcraft 4 Earth Infused Stone distributions </Description>
                     <DisplayName>Thaumcraft 4 Earth Infused Stone Size</DisplayName>
                 </OptionNumeric>
@@ -234,7 +239,7 @@
 
             <!-- Order Infused Stone Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thm4OrderInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                <OptionChoice name='thm4OrderInfusedStoneDist'  displayState=':= if(?enableThaumcraft4, "shown", "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Controls how Order Infused Stone is generated </Description>
                     <DisplayName>Thaumcraft 4 Order Infused Stone</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -254,11 +259,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Order Infused Stone is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thm4OrderInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4OrderInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Frequency multiplier for Thaumcraft 4 Order Infused Stone distributions </Description>
                     <DisplayName>Thaumcraft 4 Order Infused Stone Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thm4OrderInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4OrderInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Size multiplier for Thaumcraft 4 Order Infused Stone distributions </Description>
                     <DisplayName>Thaumcraft 4 Order Infused Stone Size</DisplayName>
                 </OptionNumeric>
@@ -268,7 +273,7 @@
 
             <!-- Entropy Infused Stone Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thm4EntropyInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                <OptionChoice name='thm4EntropyInfusedStoneDist'  displayState=':= if(?enableThaumcraft4, "shown", "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Controls how Entropy Infused Stone is generated </Description>
                     <DisplayName>Thaumcraft 4 Entropy Infused Stone</DisplayName>
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -288,11 +293,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Entropy Infused Stone is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thm4EntropyInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4EntropyInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Frequency multiplier for Thaumcraft 4 Entropy Infused Stone distributions </Description>
                     <DisplayName>Thaumcraft 4 Entropy Infused Stone Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thm4EntropyInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                <OptionNumeric name='thm4EntropyInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?enableThaumcraft4, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThaumcraft4'>
                     <Description> Size multiplier for Thaumcraft 4 Entropy Infused Stone distributions </Description>
                     <DisplayName>Thaumcraft 4 Entropy Infused Stone Size</DisplayName>
                 </OptionNumeric>
@@ -302,1402 +307,1444 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableThaumcraft4'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='thm4OverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='Thaumcraft:blockCustomOre' weight='1.0' />
-                <Replaces block='Thaumcraft:blockCustomOre:1' weight='1.0' />
-                <Replaces block='Thaumcraft:blockCustomOre:2' weight='1.0' />
-                <Replaces block='Thaumcraft:blockCustomOre:3' weight='1.0' />
-                <Replaces block='Thaumcraft:blockCustomOre:4' weight='1.0' />
-                <Replaces block='Thaumcraft:blockCustomOre:5' weight='1.0' />
-                <Replaces block='Thaumcraft:blockCustomOre:6' weight='1.0' />
-                <Replaces block='Thaumcraft:blockCustomOre:7' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Amber Generation -->
-
-            <!-- Starting SparseVeins Preset for Amber. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4AmberDist = "SparseVeins"'>
-                    <Veins name='thm4AmberVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='thm4OverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.990 * _default_ * thm4AmberFreq ' range=':=  _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.997 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 50 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.997 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.997 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <Replaces block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <Replaces block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <Replaces block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <Replaces block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <Replaces block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <Replaces block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <Replaces block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <Replaces block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Amber is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Amber. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4AmberDist = "Cloud"'>
-                    <Cloud name='thm4AmberCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.818 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.818 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * thm4AmberFreq ' range=':=  _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 50 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4AmberHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Amber Generation -->
+
+                <!-- Starting SparseVeins Preset for Amber. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4AmberDist = "SparseVeins"'>
+                        <Veins name='thm4AmberVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.990 * _default_ * thm4AmberFreq ' range=':=  _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.997 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 50 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.997 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.997 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Amber is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Amber is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Amber. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4AmberDist = "Vanilla"'>
-                    <StandardGen name='thm4AmberStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 8 * thm4AmberFreq ' range=':=  _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 50 ' range=':=  16 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Amber is complete. -->
-
-            <!-- End Amber Generation -->
-
-
-            <!-- Begin Cinnabar Generation -->
-
-            <!-- Starting SparseVeins Preset for Cinnabar. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4CinnabarDist = "SparseVeins"'>
-                    <Veins name='thm4CinnabarVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.213 * _default_ * thm4CinnabarFreq ' range=':=  _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.066 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.066 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Cinnabar is complete. -->
-
-
-            <!-- Starting Cloud Preset for Cinnabar. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4CinnabarDist = "Cloud"'>
-                    <Cloud name='thm4CinnabarCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * thm4CinnabarFreq ' range=':=  _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4CinnabarHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
+                <!-- Starting Cloud Preset for Amber. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4AmberDist = "Cloud"'>
+                        <Cloud name='thm4AmberCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Cinnabar is complete. -->
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.818 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.818 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * thm4AmberFreq ' range=':=  _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 50 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4AmberHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Amber is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Cinnabar. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4CinnabarDist = "Vanilla"'>
-                    <StandardGen name='thm4CinnabarStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 1 * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 12 * thm4CinnabarFreq ' range=':=  _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Cinnabar is complete. -->
-
-            <!-- End Cinnabar Generation -->
-
-
-            <!-- Begin Air Infused Stone Generation -->
-
-            <!-- Starting SparseVeins Preset for Air Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4AirInfusedStoneDist = "SparseVeins"'>
-                    <Veins name='thm4AirInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Veins name='thm4AirInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Plains'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <!-- "Preferred" configuration complete. -->
-
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Air Infused Stone is complete. -->
-
-
-            <!-- Starting Cloud Preset for Air Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4AirInfusedStoneDist = "Cloud"'>
-                    <Cloud name='thm4AirInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4AirInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                <!-- Starting Vanilla Preset for Amber. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4AmberDist = "Vanilla"'>
+                        <StandardGen name='thm4AmberStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * thm4AmberFreq ' range=':=  _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 50 ' range=':=  16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Amber is complete. -->
 
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Cloud name='thm4AirInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Plains'  />
-                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4AirInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                <!-- End Amber Generation -->
+
+
+                <!-- Begin Cinnabar Generation -->
+
+                <!-- Starting SparseVeins Preset for Cinnabar. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4CinnabarDist = "SparseVeins"'>
+                        <Veins name='thm4CinnabarVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.213 * _default_ * thm4CinnabarFreq ' range=':=  _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.066 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.066 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Cinnabar is complete. -->
+
+
+                <!-- Starting Cloud Preset for Cinnabar. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4CinnabarDist = "Cloud"'>
+                        <Cloud name='thm4CinnabarCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * thm4CinnabarFreq ' range=':=  _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4CinnabarHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Cinnabar is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Cinnabar. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4CinnabarDist = "Vanilla"'>
+                        <StandardGen name='thm4CinnabarStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12 * thm4CinnabarFreq ' range=':=  _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Cinnabar is complete. -->
+
+                <!-- End Cinnabar Generation -->
+
+
+                <!-- Begin Air Infused Stone Generation -->
+
+                <!-- Starting SparseVeins Preset for Air Infused
+                     Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4AirInfusedStoneDist = "SparseVeins"'>
+                        <Veins name='thm4AirInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Veins name='thm4AirInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
                             <Description>
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Plains'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                    <!-- "Preferred" configuration complete. -->
+                        <!-- "Preferred" configuration complete. -->
 
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Air Infused Stone is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Air Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4AirInfusedStoneDist = "Vanilla"'>
-                    <StandardGen name='thm4AirInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 5 * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Air Infused Stone is complete. -->
-
-            <!-- End Air Infused Stone Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Air Infused Stone is
+                     complete. -->
 
 
-            <!-- Begin Fire Infused Stone Generation -->
-
-            <!-- Starting SparseVeins Preset for Fire Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4FireInfusedStoneDist = "SparseVeins"'>
-                    <Veins name='thm4FireInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Veins name='thm4FireInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Desert'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <!-- "Preferred" configuration complete. -->
-
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Fire Infused Stone is
-                 complete. -->
-
-
-            <!-- Starting Cloud Preset for Fire Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4FireInfusedStoneDist = "Cloud"'>
-                    <Cloud name='thm4FireInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4FireInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                <!-- Starting Cloud Preset for Air Infused Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4AirInfusedStoneDist = "Cloud"'>
+                        <Cloud name='thm4AirInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4AirInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
 
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Cloud name='thm4FireInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Desert'  />
-                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4FireInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='thm4AirInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
                             <Description>
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                    <!-- "Preferred" configuration complete. -->
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Plains'  />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4AirInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
 
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Fire Infused Stone is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Fire Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4FireInfusedStoneDist = "Vanilla"'>
-                    <StandardGen name='thm4FireInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 5 * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Fire Infused Stone is complete. -->
-
-            <!-- End Fire Infused Stone Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Air Infused Stone is complete. -->
 
 
-            <!-- Begin Water Infused Stone Generation -->
-
-            <!-- Starting SparseVeins Preset for Water Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4WaterInfusedStoneDist = "SparseVeins"'>
-                    <Veins name='thm4WaterInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Veins name='thm4WaterInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Water'  />
-                        <BiomeType name='Swamp'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <!-- "Preferred" configuration complete. -->
-
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Water Infused Stone is
-                 complete. -->
-
-
-            <!-- Starting Cloud Preset for Water Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4WaterInfusedStoneDist = "Cloud"'>
-                    <Cloud name='thm4WaterInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4WaterInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                <!-- Starting Vanilla Preset for Air Infused Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4AirInfusedStoneDist = "Vanilla"'>
+                        <StandardGen name='thm4AirInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Air Infused Stone is complete. -->
 
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Cloud name='thm4WaterInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Water'  />
-                        <BiomeType name='Swamp'  />
-                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4WaterInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                <!-- End Air Infused Stone Generation -->
+
+
+                <!-- Begin Fire Infused Stone Generation -->
+
+                <!-- Starting SparseVeins Preset for Fire Infused
+                     Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4FireInfusedStoneDist = "SparseVeins"'>
+                        <Veins name='thm4FireInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Veins name='thm4FireInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
                             <Description>
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Desert'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                    <!-- "Preferred" configuration complete. -->
+                        <!-- "Preferred" configuration complete. -->
 
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Water Infused Stone is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Water Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4WaterInfusedStoneDist = "Vanilla"'>
-                    <StandardGen name='thm4WaterInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 5 * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Water Infused Stone is complete. -->
-
-            <!-- End Water Infused Stone Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Fire Infused Stone is
+                     complete. -->
 
 
-            <!-- Begin Earth Infused Stone Generation -->
-
-            <!-- Starting SparseVeins Preset for Earth Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4EarthInfusedStoneDist = "SparseVeins"'>
-                    <Veins name='thm4EarthInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Veins name='thm4EarthInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Forest'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <!-- "Preferred" configuration complete. -->
-
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Earth Infused Stone is
-                 complete. -->
-
-
-            <!-- Starting Cloud Preset for Earth Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4EarthInfusedStoneDist = "Cloud"'>
-                    <Cloud name='thm4EarthInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4EarthInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                <!-- Starting Cloud Preset for Fire Infused Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4FireInfusedStoneDist = "Cloud"'>
+                        <Cloud name='thm4FireInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4FireInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
 
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Cloud name='thm4EarthInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Forest'  />
-                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4EarthInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='thm4FireInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
                             <Description>
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                    <!-- "Preferred" configuration complete. -->
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Desert'  />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4FireInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
 
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Earth Infused Stone is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Earth Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4EarthInfusedStoneDist = "Vanilla"'>
-                    <StandardGen name='thm4EarthInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 5 * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Earth Infused Stone is complete. -->
-
-            <!-- End Earth Infused Stone Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Fire Infused Stone is complete. -->
 
 
-            <!-- Begin Order Infused Stone Generation -->
-
-            <!-- Starting SparseVeins Preset for Order Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4OrderInfusedStoneDist = "SparseVeins"'>
-                    <Veins name='thm4OrderInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Veins name='thm4OrderInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Mushroom'  />
-                        <BiomeType name='Mountain'  />
-                        <BiomeType name='Magical'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <!-- "Preferred" configuration complete. -->
-
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Order Infused Stone is
-                 complete. -->
-
-
-            <!-- Starting Cloud Preset for Order Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4OrderInfusedStoneDist = "Cloud"'>
-                    <Cloud name='thm4OrderInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4OrderInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                <!-- Starting Vanilla Preset for Fire Infused Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4FireInfusedStoneDist = "Vanilla"'>
+                        <StandardGen name='thm4FireInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Fire Infused Stone is
+                     complete. -->
 
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Cloud name='thm4OrderInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Mushroom'  />
-                        <BiomeType name='Mountain'  />
-                        <BiomeType name='Magical'  />
-                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4OrderInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                <!-- End Fire Infused Stone Generation -->
+
+
+                <!-- Begin Water Infused Stone Generation -->
+
+                <!-- Starting SparseVeins Preset for Water Infused
+                     Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4WaterInfusedStoneDist = "SparseVeins"'>
+                        <Veins name='thm4WaterInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Veins name='thm4WaterInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
                             <Description>
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Water'  />
+                            <BiomeType name='Swamp'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                    <!-- "Preferred" configuration complete. -->
+                        <!-- "Preferred" configuration complete. -->
 
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Order Infused Stone is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Order Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4OrderInfusedStoneDist = "Vanilla"'>
-                    <StandardGen name='thm4OrderInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 5 * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Order Infused Stone is complete. -->
-
-            <!-- End Order Infused Stone Generation -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Water Infused Stone is
+                     complete. -->
 
 
-            <!-- Begin Entropy Infused Stone Generation -->
-
-            <!-- Starting SparseVeins Preset for Entropy Infused
-                 Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "SparseVeins"'>
-                    <Veins name='thm4EntropyInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
-                        <Description>
-                            Large veins filled very lightly with  ore.
-                            Because they contain less ore  per volume,
-                            these veins are  relatively wide and long.
-                            Mining the  ore from them is time
-                            consuming  compared to solid ore veins.
-                            They  are also more difficult to follow,
-                            since it is harder to get an idea of
-                            their direction while mining.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Veins name='thm4EntropyInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Swamp'  />
-                        <BiomeType name='Wasteland'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                    <!-- "Preferred" configuration complete. -->
-
-                </IfCondition>
-            </ConfigSection>
-            <!-- SparseVeins Preset for Entropy Infused Stone is
-                 complete. -->
-
-
-            <!-- Starting Cloud Preset for Entropy Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "Cloud"'>
-                    <Cloud name='thm4EntropyInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4EntropyInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                <!-- Starting Cloud Preset for Water Infused Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4WaterInfusedStoneDist = "Cloud"'>
+                        <Cloud name='thm4WaterInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4WaterInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
 
-                    <!-- Beginning "Preferred" configuration. -->
-                    <Cloud name='thm4EntropyInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
-                        <Description>
-                            Ore generation is doubled in  preferred
-                            biomes.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <BiomeType name='Swamp'  />
-                        <BiomeType name='Wasteland'  />
-                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thm4EntropyInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='thm4WaterInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
                             <Description>
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Water'  />
+                            <BiomeType name='Swamp'  />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4WaterInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Water Infused Stone is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Water Infused Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4WaterInfusedStoneDist = "Vanilla"'>
+                        <StandardGen name='thm4WaterInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Water Infused Stone is
+                     complete. -->
+
+                <!-- End Water Infused Stone Generation -->
+
+
+                <!-- Begin Earth Infused Stone Generation -->
+
+                <!-- Starting SparseVeins Preset for Earth Infused
+                     Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4EarthInfusedStoneDist = "SparseVeins"'>
+                        <Veins name='thm4EarthInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                    <!-- "Preferred" configuration complete. -->
 
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Entropy Infused Stone is complete. -->
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Veins name='thm4EarthInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Forest'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Earth Infused Stone is
+                     complete. -->
 
 
-            <!-- Starting Vanilla Preset for Entropy Infused Stone. -->
-            <ConfigSection>
-                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "Vanilla"'>
-                    <StandardGen name='thm4EntropyInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 5 * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Entropy Infused Stone is complete. -->
+                <!-- Starting Cloud Preset for Earth Infused Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4EarthInfusedStoneDist = "Cloud"'>
+                        <Cloud name='thm4EarthInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4EarthInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
 
-            <!-- End Entropy Infused Stone Generation -->
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='thm4EarthInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Forest'  />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4EarthInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
 
-            <!-- Finished adding blocks -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Earth Infused Stone is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Earth Infused Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4EarthInfusedStoneDist = "Vanilla"'>
+                        <StandardGen name='thm4EarthInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Earth Infused Stone is
+                     complete. -->
+
+                <!-- End Earth Infused Stone Generation -->
+
+
+                <!-- Begin Order Infused Stone Generation -->
+
+                <!-- Starting SparseVeins Preset for Order Infused
+                     Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4OrderInfusedStoneDist = "SparseVeins"'>
+                        <Veins name='thm4OrderInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Veins name='thm4OrderInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Mushroom'  />
+                            <BiomeType name='Mountain'  />
+                            <BiomeType name='Magical'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Order Infused Stone is
+                     complete. -->
+
+
+                <!-- Starting Cloud Preset for Order Infused Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4OrderInfusedStoneDist = "Cloud"'>
+                        <Cloud name='thm4OrderInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4OrderInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='thm4OrderInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Mushroom'  />
+                            <BiomeType name='Mountain'  />
+                            <BiomeType name='Magical'  />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4OrderInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Order Infused Stone is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Order Infused Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4OrderInfusedStoneDist = "Vanilla"'>
+                        <StandardGen name='thm4OrderInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Order Infused Stone is
+                     complete. -->
+
+                <!-- End Order Infused Stone Generation -->
+
+
+                <!-- Begin Entropy Infused Stone Generation -->
+
+                <!-- Starting SparseVeins Preset for Entropy Infused
+                     Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4EntropyInfusedStoneDist = "SparseVeins"'>
+                        <Veins name='thm4EntropyInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Veins name='thm4EntropyInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Swamp'  />
+                            <BiomeType name='Wasteland'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Entropy Infused Stone is
+                     complete. -->
+
+
+                <!-- Starting Cloud Preset for Entropy Infused Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4EntropyInfusedStoneDist = "Cloud"'>
+                        <Cloud name='thm4EntropyInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4EntropyInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='thm4EntropyInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <BiomeType name='Swamp'  />
+                            <BiomeType name='Wasteland'  />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thm4EntropyInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Entropy Infused Stone is
+                     complete. -->
+
+
+                <!-- Starting Vanilla Preset for Entropy Infused
+                     Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4EntropyInfusedStoneDist = "Vanilla"'>
+                        <StandardGen name='thm4EntropyInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Entropy Infused Stone is
+                     complete. -->
+
+                <!-- End Entropy Infused Stone Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -1,2372 +1,1718 @@
- <!-- ================================================================
-      Custom Ore Generation "Thaumcraft 4" Module: This configuration
-      covers amber, cinnabar, air infused stone, fire infused stone,
-      water infused  stone, earth infused stone, order infused stone,
-      and entropy infused  stone.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Thaumcraft 4" Module: This configuration
+     covers amber, cinnabar, air infused stone, fire infused stone,
+     water infused stone, earth infused stone, order infused stone,
+     and entropy infused stone.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="Thaumcraft">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "Thaumcraft 4" mod on the system?  Let's find out! -->
+<IfModInstalled name="Thaumcraft">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupThaumcraft4' displayName='Thaumcraft 4' displayState='shown'>
+                <Description>
+                    Distribution options for Thaumcraft 4 Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Amber Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupThaumcraft4' displayName='Thaumcraft 4' displayState='shown'> 
-                    <Description>
-                        Distribution options for Thaumcraft 4 Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Amber Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thm4AmberDist'  displayState='shown' displayGroup='groupThaumcraft4'> 
-                        <Description> Controls how Amber is generated </Description> 
-                        <DisplayName>Thaumcraft 4 Amber</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Amber is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thm4AmberFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Frequency multiplier for Thaumcraft 4 Amber distributions </Description>
-                        <DisplayName>Thaumcraft 4 Amber Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thm4AmberSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Size multiplier for Thaumcraft 4 Amber distributions </Description>
-                        <DisplayName>Thaumcraft 4 Amber Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Amber Configuration UI Complete -->
-                
-                
-                <!-- Cinnabar Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thm4CinnabarDist'  displayState='shown' displayGroup='groupThaumcraft4'> 
-                        <Description> Controls how Cinnabar is generated </Description> 
-                        <DisplayName>Thaumcraft 4 Cinnabar</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Cinnabar is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thm4CinnabarFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Frequency multiplier for Thaumcraft 4 Cinnabar distributions </Description>
-                        <DisplayName>Thaumcraft 4 Cinnabar Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thm4CinnabarSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Size multiplier for Thaumcraft 4 Cinnabar distributions </Description>
-                        <DisplayName>Thaumcraft 4 Cinnabar Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Cinnabar Configuration UI Complete -->
-                
-                
-                <!-- Air Infused Stone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thm4AirInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'> 
-                        <Description> Controls how Air Infused Stone is generated </Description> 
-                        <DisplayName>Thaumcraft 4 Air Infused Stone</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Air Infused Stone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thm4AirInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Frequency multiplier for Thaumcraft 4 Air Infused Stone distributions </Description>
-                        <DisplayName>Thaumcraft 4 Air Infused Stone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thm4AirInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Size multiplier for Thaumcraft 4 Air Infused Stone distributions </Description>
-                        <DisplayName>Thaumcraft 4 Air Infused Stone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Air Infused Stone Configuration UI Complete -->
-                
-                
-                <!-- Fire Infused Stone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thm4FireInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'> 
-                        <Description> Controls how Fire Infused Stone is generated </Description> 
-                        <DisplayName>Thaumcraft 4 Fire Infused Stone</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Fire Infused Stone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thm4FireInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Frequency multiplier for Thaumcraft 4 Fire Infused Stone distributions </Description>
-                        <DisplayName>Thaumcraft 4 Fire Infused Stone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thm4FireInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Size multiplier for Thaumcraft 4 Fire Infused Stone distributions </Description>
-                        <DisplayName>Thaumcraft 4 Fire Infused Stone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Fire Infused Stone Configuration UI Complete -->
-                
-                
-                <!-- Water Infused Stone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thm4WaterInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'> 
-                        <Description> Controls how Water Infused Stone is generated </Description> 
-                        <DisplayName>Thaumcraft 4 Water Infused Stone</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Water Infused Stone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thm4WaterInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Frequency multiplier for Thaumcraft 4 Water Infused Stone distributions </Description>
-                        <DisplayName>Thaumcraft 4 Water Infused Stone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thm4WaterInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Size multiplier for Thaumcraft 4 Water Infused Stone distributions </Description>
-                        <DisplayName>Thaumcraft 4 Water Infused Stone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Water Infused Stone Configuration UI Complete -->
-                
-                
-                <!-- Earth Infused Stone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thm4EarthInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'> 
-                        <Description> Controls how Earth Infused Stone is generated </Description> 
-                        <DisplayName>Thaumcraft 4 Earth Infused Stone</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Earth Infused Stone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thm4EarthInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Frequency multiplier for Thaumcraft 4 Earth Infused Stone distributions </Description>
-                        <DisplayName>Thaumcraft 4 Earth Infused Stone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thm4EarthInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Size multiplier for Thaumcraft 4 Earth Infused Stone distributions </Description>
-                        <DisplayName>Thaumcraft 4 Earth Infused Stone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Earth Infused Stone Configuration UI Complete -->
-                
-                
-                <!-- Order Infused Stone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thm4OrderInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'> 
-                        <Description> Controls how Order Infused Stone is generated </Description> 
-                        <DisplayName>Thaumcraft 4 Order Infused Stone</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Order Infused Stone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thm4OrderInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Frequency multiplier for Thaumcraft 4 Order Infused Stone distributions </Description>
-                        <DisplayName>Thaumcraft 4 Order Infused Stone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thm4OrderInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Size multiplier for Thaumcraft 4 Order Infused Stone distributions </Description>
-                        <DisplayName>Thaumcraft 4 Order Infused Stone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Order Infused Stone Configuration UI Complete -->
-                
-                
-                <!-- Entropy Infused Stone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thm4EntropyInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'> 
-                        <Description> Controls how Entropy Infused Stone is generated </Description> 
-                        <DisplayName>Thaumcraft 4 Entropy Infused Stone</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Entropy Infused Stone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thm4EntropyInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Frequency multiplier for Thaumcraft 4 Entropy Infused Stone distributions </Description>
-                        <DisplayName>Thaumcraft 4 Entropy Infused Stone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thm4EntropyInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
-                        <Description> Size multiplier for Thaumcraft 4 Entropy Infused Stone distributions </Description>
-                        <DisplayName>Thaumcraft 4 Entropy Infused Stone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Entropy Infused Stone Configuration UI Complete -->
-                
+                <OptionChoice name='thm4AmberDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                    <Description> Controls how Amber is generated </Description>
+                    <DisplayName>Thaumcraft 4 Amber</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
+                        <Description>
+                            Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Amber is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thm4AmberFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Frequency multiplier for Thaumcraft 4 Amber distributions </Description>
+                    <DisplayName>Thaumcraft 4 Amber Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thm4AmberSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Size multiplier for Thaumcraft 4 Amber distributions </Description>
+                    <DisplayName>Thaumcraft 4 Amber Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Amber Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='thm4OverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='Thaumcraft:blockCustomOre:7' />
-                    <Replaces block='Thaumcraft:blockCustomOre' />
-                    <Replaces block='Thaumcraft:blockCustomOre:1' />
-                    <Replaces block='Thaumcraft:blockCustomOre:2' />
-                    <Replaces block='Thaumcraft:blockCustomOre:3' />
-                    <Replaces block='Thaumcraft:blockCustomOre:4' />
-                    <Replaces block='Thaumcraft:blockCustomOre:5' />
-                    <Replaces block='Thaumcraft:blockCustomOre:6' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Amber Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Amber -->
-                <IfCondition condition=':= thm4AmberDist = "sparseVeins"'>
-                
-                    <Veins name='thm4AmberBaseVeins' block='Thaumcraft:blockCustomOre:7'  inherits='PresetSparseVeins' >
+            <!-- Cinnabar Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='thm4CinnabarDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                    <Description> Controls how Cinnabar is generated </Description>
+                    <DisplayName>Thaumcraft 4 Cinnabar</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FE9D1B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * thm4AmberSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 80' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * thm4AmberSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 3 * thm4AmberFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Amber Sparse Veins) Settings -->
-                    <Veins name='thm4AmberPrefersVeins' block='Thaumcraft:blockCustomOre:7'  inherits='thm4AmberBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FE9D1B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Amber Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Amber -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Amber -->
-                <IfCondition condition=':= thm4AmberDist = "smallDeposits"'>
-                
-                    <Veins name='thm4AmberBaseVeins' block='Thaumcraft:blockCustomOre:7'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FE9D1B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * thm4AmberSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 80' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * thm4AmberSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 3 * thm4AmberFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Amber Deposit Veins) Settings -->
-                    <Veins name='thm4AmberPrefersVeins' block='Thaumcraft:blockCustomOre:7'  inherits='thm4AmberBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FE9D1B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Amber Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Amber -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Amber -->
-                <IfCondition condition=':= thm4AmberDist = "hugeVeins"'>
-                
-                    <Veins name='thm4AmberBaseVeins' block='Thaumcraft:blockCustomOre:7'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FE9D1B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * thm4AmberSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 80' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * thm4AmberSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 3 * thm4AmberFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Amber Huge Veins) Settings -->
-                    <Veins name='thm4AmberPrefersVeins' block='Thaumcraft:blockCustomOre:7'  inherits='thm4AmberBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FE9D1B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Amber Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Amber -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Amber -->
-                <IfCondition condition=':= thm4AmberDist = "strategicCloud"'>
-                
-                    <Cloud name='thm4AmberBaseCloud' block='Thaumcraft:blockCustomOre:7' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FE9D1B</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * thm4AmberSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * thm4AmberSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 80' range=':= 20' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * thm4AmberSize * _default_' range=':= 1 * 1 * 1 * thm4AmberSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * thm4AmberFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Amber Strategic Cloud Hint Veins -->
-                        <Veins name='thm4AmberBaseHintVeins' block='Thaumcraft:blockCustomOre:7' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FE9D1B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Amber Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Cinnabar is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thm4CinnabarFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Frequency multiplier for Thaumcraft 4 Cinnabar distributions </Description>
+                    <DisplayName>Thaumcraft 4 Cinnabar Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thm4CinnabarSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Size multiplier for Thaumcraft 4 Cinnabar distributions </Description>
+                    <DisplayName>Thaumcraft 4 Cinnabar Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Cinnabar Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Amber -->
-                
-                
-                <!-- Begin  Vanilla distribution of Amber -->
-                <IfCondition condition=':= thm4AmberDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thm4AmberBaseStandard' block='Thaumcraft:blockCustomOre:7' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FE9D1B</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * thm4AmberSize * _default_'/>
-                        <Setting name='Height' avg=':= 80' range=':= 20' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * thm4AmberFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Amber -->
-                
-                <!-- End Amber Generation --> 
 
-                
-                <!-- Begin Cinnabar Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Cinnabar -->
-                <IfCondition condition=':= thm4CinnabarDist = "sparseVeins"'>
-                
-                    <Veins name='thm4CinnabarBaseVeins' block='Thaumcraft:blockCustomOre'  inherits='PresetSparseVeins' >
+            <!-- Air Infused Stone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='thm4AirInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                    <Description> Controls how Air Infused Stone is generated </Description>
+                    <DisplayName>Thaumcraft 4 Air Infused Stone</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60831C20</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * thm4CinnabarSize * _default_' range=':= 1 * 0.8 * thm4CinnabarSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * thm4CinnabarSize * _default_' range=':= 1 * 0.8 * thm4CinnabarSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 3 * thm4CinnabarFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Cinnabar Sparse Veins) Settings -->
-                    <Veins name='thm4CinnabarPrefersVeins' block='Thaumcraft:blockCustomOre'  inherits='thm4CinnabarBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60831C20</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Ocean'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Cinnabar Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Cinnabar -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Cinnabar -->
-                <IfCondition condition=':= thm4CinnabarDist = "smallDeposits"'>
-                
-                    <Veins name='thm4CinnabarBaseVeins' block='Thaumcraft:blockCustomOre'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60831C20</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * thm4CinnabarSize * _default_' range=':= 1 * 0.8 * thm4CinnabarSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * thm4CinnabarSize * _default_' range=':= 1 * 0.8 * thm4CinnabarSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 3 * thm4CinnabarFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Cinnabar Deposit Veins) Settings -->
-                    <Veins name='thm4CinnabarPrefersVeins' block='Thaumcraft:blockCustomOre'  inherits='thm4CinnabarBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60831C20</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Ocean'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Cinnabar Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Cinnabar -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Cinnabar -->
-                <IfCondition condition=':= thm4CinnabarDist = "hugeVeins"'>
-                
-                    <Veins name='thm4CinnabarBaseVeins' block='Thaumcraft:blockCustomOre'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60831C20</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * thm4CinnabarSize * _default_' range=':= 1 * 0.8 * thm4CinnabarSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 50' range=':= 10' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * thm4CinnabarSize * _default_' range=':= 1 * 0.8 * thm4CinnabarSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 3 * thm4CinnabarFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Cinnabar Huge Veins) Settings -->
-                    <Veins name='thm4CinnabarPrefersVeins' block='Thaumcraft:blockCustomOre'  inherits='thm4CinnabarBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60831C20</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Ocean'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Cinnabar Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Cinnabar -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Cinnabar -->
-                <IfCondition condition=':= thm4CinnabarDist = "strategicCloud"'>
-                
-                    <Cloud name='thm4CinnabarBaseCloud' block='Thaumcraft:blockCustomOre' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60831C20</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.5 * thm4CinnabarSize * _default_' range=':= 1 * 0.5 * thm4CinnabarSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.5 * thm4CinnabarSize * _default_' range=':= 1 * 0.5 * thm4CinnabarSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.5 * 0.5 * thm4CinnabarSize * _default_' range=':= 1 * 0.5 * 0.5 * thm4CinnabarSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * thm4CinnabarFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Cinnabar Strategic Cloud Hint Veins -->
-                        <Veins name='thm4CinnabarBaseHintVeins' block='Thaumcraft:blockCustomOre' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60831C20</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Cinnabar Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Air Infused Stone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thm4AirInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Frequency multiplier for Thaumcraft 4 Air Infused Stone distributions </Description>
+                    <DisplayName>Thaumcraft 4 Air Infused Stone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thm4AirInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Size multiplier for Thaumcraft 4 Air Infused Stone distributions </Description>
+                    <DisplayName>Thaumcraft 4 Air Infused Stone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Air Infused Stone Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Cinnabar -->
-                
-                
-                <!-- Begin  Vanilla distribution of Cinnabar -->
-                <IfCondition condition=':= thm4CinnabarDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thm4CinnabarBaseStandard' block='Thaumcraft:blockCustomOre' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60831C20</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1/6 * thm4CinnabarSize * _default_'/>
-                        <Setting name='Height' avg=':= 52' range=':= 20' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/10 * thm4CinnabarFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Cinnabar -->
-                
-                <!-- End Cinnabar Generation --> 
 
-                
-                <!-- Begin Air Infused Stone Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Air Infused Stone -->
-                <IfCondition condition=':= thm4AirInfusedStoneDist = "sparseVeins"'>
-                
-                    <Veins name='thm4AirInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:1'  inherits='PresetSparseVeins' >
+            <!-- Fire Infused Stone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='thm4FireInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                    <Description> Controls how Fire Infused Stone is generated </Description>
+                    <DisplayName>Thaumcraft 4 Fire Infused Stone</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFEAB</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4AirInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Air Infused Stone Sparse Veins) Settings -->
-                    <Veins name='thm4AirInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:1'  inherits='thm4AirInfusedStoneBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 4 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFEAB</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Air Infused Stone Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Air Infused Stone -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Air Infused Stone -->
-                <IfCondition condition=':= thm4AirInfusedStoneDist = "smallDeposits"'>
-                
-                    <Veins name='thm4AirInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:1'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFEAB</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4AirInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Air Infused Stone Deposit Veins) Settings -->
-                    <Veins name='thm4AirInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:1'  inherits='thm4AirInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFEAB</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Air Infused Stone Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Air Infused Stone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Air Infused Stone -->
-                <IfCondition condition=':= thm4AirInfusedStoneDist = "hugeVeins"'>
-                
-                    <Veins name='thm4AirInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:1'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFEAB</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4AirInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4AirInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Air Infused Stone Huge Veins) Settings -->
-                    <Veins name='thm4AirInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:1'  inherits='thm4AirInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFEAB</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Air Infused Stone Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Air Infused Stone -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Air Infused Stone -->
-                <IfCondition condition=':= thm4AirInfusedStoneDist = "strategicCloud"'>
-                
-                    <Cloud name='thm4AirInfusedStoneBaseCloud' block='Thaumcraft:blockCustomOre:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFEAB</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 1 * thm4AirInfusedStoneSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 1 * thm4AirInfusedStoneSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * thm4AirInfusedStoneSize * _default_' range=':= 1 * 1 * 1 * thm4AirInfusedStoneSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * thm4AirInfusedStoneFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Air Infused Stone Strategic Cloud Hint Veins -->
-                        <Veins name='thm4AirInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FEFEAB</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                            <BiomeType name='Plains'/>
-                            <BiomeType name='Hills'/>
-                            <BiomeType name='Jungle'/>
-                            <BiomeType name='Beach'/>
-                            <BiomeType name='Mushroom'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Air Infused Stone Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Fire Infused Stone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thm4FireInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Frequency multiplier for Thaumcraft 4 Fire Infused Stone distributions </Description>
+                    <DisplayName>Thaumcraft 4 Fire Infused Stone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thm4FireInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Size multiplier for Thaumcraft 4 Fire Infused Stone distributions </Description>
+                    <DisplayName>Thaumcraft 4 Fire Infused Stone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Fire Infused Stone Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Air Infused Stone -->
-                
-                
-                <!-- Begin  Vanilla distribution of Air Infused Stone -->
-                <IfCondition condition=':= thm4AirInfusedStoneDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thm4AirInfusedStoneBaseStandard' block='Thaumcraft:blockCustomOre:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEFEAB</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1/6 * thm4AirInfusedStoneSize * _default_'/>
-                        <Setting name='Height' avg=':= 35' range=':= 20' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/10 * thm4AirInfusedStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Air Infused Stone -->
-                
-                <!-- End Air Infused Stone Generation --> 
 
-                
-                <!-- Begin Fire Infused Stone Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Fire Infused Stone -->
-                <IfCondition condition=':= thm4FireInfusedStoneDist = "sparseVeins"'>
-                
-                    <Veins name='thm4FireInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:2'  inherits='PresetSparseVeins' >
+            <!-- Water Infused Stone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='thm4WaterInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                    <Description> Controls how Water Infused Stone is generated </Description>
+                    <DisplayName>Thaumcraft 4 Water Infused Stone</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FC5100</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4FireInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Fire Infused Stone Sparse Veins) Settings -->
-                    <Veins name='thm4FireInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:2'  inherits='thm4FireInfusedStoneBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 4 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FC5100</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Fire Infused Stone Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Fire Infused Stone -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Fire Infused Stone -->
-                <IfCondition condition=':= thm4FireInfusedStoneDist = "smallDeposits"'>
-                
-                    <Veins name='thm4FireInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:2'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FC5100</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4FireInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Fire Infused Stone Deposit Veins) Settings -->
-                    <Veins name='thm4FireInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:2'  inherits='thm4FireInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FC5100</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Fire Infused Stone Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Fire Infused Stone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Fire Infused Stone -->
-                <IfCondition condition=':= thm4FireInfusedStoneDist = "hugeVeins"'>
-                
-                    <Veins name='thm4FireInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:2'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FC5100</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4FireInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4FireInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Fire Infused Stone Huge Veins) Settings -->
-                    <Veins name='thm4FireInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:2'  inherits='thm4FireInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FC5100</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Fire Infused Stone Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Fire Infused Stone -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Fire Infused Stone -->
-                <IfCondition condition=':= thm4FireInfusedStoneDist = "strategicCloud"'>
-                
-                    <Cloud name='thm4FireInfusedStoneBaseCloud' block='Thaumcraft:blockCustomOre:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FC5100</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 1 * thm4FireInfusedStoneSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 1 * thm4FireInfusedStoneSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * thm4FireInfusedStoneSize * _default_' range=':= 1 * 1 * 1 * thm4FireInfusedStoneSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * thm4FireInfusedStoneFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Fire Infused Stone Strategic Cloud Hint Veins -->
-                        <Veins name='thm4FireInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FC5100</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                            <BiomeType name='Desert'/>
-                            <BiomeType name='Wasteland'/>
-                            <BiomeType name='Beach'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Fire Infused Stone Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Water Infused Stone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thm4WaterInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Frequency multiplier for Thaumcraft 4 Water Infused Stone distributions </Description>
+                    <DisplayName>Thaumcraft 4 Water Infused Stone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thm4WaterInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Size multiplier for Thaumcraft 4 Water Infused Stone distributions </Description>
+                    <DisplayName>Thaumcraft 4 Water Infused Stone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Water Infused Stone Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Fire Infused Stone -->
-                
-                
-                <!-- Begin  Vanilla distribution of Fire Infused Stone -->
-                <IfCondition condition=':= thm4FireInfusedStoneDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thm4FireInfusedStoneBaseStandard' block='Thaumcraft:blockCustomOre:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FC5100</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1/6 * thm4FireInfusedStoneSize * _default_'/>
-                        <Setting name='Height' avg=':= 35' range=':= 20' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/10 * thm4FireInfusedStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Magical'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Fire Infused Stone -->
-                
-                <!-- End Fire Infused Stone Generation --> 
 
-                
-                <!-- Begin Water Infused Stone Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Water Infused Stone -->
-                <IfCondition condition=':= thm4WaterInfusedStoneDist = "sparseVeins"'>
-                
-                    <Veins name='thm4WaterInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:3'  inherits='PresetSparseVeins' >
+            <!-- Earth Infused Stone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='thm4EarthInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                    <Description> Controls how Earth Infused Stone is generated </Description>
+                    <DisplayName>Thaumcraft 4 Earth Infused Stone</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000C0FA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4WaterInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Water'/>
-                        <BiomeType name='Frozen'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Water Infused Stone Sparse Veins) Settings -->
-                    <Veins name='thm4WaterInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:3'  inherits='thm4WaterInfusedStoneBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000C0FA</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Water'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Water Infused Stone Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Water Infused Stone -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Water Infused Stone -->
-                <IfCondition condition=':= thm4WaterInfusedStoneDist = "smallDeposits"'>
-                
-                    <Veins name='thm4WaterInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:3'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000C0FA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4WaterInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Water'/>
-                        <BiomeType name='Frozen'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Water Infused Stone Deposit Veins) Settings -->
-                    <Veins name='thm4WaterInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:3'  inherits='thm4WaterInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000C0FA</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Water'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Water Infused Stone Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Water Infused Stone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Water Infused Stone -->
-                <IfCondition condition=':= thm4WaterInfusedStoneDist = "hugeVeins"'>
-                
-                    <Veins name='thm4WaterInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:3'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000C0FA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4WaterInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4WaterInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Water'/>
-                        <BiomeType name='Frozen'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Water Infused Stone Huge Veins) Settings -->
-                    <Veins name='thm4WaterInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:3'  inherits='thm4WaterInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000C0FA</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Water'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Water Infused Stone Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Water Infused Stone -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Water Infused Stone -->
-                <IfCondition condition=':= thm4WaterInfusedStoneDist = "strategicCloud"'>
-                
-                    <Cloud name='thm4WaterInfusedStoneBaseCloud' block='Thaumcraft:blockCustomOre:3' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000C0FA</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 1 * thm4WaterInfusedStoneSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 1 * thm4WaterInfusedStoneSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * thm4WaterInfusedStoneSize * _default_' range=':= 1 * 1 * 1 * thm4WaterInfusedStoneSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * thm4WaterInfusedStoneFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Water'/>
-                        <BiomeType name='Frozen'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Water Infused Stone Strategic Cloud Hint Veins -->
-                        <Veins name='thm4WaterInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6000C0FA</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                            <BiomeType name='Swamp'/>
-                            <BiomeType name='Water'/>
-                            <BiomeType name='Frozen'/>
-                            <BiomeType name='Jungle'/>
-                            <BiomeType name='Beach'/>
-                            <BiomeType name='Mushroom'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Water Infused Stone Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Earth Infused Stone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thm4EarthInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Frequency multiplier for Thaumcraft 4 Earth Infused Stone distributions </Description>
+                    <DisplayName>Thaumcraft 4 Earth Infused Stone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thm4EarthInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Size multiplier for Thaumcraft 4 Earth Infused Stone distributions </Description>
+                    <DisplayName>Thaumcraft 4 Earth Infused Stone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Earth Infused Stone Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Water Infused Stone -->
-                
-                
-                <!-- Begin  Vanilla distribution of Water Infused Stone -->
-                <IfCondition condition=':= thm4WaterInfusedStoneDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thm4WaterInfusedStoneBaseStandard' block='Thaumcraft:blockCustomOre:3' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000C0FA</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1/6 * thm4WaterInfusedStoneSize * _default_'/>
-                        <Setting name='Height' avg=':= 35' range=':= 20' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/10 * thm4WaterInfusedStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Water'/>
-                        <BiomeType name='Frozen'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Water Infused Stone -->
-                
-                <!-- End Water Infused Stone Generation --> 
 
-                
-                <!-- Begin Earth Infused Stone Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Earth Infused Stone -->
-                <IfCondition condition=':= thm4EarthInfusedStoneDist = "sparseVeins"'>
-                
-                    <Veins name='thm4EarthInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:4'  inherits='PresetSparseVeins' >
+            <!-- Order Infused Stone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='thm4OrderInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                    <Description> Controls how Order Infused Stone is generated </Description>
+                    <DisplayName>Thaumcraft 4 Order Infused Stone</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000D900</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4EarthInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Earth Infused Stone Sparse Veins) Settings -->
-                    <Veins name='thm4EarthInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:4'  inherits='thm4EarthInfusedStoneBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 4 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000D900</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Earth Infused Stone Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Earth Infused Stone -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Earth Infused Stone -->
-                <IfCondition condition=':= thm4EarthInfusedStoneDist = "smallDeposits"'>
-                
-                    <Veins name='thm4EarthInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:4'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000D900</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4EarthInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Earth Infused Stone Deposit Veins) Settings -->
-                    <Veins name='thm4EarthInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:4'  inherits='thm4EarthInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000D900</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Earth Infused Stone Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Earth Infused Stone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Earth Infused Stone -->
-                <IfCondition condition=':= thm4EarthInfusedStoneDist = "hugeVeins"'>
-                
-                    <Veins name='thm4EarthInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:4'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000D900</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EarthInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4EarthInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Earth Infused Stone Huge Veins) Settings -->
-                    <Veins name='thm4EarthInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:4'  inherits='thm4EarthInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000D900</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Earth Infused Stone Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Earth Infused Stone -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Earth Infused Stone -->
-                <IfCondition condition=':= thm4EarthInfusedStoneDist = "strategicCloud"'>
-                
-                    <Cloud name='thm4EarthInfusedStoneBaseCloud' block='Thaumcraft:blockCustomOre:4' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000D900</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 1 * thm4EarthInfusedStoneSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 1 * thm4EarthInfusedStoneSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * thm4EarthInfusedStoneSize * _default_' range=':= 1 * 1 * 1 * thm4EarthInfusedStoneSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * thm4EarthInfusedStoneFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Earth Infused Stone Strategic Cloud Hint Veins -->
-                        <Veins name='thm4EarthInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6000D900</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Mountain'/>
-                            <BiomeType name='Hills'/>
-                            <BiomeType name='Desert'/>
-                            <BiomeType name='Jungle'/>
-                            <BiomeType name='Wasteland'/>
-                            <BiomeType name='Beach'/>
-                            <BiomeType name='Mushroom'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Earth Infused Stone Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Order Infused Stone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thm4OrderInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Frequency multiplier for Thaumcraft 4 Order Infused Stone distributions </Description>
+                    <DisplayName>Thaumcraft 4 Order Infused Stone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thm4OrderInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Size multiplier for Thaumcraft 4 Order Infused Stone distributions </Description>
+                    <DisplayName>Thaumcraft 4 Order Infused Stone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Order Infused Stone Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Earth Infused Stone -->
-                
-                
-                <!-- Begin  Vanilla distribution of Earth Infused Stone -->
-                <IfCondition condition=':= thm4EarthInfusedStoneDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thm4EarthInfusedStoneBaseStandard' block='Thaumcraft:blockCustomOre:4' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6000D900</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1/6 * thm4EarthInfusedStoneSize * _default_'/>
-                        <Setting name='Height' avg=':= 35' range=':= 20' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/10 * thm4EarthInfusedStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Earth Infused Stone -->
-                
-                <!-- End Earth Infused Stone Generation --> 
 
-                
-                <!-- Begin Order Infused Stone Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Order Infused Stone -->
-                <IfCondition condition=':= thm4OrderInfusedStoneDist = "sparseVeins"'>
-                
-                    <Veins name='thm4OrderInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:5'  inherits='PresetSparseVeins' >
+            <!-- Entropy Infused Stone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='thm4EntropyInfusedStoneDist'  displayState='shown' displayGroup='groupThaumcraft4'>
+                    <Description> Controls how Entropy Infused Stone is generated </Description>
+                    <DisplayName>Thaumcraft 4 Entropy Infused Stone</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EBEBF9</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4OrderInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Order Infused Stone Sparse Veins) Settings -->
-                    <Veins name='thm4OrderInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:5'  inherits='thm4OrderInfusedStoneBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 4 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EBEBF9</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Order Infused Stone Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Order Infused Stone -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Order Infused Stone -->
-                <IfCondition condition=':= thm4OrderInfusedStoneDist = "smallDeposits"'>
-                
-                    <Veins name='thm4OrderInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:5'  inherits='PresetSmallDeposits' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EBEBF9</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4OrderInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Order Infused Stone Deposit Veins) Settings -->
-                    <Veins name='thm4OrderInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:5'  inherits='thm4OrderInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EBEBF9</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Order Infused Stone Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Order Infused Stone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Order Infused Stone -->
-                <IfCondition condition=':= thm4OrderInfusedStoneDist = "hugeVeins"'>
-                
-                    <Veins name='thm4OrderInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:5'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EBEBF9</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4OrderInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4OrderInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Order Infused Stone Huge Veins) Settings -->
-                    <Veins name='thm4OrderInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:5'  inherits='thm4OrderInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EBEBF9</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Order Infused Stone Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Order Infused Stone -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Order Infused Stone -->
-                <IfCondition condition=':= thm4OrderInfusedStoneDist = "strategicCloud"'>
-                
-                    <Cloud name='thm4OrderInfusedStoneBaseCloud' block='Thaumcraft:blockCustomOre:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EBEBF9</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 1 * thm4OrderInfusedStoneSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 1 * thm4OrderInfusedStoneSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * thm4OrderInfusedStoneSize * _default_' range=':= 1 * 1 * 1 * thm4OrderInfusedStoneSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * thm4OrderInfusedStoneFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Order Infused Stone Strategic Cloud Hint Veins -->
-                        <Veins name='thm4OrderInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EBEBF9</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Forest'/>
-                            <BiomeType name='Plains'/>
-                            <BiomeType name='Mountain'/>
-                            <BiomeType name='Hills'/>
-                            <BiomeType name='Jungle'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Order Infused Stone Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Entropy Infused Stone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thm4EntropyInfusedStoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Frequency multiplier for Thaumcraft 4 Entropy Infused Stone distributions </Description>
+                    <DisplayName>Thaumcraft 4 Entropy Infused Stone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thm4EntropyInfusedStoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThaumcraft4'>
+                    <Description> Size multiplier for Thaumcraft 4 Entropy Infused Stone distributions </Description>
+                    <DisplayName>Thaumcraft 4 Entropy Infused Stone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Entropy Infused Stone Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Order Infused Stone -->
-                
-                
-                <!-- Begin  Vanilla distribution of Order Infused Stone -->
-                <IfCondition condition=':= thm4OrderInfusedStoneDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thm4OrderInfusedStoneBaseStandard' block='Thaumcraft:blockCustomOre:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EBEBF9</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1/6 * thm4OrderInfusedStoneSize * _default_'/>
-                        <Setting name='Height' avg=':= 35' range=':= 20' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/10 * thm4OrderInfusedStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Forest'/>
-                        <BiomeType name='Plains'/>
-                        <BiomeType name='Mountain'/>
-                        <BiomeType name='Hills'/>
-                        <BiomeType name='Jungle'/>
-                        <BiomeType name='Magical'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Order Infused Stone -->
-                
-                <!-- End Order Infused Stone Generation --> 
-
-                
-                <!-- Begin Entropy Infused Stone Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Entropy Infused Stone -->
-                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "sparseVeins"'>
-                
-                    <Veins name='thm4EntropyInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:6'  inherits='PresetSparseVeins' >
-                        <Description>
-                            Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60260920</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4EntropyInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Entropy Infused Stone Sparse Veins) Settings -->
-                    <Veins name='thm4EntropyInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:6'  inherits='thm4EntropyInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60260920</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Entropy Infused Stone Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Entropy Infused Stone -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Entropy Infused Stone -->
-                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "smallDeposits"'>
-                
-                    <Veins name='thm4EntropyInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:6'  inherits='PresetSmallDeposits' >
-                        <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60260920</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4EntropyInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Entropy Infused Stone Deposit Veins) Settings -->
-                    <Veins name='thm4EntropyInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:6'  inherits='thm4EntropyInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60260920</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Entropy Infused Stone Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Entropy Infused Stone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Entropy Infused Stone -->
-                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "hugeVeins"'>
-                
-                    <Veins name='thm4EntropyInfusedStoneBaseVeins' block='Thaumcraft:blockCustomOre:6'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60260920</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 0.75 * thm4EntropyInfusedStoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thm4EntropyInfusedStoneFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Entropy Infused Stone Huge Veins) Settings -->
-                    <Veins name='thm4EntropyInfusedStonePrefersVeins' block='Thaumcraft:blockCustomOre:6'  inherits='thm4EntropyInfusedStoneBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60260920</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Entropy Infused Stone Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Entropy Infused Stone -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Entropy Infused Stone -->
-                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "strategicCloud"'>
-                
-                    <Cloud name='thm4EntropyInfusedStoneBaseCloud' block='Thaumcraft:blockCustomOre:6' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60260920</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 1 * thm4EntropyInfusedStoneSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 1 * thm4EntropyInfusedStoneSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * thm4EntropyInfusedStoneSize * _default_' range=':= 1 * 1 * 1 * thm4EntropyInfusedStoneSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * thm4EntropyInfusedStoneFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                        
-                        <!-- Begin Entropy Infused Stone Strategic Cloud Hint Veins -->
-                        <Veins name='thm4EntropyInfusedStoneBaseHintVeins' block='Thaumcraft:blockCustomOre:6' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60260920</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                            <BiomeType name='Swamp'/>
-                            <BiomeType name='Desert'/>
-                            <BiomeType name='Wasteland'/>
-                            <BiomeType name='Beach'/>
-                            <BiomeType name='Mushroom'/>
-                            <BiomeType name='Magical'/>
-                        </Veins>
-                        <!-- End Entropy Infused Stone Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Entropy Infused Stone -->
-                
-                
-                <!-- Begin  Vanilla distribution of Entropy Infused Stone -->
-                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thm4EntropyInfusedStoneBaseStandard' block='Thaumcraft:blockCustomOre:6' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60260920</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1/6 * thm4EntropyInfusedStoneSize * _default_'/>
-                        <Setting name='Height' avg=':= 35' range=':= 20' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/10 * thm4EntropyInfusedStoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        <BiomeType name='Swamp'/>
-                        <BiomeType name='Desert'/>
-                        <BiomeType name='Wasteland'/>
-                        <BiomeType name='Beach'/>
-                        <BiomeType name='Mushroom'/>
-                        <BiomeType name='Magical'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Entropy Infused Stone -->
-                
-                <!-- End Entropy Infused Stone Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='thm4OverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='Thaumcraft:blockCustomOre' weight='1.0' />
+                <Replaces block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                <Replaces block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                <Replaces block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                <Replaces block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                <Replaces block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                <Replaces block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                <Replaces block='Thaumcraft:blockCustomOre:7' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Amber Generation -->
+
+            <!-- Starting SparseVeins Preset for Amber. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4AmberDist = "SparseVeins"'>
+                    <Veins name='thm4AmberVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.990 * _default_ * thm4AmberFreq ' range=':=  _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.997 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 50 ' range=':=  16 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.997 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.997 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Amber is complete. -->
+
+
+            <!-- Starting Cloud Preset for Amber. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4AmberDist = "Cloud"'>
+                    <Cloud name='thm4AmberCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.818 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.818 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * thm4AmberFreq ' range=':=  _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 50 ' range=':=  16 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4AmberHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Amber is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Amber. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4AmberDist = "Vanilla"'>
+                    <StandardGen name='thm4AmberStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 1 * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 8 * thm4AmberFreq ' range=':=  _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 50 ' range=':=  16 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Amber is complete. -->
+
+            <!-- End Amber Generation -->
+
+
+            <!-- Begin Cinnabar Generation -->
+
+            <!-- Starting SparseVeins Preset for Cinnabar. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4CinnabarDist = "SparseVeins"'>
+                    <Veins name='thm4CinnabarVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.213 * _default_ * thm4CinnabarFreq ' range=':=  _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.066 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.066 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Cinnabar is complete. -->
+
+
+            <!-- Starting Cloud Preset for Cinnabar. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4CinnabarDist = "Cloud"'>
+                    <Cloud name='thm4CinnabarCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * thm4CinnabarFreq ' range=':=  _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4CinnabarHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Cinnabar is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Cinnabar. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4CinnabarDist = "Vanilla"'>
+                    <StandardGen name='thm4CinnabarStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 1 * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 12 * thm4CinnabarFreq ' range=':=  _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Cinnabar is complete. -->
+
+            <!-- End Cinnabar Generation -->
+
+
+            <!-- Begin Air Infused Stone Generation -->
+
+            <!-- Starting SparseVeins Preset for Air Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4AirInfusedStoneDist = "SparseVeins"'>
+                    <Veins name='thm4AirInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Veins name='thm4AirInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Plains'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Air Infused Stone is complete. -->
+
+
+            <!-- Starting Cloud Preset for Air Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4AirInfusedStoneDist = "Cloud"'>
+                    <Cloud name='thm4AirInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4AirInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Cloud name='thm4AirInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Plains'  />
+                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4AirInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Air Infused Stone is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Air Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4AirInfusedStoneDist = "Vanilla"'>
+                    <StandardGen name='thm4AirInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 5 * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Air Infused Stone is complete. -->
+
+            <!-- End Air Infused Stone Generation -->
+
+
+            <!-- Begin Fire Infused Stone Generation -->
+
+            <!-- Starting SparseVeins Preset for Fire Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4FireInfusedStoneDist = "SparseVeins"'>
+                    <Veins name='thm4FireInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Veins name='thm4FireInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Desert'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Fire Infused Stone is
+                 complete. -->
+
+
+            <!-- Starting Cloud Preset for Fire Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4FireInfusedStoneDist = "Cloud"'>
+                    <Cloud name='thm4FireInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4FireInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Cloud name='thm4FireInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Desert'  />
+                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4FireInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Fire Infused Stone is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Fire Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4FireInfusedStoneDist = "Vanilla"'>
+                    <StandardGen name='thm4FireInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 5 * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Fire Infused Stone is complete. -->
+
+            <!-- End Fire Infused Stone Generation -->
+
+
+            <!-- Begin Water Infused Stone Generation -->
+
+            <!-- Starting SparseVeins Preset for Water Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4WaterInfusedStoneDist = "SparseVeins"'>
+                    <Veins name='thm4WaterInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Veins name='thm4WaterInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Water'  />
+                        <BiomeType name='Swamp'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Water Infused Stone is
+                 complete. -->
+
+
+            <!-- Starting Cloud Preset for Water Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4WaterInfusedStoneDist = "Cloud"'>
+                    <Cloud name='thm4WaterInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4WaterInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Cloud name='thm4WaterInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Water'  />
+                        <BiomeType name='Swamp'  />
+                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4WaterInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Water Infused Stone is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Water Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4WaterInfusedStoneDist = "Vanilla"'>
+                    <StandardGen name='thm4WaterInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 5 * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Water Infused Stone is complete. -->
+
+            <!-- End Water Infused Stone Generation -->
+
+
+            <!-- Begin Earth Infused Stone Generation -->
+
+            <!-- Starting SparseVeins Preset for Earth Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4EarthInfusedStoneDist = "SparseVeins"'>
+                    <Veins name='thm4EarthInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Veins name='thm4EarthInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Forest'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Earth Infused Stone is
+                 complete. -->
+
+
+            <!-- Starting Cloud Preset for Earth Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4EarthInfusedStoneDist = "Cloud"'>
+                    <Cloud name='thm4EarthInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4EarthInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Cloud name='thm4EarthInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Forest'  />
+                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4EarthInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Earth Infused Stone is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Earth Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4EarthInfusedStoneDist = "Vanilla"'>
+                    <StandardGen name='thm4EarthInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 5 * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Earth Infused Stone is complete. -->
+
+            <!-- End Earth Infused Stone Generation -->
+
+
+            <!-- Begin Order Infused Stone Generation -->
+
+            <!-- Starting SparseVeins Preset for Order Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4OrderInfusedStoneDist = "SparseVeins"'>
+                    <Veins name='thm4OrderInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Veins name='thm4OrderInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Mushroom'  />
+                        <BiomeType name='Mountain'  />
+                        <BiomeType name='Magical'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Order Infused Stone is
+                 complete. -->
+
+
+            <!-- Starting Cloud Preset for Order Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4OrderInfusedStoneDist = "Cloud"'>
+                    <Cloud name='thm4OrderInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4OrderInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Cloud name='thm4OrderInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Mushroom'  />
+                        <BiomeType name='Mountain'  />
+                        <BiomeType name='Magical'  />
+                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4OrderInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Order Infused Stone is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Order Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4OrderInfusedStoneDist = "Vanilla"'>
+                    <StandardGen name='thm4OrderInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 5 * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Order Infused Stone is complete. -->
+
+            <!-- End Order Infused Stone Generation -->
+
+
+            <!-- Begin Entropy Infused Stone Generation -->
+
+            <!-- Starting SparseVeins Preset for Entropy Infused
+                 Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "SparseVeins"'>
+                    <Veins name='thm4EntropyInfusedStoneVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                        <Description>
+                            Large veins filled very lightly with  ore.
+                            Because they contain less ore  per volume,
+                            these veins are  relatively wide and long.
+                            Mining the  ore from them is time
+                            consuming  compared to solid ore veins.
+                            They  are also more difficult to follow,
+                            since it is harder to get an idea of
+                            their direction while mining.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Veins name='thm4EntropyInfusedStonePreferredVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Swamp'  />
+                        <BiomeType name='Wasteland'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- SparseVeins Preset for Entropy Infused Stone is
+                 complete. -->
+
+
+            <!-- Starting Cloud Preset for Entropy Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "Cloud"'>
+                    <Cloud name='thm4EntropyInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4EntropyInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+
+                    <!-- Beginning "Preferred" configuration. -->
+                    <Cloud name='thm4EntropyInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                        <Description>
+                            Ore generation is doubled in  preferred
+                            biomes.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <BiomeType name='Swamp'  />
+                        <BiomeType name='Wasteland'  />
+                        <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thm4EntropyInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                    <!-- "Preferred" configuration complete. -->
+
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Entropy Infused Stone is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Entropy Infused Stone. -->
+            <ConfigSection>
+                <IfCondition condition=':= thm4EntropyInfusedStoneDist = "Vanilla"'>
+                    <StandardGen name='thm4EntropyInfusedStoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 5 * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Entropy Infused Stone is complete. -->
+
+            <!-- End Entropy Infused Stone Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Thaumcraft 4" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -29,10 +29,15 @@
                     Distribution options for Thermal Foundation Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableThermalFoundation' displayName='Handle Thermal Foundation Setup?' default='true' displayState='shown_dynamic' displayGroup='groupThermalFoundation'>
+                <Description> Should Custom Ore Generation handle Thermal Foundation ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Thermal Foundation ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Thermal Foundation ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Copper Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thfoCopperDist'  displayState='shown' displayGroup='groupThermalFoundation'>
+                <OptionChoice name='thfoCopperDist'  displayState=':= if(?enableThermalFoundation, "shown", "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Controls how Copper is generated </Description>
                     <DisplayName>Thermal Foundation Copper</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -52,11 +57,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thfoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                <OptionNumeric name='thfoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?enableThermalFoundation, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Frequency multiplier for Thermal Foundation Copper distributions </Description>
                     <DisplayName>Thermal Foundation Copper Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thfoCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                <OptionNumeric name='thfoCopperSize' default='1'  min='0' max='5' displayState=':= if(?enableThermalFoundation, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Size multiplier for Thermal Foundation Copper distributions </Description>
                     <DisplayName>Thermal Foundation Copper Size</DisplayName>
                 </OptionNumeric>
@@ -66,7 +71,7 @@
 
             <!-- Tin Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thfoTinDist'  displayState='shown' displayGroup='groupThermalFoundation'>
+                <OptionChoice name='thfoTinDist'  displayState=':= if(?enableThermalFoundation, "shown", "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Controls how Tin is generated </Description>
                     <DisplayName>Thermal Foundation Tin</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -86,11 +91,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thfoTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                <OptionNumeric name='thfoTinFreq' default='1'  min='0' max='5' displayState=':= if(?enableThermalFoundation, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Frequency multiplier for Thermal Foundation Tin distributions </Description>
                     <DisplayName>Thermal Foundation Tin Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thfoTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                <OptionNumeric name='thfoTinSize' default='1'  min='0' max='5' displayState=':= if(?enableThermalFoundation, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Size multiplier for Thermal Foundation Tin distributions </Description>
                     <DisplayName>Thermal Foundation Tin Size</DisplayName>
                 </OptionNumeric>
@@ -100,7 +105,7 @@
 
             <!-- Silver Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thfoSilverDist'  displayState='shown' displayGroup='groupThermalFoundation'>
+                <OptionChoice name='thfoSilverDist'  displayState=':= if(?enableThermalFoundation, "shown", "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Controls how Silver is generated </Description>
                     <DisplayName>Thermal Foundation Silver</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -120,11 +125,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thfoSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                <OptionNumeric name='thfoSilverFreq' default='1'  min='0' max='5' displayState=':= if(?enableThermalFoundation, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Frequency multiplier for Thermal Foundation Silver distributions </Description>
                     <DisplayName>Thermal Foundation Silver Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thfoSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                <OptionNumeric name='thfoSilverSize' default='1'  min='0' max='5' displayState=':= if(?enableThermalFoundation, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Size multiplier for Thermal Foundation Silver distributions </Description>
                     <DisplayName>Thermal Foundation Silver Size</DisplayName>
                 </OptionNumeric>
@@ -134,7 +139,7 @@
 
             <!-- Lead Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thfoLeadDist'  displayState='shown' displayGroup='groupThermalFoundation'>
+                <OptionChoice name='thfoLeadDist'  displayState=':= if(?enableThermalFoundation, "shown", "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Controls how Lead is generated </Description>
                     <DisplayName>Thermal Foundation Lead</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -154,11 +159,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Lead is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thfoLeadFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                <OptionNumeric name='thfoLeadFreq' default='1'  min='0' max='5' displayState=':= if(?enableThermalFoundation, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Frequency multiplier for Thermal Foundation Lead distributions </Description>
                     <DisplayName>Thermal Foundation Lead Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thfoLeadSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                <OptionNumeric name='thfoLeadSize' default='1'  min='0' max='5' displayState=':= if(?enableThermalFoundation, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Size multiplier for Thermal Foundation Lead distributions </Description>
                     <DisplayName>Thermal Foundation Lead Size</DisplayName>
                 </OptionNumeric>
@@ -168,7 +173,7 @@
 
             <!-- Ferrous Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thfoFerrousDist'  displayState='shown' displayGroup='groupThermalFoundation'>
+                <OptionChoice name='thfoFerrousDist'  displayState=':= if(?enableThermalFoundation, "shown", "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Controls how Ferrous is generated </Description>
                     <DisplayName>Thermal Foundation Ferrous</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -188,11 +193,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Ferrous is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thfoFerrousFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                <OptionNumeric name='thfoFerrousFreq' default='1'  min='0' max='5' displayState=':= if(?enableThermalFoundation, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Frequency multiplier for Thermal Foundation Ferrous distributions </Description>
                     <DisplayName>Thermal Foundation Ferrous Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thfoFerrousSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                <OptionNumeric name='thfoFerrousSize' default='1'  min='0' max='5' displayState=':= if(?enableThermalFoundation, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Size multiplier for Thermal Foundation Ferrous distributions </Description>
                     <DisplayName>Thermal Foundation Ferrous Size</DisplayName>
                 </OptionNumeric>
@@ -202,7 +207,7 @@
 
             <!-- Shiny Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='thfoShinyDist'  displayState='shown' displayGroup='groupThermalFoundation'>
+                <OptionChoice name='thfoShinyDist'  displayState=':= if(?enableThermalFoundation, "shown", "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Controls how Shiny is generated </Description>
                     <DisplayName>Thermal Foundation Shiny</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -222,11 +227,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Shiny is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='thfoShinyFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                <OptionNumeric name='thfoShinyFreq' default='1'  min='0' max='5' displayState=':= if(?enableThermalFoundation, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Frequency multiplier for Thermal Foundation Shiny distributions </Description>
                     <DisplayName>Thermal Foundation Shiny Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='thfoShinySize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                <OptionNumeric name='thfoShinySize' default='1'  min='0' max='5' displayState=':= if(?enableThermalFoundation, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupThermalFoundation'>
                     <Description> Size multiplier for Thermal Foundation Shiny distributions </Description>
                     <DisplayName>Thermal Foundation Shiny Size</DisplayName>
                 </OptionNumeric>
@@ -236,744 +241,761 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableThermalFoundation'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='thfoOverworldBlockSubstitute0' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='ThermalFoundation:Ore' weight='1.0' />
-                <Replaces block='ThermalFoundation:Ore:1' weight='1.0' />
-                <Replaces block='ThermalFoundation:Ore:2' weight='1.0' />
-                <Replaces block='ThermalFoundation:Ore:3' weight='1.0' />
-                <Replaces block='ThermalFoundation:Ore:4' weight='1.0' />
-                <Replaces block='ThermalFoundation:Ore:5' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Copper Generation -->
-
-            <!-- Starting LayeredVeins Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoCopperDist = "LayeredVeins"'>
-                    <Veins name='thfoCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='thfoOverworldBlockSubstitute0' block='minecraft:stone'>
                         <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * thfoCopperFreq ' range=':=  _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.019 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <Replaces block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <Replaces block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <Replaces block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <Replaces block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <Replaces block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <Replaces block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Copper is complete. -->
 
+                <!-- Original "Overworld" Block Removal Complete -->
 
-            <!-- Starting Cloud Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoCopperDist = "Cloud"'>
-                    <Cloud name='thfoCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.454 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.454 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.115  * _default_ * thfoCopperFreq ' range=':=  _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thfoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <!-- Adding blocks -->
+
+                <!-- Begin Copper Generation -->
+
+                <!-- Starting LayeredVeins Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoCopperDist = "LayeredVeins"'>
+                        <Veins name='thfoCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * thfoCopperFreq ' range=':=  _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.019 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Copper is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoCopperDist = "Vanilla"'>
-                    <StandardGen name='thfoCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 10 * thfoCopperFreq ' range=':=  _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Copper is complete. -->
-
-            <!-- End Copper Generation -->
-
-
-            <!-- Begin Tin Generation -->
-
-            <!-- Starting LayeredVeins Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoTinDist = "LayeredVeins"'>
-                    <Veins name='thfoTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * thfoTinFreq ' range=':=  _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Tin is complete. -->
-
-
-            <!-- Starting Cloud Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoTinDist = "Cloud"'>
-                    <Cloud name='thfoTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.375 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.375 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * thfoTinFreq ' range=':=  _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thfoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                <!-- Starting Cloud Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoCopperDist = "Cloud"'>
+                        <Cloud name='thfoCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Tin is complete. -->
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.454 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.454 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.115  * _default_ * thfoCopperFreq ' range=':=  _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thfoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoTinDist = "Vanilla"'>
-                    <StandardGen name='thfoTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 8 * thfoTinFreq ' range=':=  _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Tin is complete. -->
-
-            <!-- End Tin Generation -->
-
-
-            <!-- Begin Silver Generation -->
-
-            <!-- Starting LayeredVeins Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoSilverDist = "LayeredVeins"'>
-                    <Veins name='thfoSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * thfoSilverFreq ' range=':=  _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Silver is complete. -->
-
-
-            <!-- Starting Cloud Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoSilverDist = "Cloud"'>
-                    <Cloud name='thfoSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * thfoSilverFreq ' range=':=  _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thfoSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                <!-- Starting Vanilla Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoCopperDist = "Vanilla"'>
+                        <StandardGen name='thfoCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Silver is complete. -->
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10 * thfoCopperFreq ' range=':=  _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Copper is complete. -->
+
+                <!-- End Copper Generation -->
 
 
-            <!-- Starting Vanilla Preset for Silver. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoSilverDist = "Vanilla"'>
-                    <StandardGen name='thfoSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 6 * thfoSilverFreq ' range=':=  _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Silver is complete. -->
+                <!-- Begin Tin Generation -->
 
-            <!-- End Silver Generation -->
-
-
-            <!-- Begin Lead Generation -->
-
-            <!-- Starting LayeredVeins Preset for Lead. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoLeadDist = "LayeredVeins"'>
-                    <Veins name='thfoLeadVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * thfoLeadFreq ' range=':=  _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Lead is complete. -->
-
-
-            <!-- Starting Cloud Preset for Lead. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoLeadDist = "Cloud"'>
-                    <Cloud name='thfoLeadCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.375 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.375 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * thfoLeadFreq ' range=':=  _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thfoLeadHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                <!-- Starting LayeredVeins Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoTinDist = "LayeredVeins"'>
+                        <Veins name='thfoTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * thfoTinFreq ' range=':=  _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Lead is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Tin is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Lead. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoLeadDist = "Vanilla"'>
-                    <StandardGen name='thfoLeadStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 8 * thfoLeadFreq ' range=':=  _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Lead is complete. -->
-
-            <!-- End Lead Generation -->
-
-
-            <!-- Begin Ferrous Generation -->
-
-            <!-- Starting LayeredVeins Preset for Ferrous. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoFerrousDist = "LayeredVeins"'>
-                    <Veins name='thfoFerrousVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * thfoFerrousFreq ' range=':=  _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Ferrous is complete. -->
-
-
-            <!-- Starting Cloud Preset for Ferrous. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoFerrousDist = "Cloud"'>
-                    <Cloud name='thfoFerrousCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * thfoFerrousFreq ' range=':=  _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thfoFerrousHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
+                <!-- Starting Cloud Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoTinDist = "Cloud"'>
+                        <Cloud name='thfoTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Ferrous is complete. -->
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * thfoTinFreq ' range=':=  _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thfoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tin is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Ferrous. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoFerrousDist = "Vanilla"'>
-                    <StandardGen name='thfoFerrousStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 4 * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * thfoFerrousFreq ' range=':=  _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Ferrous is complete. -->
-
-            <!-- End Ferrous Generation -->
-
-
-            <!-- Begin Shiny Generation -->
-
-            <!-- Starting LayeredVeins Preset for Shiny. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoShinyDist = "LayeredVeins"'>
-                    <Veins name='thfoShinyVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.205 * _default_ * thfoShinyFreq ' range=':=  _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.590 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.590 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.590 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Shiny is complete. -->
-
-
-            <!-- Starting Cloud Preset for Shiny. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoShinyDist = "Cloud"'>
-                    <Cloud name='thfoShinyCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.640 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.640 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.410  * _default_ * thfoShinyFreq ' range=':=  _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='thfoShinyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
+                <!-- Starting Vanilla Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoTinDist = "Vanilla"'>
+                        <StandardGen name='thfoTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * thfoTinFreq ' range=':=  _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tin is complete. -->
+
+                <!-- End Tin Generation -->
+
+
+                <!-- Begin Silver Generation -->
+
+                <!-- Starting LayeredVeins Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoSilverDist = "LayeredVeins"'>
+                        <Veins name='thfoSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * thfoSilverFreq ' range=':=  _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Shiny is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Silver is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Shiny. -->
-            <ConfigSection>
-                <IfCondition condition=':= thfoShinyDist = "Vanilla"'>
-                    <StandardGen name='thfoShinyStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 1 * thfoShinyFreq ' range=':=  _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Shiny is complete. -->
+                <!-- Starting Cloud Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoSilverDist = "Cloud"'>
+                        <Cloud name='thfoSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * thfoSilverFreq ' range=':=  _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thfoSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Silver is complete. -->
 
-            <!-- End Shiny Generation -->
 
-            <!-- Finished adding blocks -->
+                <!-- Starting Vanilla Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoSilverDist = "Vanilla"'>
+                        <StandardGen name='thfoSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * thfoSilverFreq ' range=':=  _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Silver is complete. -->
+
+                <!-- End Silver Generation -->
+
+
+                <!-- Begin Lead Generation -->
+
+                <!-- Starting LayeredVeins Preset for Lead. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoLeadDist = "LayeredVeins"'>
+                        <Veins name='thfoLeadVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * thfoLeadFreq ' range=':=  _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Lead is complete. -->
+
+
+                <!-- Starting Cloud Preset for Lead. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoLeadDist = "Cloud"'>
+                        <Cloud name='thfoLeadCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * thfoLeadFreq ' range=':=  _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thfoLeadHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Lead is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Lead. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoLeadDist = "Vanilla"'>
+                        <StandardGen name='thfoLeadStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * thfoLeadFreq ' range=':=  _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Lead is complete. -->
+
+                <!-- End Lead Generation -->
+
+
+                <!-- Begin Ferrous Generation -->
+
+                <!-- Starting LayeredVeins Preset for Ferrous. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoFerrousDist = "LayeredVeins"'>
+                        <Veins name='thfoFerrousVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * thfoFerrousFreq ' range=':=  _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Ferrous is complete. -->
+
+
+                <!-- Starting Cloud Preset for Ferrous. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoFerrousDist = "Cloud"'>
+                        <Cloud name='thfoFerrousCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * thfoFerrousFreq ' range=':=  _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thfoFerrousHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Ferrous is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Ferrous. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoFerrousDist = "Vanilla"'>
+                        <StandardGen name='thfoFerrousStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * thfoFerrousFreq ' range=':=  _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Ferrous is complete. -->
+
+                <!-- End Ferrous Generation -->
+
+
+                <!-- Begin Shiny Generation -->
+
+                <!-- Starting LayeredVeins Preset for Shiny. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoShinyDist = "LayeredVeins"'>
+                        <Veins name='thfoShinyVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.205 * _default_ * thfoShinyFreq ' range=':=  _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.590 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.590 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.590 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Shiny is complete. -->
+
+
+                <!-- Starting Cloud Preset for Shiny. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoShinyDist = "Cloud"'>
+                        <Cloud name='thfoShinyCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.640 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.640 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.410  * _default_ * thfoShinyFreq ' range=':=  _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='thfoShinyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Shiny is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Shiny. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thfoShinyDist = "Vanilla"'>
+                        <StandardGen name='thfoShinyStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thfoShinyFreq ' range=':=  _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Shiny is complete. -->
+
+                <!-- End Shiny Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -1,1563 +1,994 @@
- <!-- ================================================================
-      Custom Ore Generation "Thermal Foundation" Module: This
-      configuration covers copper, tin, silver, lead, ferrous, shiny,
-      and mana infused.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Thermal Foundation" Module: This
+     configuration covers copper, tin, silver, lead, ferrous, and
+     shiny.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="ThermalFoundation">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+<!-- Thermal Foundation is the basis upon which "Thermal Expansion"
+     depends.  Included in this foundation are the six ores that are
+     heavily used by all associated mods. -->
+
+
+
+
+<!-- Is the "Thermal Foundation" mod on the system?  Let's find out! -->
+<IfModInstalled name="ThermalFoundation">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupThermalFoundation' displayName='Thermal Foundation' displayState='shown'>
+                <Description>
+                    Distribution options for Thermal Foundation Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Copper Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupThermalFoundation' displayName='Thermal Foundation' displayState='shown'> 
-                    <Description>
-                        Distribution options for Thermal Foundation Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Copper Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thfoCopperDist'  displayState='shown' displayGroup='groupThermalFoundation'> 
-                        <Description> Controls how Copper is generated </Description> 
-                        <DisplayName>Thermal Foundation Copper</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thfoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Frequency multiplier for Thermal Foundation Copper distributions </Description>
-                        <DisplayName>Thermal Foundation Copper Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thfoCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Size multiplier for Thermal Foundation Copper distributions </Description>
-                        <DisplayName>Thermal Foundation Copper Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Copper Configuration UI Complete -->
-                
-                
-                <!-- Tin Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thfoTinDist'  displayState='shown' displayGroup='groupThermalFoundation'> 
-                        <Description> Controls how Tin is generated </Description> 
-                        <DisplayName>Thermal Foundation Tin</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thfoTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Frequency multiplier for Thermal Foundation Tin distributions </Description>
-                        <DisplayName>Thermal Foundation Tin Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thfoTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Size multiplier for Thermal Foundation Tin distributions </Description>
-                        <DisplayName>Thermal Foundation Tin Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Tin Configuration UI Complete -->
-                
-                
-                <!-- Silver Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thfoSilverDist'  displayState='shown' displayGroup='groupThermalFoundation'> 
-                        <Description> Controls how Silver is generated </Description> 
-                        <DisplayName>Thermal Foundation Silver</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thfoSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Frequency multiplier for Thermal Foundation Silver distributions </Description>
-                        <DisplayName>Thermal Foundation Silver Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thfoSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Size multiplier for Thermal Foundation Silver distributions </Description>
-                        <DisplayName>Thermal Foundation Silver Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Silver Configuration UI Complete -->
-                
-                
-                <!-- Lead Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thfoLeadDist'  displayState='shown' displayGroup='groupThermalFoundation'> 
-                        <Description> Controls how Lead is generated </Description> 
-                        <DisplayName>Thermal Foundation Lead</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Lead is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thfoLeadFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Frequency multiplier for Thermal Foundation Lead distributions </Description>
-                        <DisplayName>Thermal Foundation Lead Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thfoLeadSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Size multiplier for Thermal Foundation Lead distributions </Description>
-                        <DisplayName>Thermal Foundation Lead Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Lead Configuration UI Complete -->
-                
-                
-                <!-- Ferrous Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thfoFerrousDist'  displayState='shown' displayGroup='groupThermalFoundation'> 
-                        <Description> Controls how Ferrous is generated </Description> 
-                        <DisplayName>Thermal Foundation Ferrous</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Ferrous is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thfoFerrousFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Frequency multiplier for Thermal Foundation Ferrous distributions </Description>
-                        <DisplayName>Thermal Foundation Ferrous Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thfoFerrousSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Size multiplier for Thermal Foundation Ferrous distributions </Description>
-                        <DisplayName>Thermal Foundation Ferrous Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Ferrous Configuration UI Complete -->
-                
-                
-                <!-- Shiny Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thfoShinyDist'  displayState='shown' displayGroup='groupThermalFoundation'> 
-                        <Description> Controls how Shiny is generated </Description> 
-                        <DisplayName>Thermal Foundation Shiny</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Shiny is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thfoShinyFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Frequency multiplier for Thermal Foundation Shiny distributions </Description>
-                        <DisplayName>Thermal Foundation Shiny Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thfoShinySize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Size multiplier for Thermal Foundation Shiny distributions </Description>
-                        <DisplayName>Thermal Foundation Shiny Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Shiny Configuration UI Complete -->
-                
-                
-                <!-- Mana Infused Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='thfoManaInfusedDist'  displayState='shown' displayGroup='groupThermalFoundation'> 
-                        <Description> Controls how Mana Infused is generated </Description> 
-                        <DisplayName>Thermal Foundation Mana Infused</DisplayName>
-                        <Choice value='sparseVeins' displayValue='Sparse Veins'>
-                            <Description>
-                                Sparse Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='smallDeposits' displayValue='Small Deposits'>
-                            <Description>
-                                Small Deposits.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Mana Infused is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='thfoManaInfusedFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Frequency multiplier for Thermal Foundation Mana Infused distributions </Description>
-                        <DisplayName>Thermal Foundation Mana Infused Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='thfoManaInfusedSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
-                        <Description> Size multiplier for Thermal Foundation Mana Infused distributions </Description>
-                        <DisplayName>Thermal Foundation Mana Infused Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Mana Infused Configuration UI Complete -->
-                
+                <OptionChoice name='thfoCopperDist'  displayState='shown' displayGroup='groupThermalFoundation'>
+                    <Description> Controls how Copper is generated </Description>
+                    <DisplayName>Thermal Foundation Copper</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thfoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                    <Description> Frequency multiplier for Thermal Foundation Copper distributions </Description>
+                    <DisplayName>Thermal Foundation Copper Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thfoCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                    <Description> Size multiplier for Thermal Foundation Copper distributions </Description>
+                    <DisplayName>Thermal Foundation Copper Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Copper Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='thfoOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='ThermalFoundation:Ore' />
-                    <Replaces block='ThermalFoundation:Ore:1' />
-                    <Replaces block='ThermalFoundation:Ore:2' />
-                    <Replaces block='ThermalFoundation:Ore:3' />
-                    <Replaces block='ThermalFoundation:Ore:4' />
-                    <Replaces block='ThermalFoundation:Ore:5' />
-                    <Replaces block='ThermalFoundation:Ore:5' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Copper Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Copper -->
-                <IfCondition condition=':= thfoCopperDist = "layeredVeins"'>
-                
-                    <Veins name='thfoCopperBaseVeins' block='ThermalFoundation:Ore'  inherits='PresetLayeredVeins' >
+            <!-- Tin Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='thfoTinDist'  displayState='shown' displayGroup='groupThermalFoundation'>
+                    <Description> Controls how Tin is generated </Description>
+                    <DisplayName>Thermal Foundation Tin</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.9 * thfoCopperSize * _default_' range=':= 1 * 0.9 * thfoCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 45' range=':= 10' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.9 * thfoCopperSize * _default_' range=':= 1 * 0.9 * thfoCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * thfoCopperFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.95 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.95 * _default_' range=':= 0.95 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='thfoCopperPrefersVeins' block='ThermalFoundation:Ore'  inherits='thfoCopperBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Jungle'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Copper -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Copper -->
-                <IfCondition condition=':= thfoCopperDist = "hugeVeins"'>
-                
-                    <Veins name='thfoCopperBaseVeins' block='ThermalFoundation:Ore'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.9 * thfoCopperSize * _default_' range=':= 1 * 0.9 * thfoCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 45' range=':= 10' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.9 * thfoCopperSize * _default_' range=':= 1 * 0.9 * thfoCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.9 * thfoCopperFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.95 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.95 * _default_' range=':= 0.95 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                    <Veins name='thfoCopperPrefersVeins' block='ThermalFoundation:Ore'  inherits='thfoCopperBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Jungle'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Copper -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Copper -->
-                <IfCondition condition=':= thfoCopperDist = "strategicCloud"'>
-                
-                    <Cloud name='thfoCopperBaseCloud' block='ThermalFoundation:Ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.95 * thfoCopperSize * _default_' range=':= 1 * 0.95 * thfoCopperSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.95 * thfoCopperSize * _default_' range=':= 1 * 0.95 * thfoCopperSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.95 * 0.95 * thfoCopperSize * _default_' range=':= 1 * 0.95 * 0.95 * thfoCopperSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * thfoCopperFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Copper Strategic Cloud Hint Veins -->
-                        <Veins name='thfoCopperBaseHintVeins' block='ThermalFoundation:Ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Copper Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thfoTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                    <Description> Frequency multiplier for Thermal Foundation Tin distributions </Description>
+                    <DisplayName>Thermal Foundation Tin Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thfoTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                    <Description> Size multiplier for Thermal Foundation Tin distributions </Description>
+                    <DisplayName>Thermal Foundation Tin Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Tin Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Copper -->
-                
-                
-                <!-- Begin  Vanilla distribution of Copper -->
-                <IfCondition condition=':= thfoCopperDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thfoCopperBaseStandard' block='ThermalFoundation:Ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * thfoCopperSize * _default_'/>
-                        <Setting name='Height' avg=':= 57' range=':= 17' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1.2 * thfoCopperFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Copper -->
-                
-                <!-- End Copper Generation --> 
 
-                
-                <!-- Begin Tin Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Tin -->
-                <IfCondition condition=':= thfoTinDist = "layeredVeins"'>
-                
-                    <Veins name='thfoTinBaseVeins' block='ThermalFoundation:Ore:1'  inherits='PresetLayeredVeins' >
+            <!-- Silver Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='thfoSilverDist'  displayState='shown' displayGroup='groupThermalFoundation'>
+                    <Description> Controls how Silver is generated </Description>
+                    <DisplayName>Thermal Foundation Silver</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * thfoTinSize * _default_' range=':= 1 * 0.85 * thfoTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * thfoTinSize * _default_' range=':= 1 * 0.85 * thfoTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * thfoTinFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.9 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.9 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 11'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='thfoTinPrefersVeins' block='ThermalFoundation:Ore:1'  inherits='thfoTinBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Tin -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Tin -->
-                <IfCondition condition=':= thfoTinDist = "hugeVeins"'>
-                
-                    <Veins name='thfoTinBaseVeins' block='ThermalFoundation:Ore:1'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * thfoTinSize * _default_' range=':= 1 * 0.85 * thfoTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 30' range=':= 11' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * thfoTinSize * _default_' range=':= 1 * 0.85 * thfoTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * thfoTinFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.9 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.9 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 11'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                    <Veins name='thfoTinPrefersVeins' block='ThermalFoundation:Ore:1'  inherits='thfoTinBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Tin -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Tin -->
-                <IfCondition condition=':= thfoTinDist = "strategicCloud"'>
-                
-                    <Cloud name='thfoTinBaseCloud' block='ThermalFoundation:Ore:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.9 * thfoTinSize * _default_' range=':= 1 * 0.9 * thfoTinSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.9 * thfoTinSize * _default_' range=':= 1 * 0.9 * thfoTinSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.9 * 0.9 * thfoTinSize * _default_' range=':= 1 * 0.9 * 0.9 * thfoTinSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * thfoTinFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Tin Strategic Cloud Hint Veins -->
-                        <Veins name='thfoTinBaseHintVeins' block='ThermalFoundation:Ore:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Tin Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thfoSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                    <Description> Frequency multiplier for Thermal Foundation Silver distributions </Description>
+                    <DisplayName>Thermal Foundation Silver Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thfoSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                    <Description> Size multiplier for Thermal Foundation Silver distributions </Description>
+                    <DisplayName>Thermal Foundation Silver Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Silver Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Tin -->
-                
-                
-                <!-- Begin  Vanilla distribution of Tin -->
-                <IfCondition condition=':= thfoTinDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thfoTinBaseStandard' block='ThermalFoundation:Ore:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * thfoTinSize * _default_'/>
-                        <Setting name='Height' avg=':= 37' range=':= 17' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.75 * thfoTinFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Tin -->
-                
-                <!-- End Tin Generation --> 
 
-                
-                <!-- Begin Silver Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Silver -->
-                <IfCondition condition=':= thfoSilverDist = "layeredVeins"'>
-                
-                    <Veins name='thfoSilverBaseVeins' block='ThermalFoundation:Ore:2'  inherits='PresetLayeredVeins' >
+            <!-- Lead Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='thfoLeadDist'  displayState='shown' displayGroup='groupThermalFoundation'>
+                    <Description> Controls how Lead is generated </Description>
+                    <DisplayName>Thermal Foundation Lead</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * thfoSilverSize * _default_' range=':= 1 * 0.85 * thfoSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * thfoSilverSize * _default_' range=':= 1 * 0.85 * thfoSilverSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * thfoSilverFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                    <Veins name='thfoSilverPrefersVeins' block='ThermalFoundation:Ore:2'  inherits='thfoSilverBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Silver Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Silver -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Silver -->
-                <IfCondition condition=':= thfoSilverDist = "hugeVeins"'>
-                
-                    <Veins name='thfoSilverBaseVeins' block='ThermalFoundation:Ore:2'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * thfoSilverSize * _default_' range=':= 1 * 0.85 * thfoSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * thfoSilverSize * _default_' range=':= 1 * 0.85 * thfoSilverSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * thfoSilverFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Silver Huge Veins) Settings -->
-                    <Veins name='thfoSilverPrefersVeins' block='ThermalFoundation:Ore:2'  inherits='thfoSilverBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Mountain'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Silver Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Silver -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Silver -->
-                <IfCondition condition=':= thfoSilverDist = "strategicCloud"'>
-                
-                    <Cloud name='thfoSilverBaseCloud' block='ThermalFoundation:Ore:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * thfoSilverSize * _default_' range=':= 1 * 0.8 * thfoSilverSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * thfoSilverSize * _default_' range=':= 1 * 0.8 * thfoSilverSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.5 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * thfoSilverSize * _default_' range=':= 1 * 0.8 * 0.8 * thfoSilverSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * thfoSilverFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Silver Strategic Cloud Hint Veins -->
-                        <Veins name='thfoSilverBaseHintVeins' block='ThermalFoundation:Ore:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E3F2F7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Silver Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Lead is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thfoLeadFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                    <Description> Frequency multiplier for Thermal Foundation Lead distributions </Description>
+                    <DisplayName>Thermal Foundation Lead Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thfoLeadSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                    <Description> Size multiplier for Thermal Foundation Lead distributions </Description>
+                    <DisplayName>Thermal Foundation Lead Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Lead Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Silver -->
-                
-                
-                <!-- Begin  Vanilla distribution of Silver -->
-                <IfCondition condition=':= thfoSilverDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thfoSilverBaseStandard' block='ThermalFoundation:Ore:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * thfoSilverSize * _default_'/>
-                        <Setting name='Height' avg=':= 18' range=':= 12' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.15 * thfoSilverFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Silver -->
-                
-                <!-- End Silver Generation --> 
 
-                
-                <!-- Begin Lead Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Lead -->
-                <IfCondition condition=':= thfoLeadDist = "layeredVeins"'>
-                
-                    <Veins name='thfoLeadBaseVeins' block='ThermalFoundation:Ore:3'  inherits='PresetLayeredVeins' >
+            <!-- Ferrous Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='thfoFerrousDist'  displayState='shown' displayGroup='groupThermalFoundation'>
+                    <Description> Controls how Ferrous is generated </Description>
+                    <DisplayName>Thermal Foundation Ferrous</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * thfoLeadSize * _default_' range=':= 1 * 1 * thfoLeadSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * thfoLeadSize * _default_' range=':= 1 * 1 * thfoLeadSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * thfoLeadFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Lead Layered Veins) Settings -->
-                    <Veins name='thfoLeadPrefersVeins' block='ThermalFoundation:Ore:3'  inherits='thfoLeadBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Desert'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Lead Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Lead -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Lead -->
-                <IfCondition condition=':= thfoLeadDist = "hugeVeins"'>
-                
-                    <Veins name='thfoLeadBaseVeins' block='ThermalFoundation:Ore:3'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * thfoLeadSize * _default_' range=':= 1 * 1 * thfoLeadSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * thfoLeadSize * _default_' range=':= 1 * 1 * thfoLeadSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * thfoLeadFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Lead Huge Veins) Settings -->
-                    <Veins name='thfoLeadPrefersVeins' block='ThermalFoundation:Ore:3'  inherits='thfoLeadBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Desert'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Lead Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Lead -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Lead -->
-                <IfCondition condition=':= thfoLeadDist = "strategicCloud"'>
-                
-                    <Cloud name='thfoLeadBaseCloud' block='ThermalFoundation:Ore:3' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.85 * thfoLeadSize * _default_' range=':= 1 * 0.85 * thfoLeadSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.85 * thfoLeadSize * _default_' range=':= 1 * 0.85 * thfoLeadSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.85 * 0.85 * thfoLeadSize * _default_' range=':= 1 * 0.85 * 0.85 * thfoLeadSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 2.5 * thfoLeadFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Lead Strategic Cloud Hint Veins -->
-                        <Veins name='thfoLeadBaseHintVeins' block='ThermalFoundation:Ore:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60818EBE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Lead Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Ferrous is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thfoFerrousFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                    <Description> Frequency multiplier for Thermal Foundation Ferrous distributions </Description>
+                    <DisplayName>Thermal Foundation Ferrous Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thfoFerrousSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                    <Description> Size multiplier for Thermal Foundation Ferrous distributions </Description>
+                    <DisplayName>Thermal Foundation Ferrous Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Ferrous Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Lead -->
-                
-                
-                <!-- Begin  Vanilla distribution of Lead -->
-                <IfCondition condition=':= thfoLeadDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thfoLeadBaseStandard' block='ThermalFoundation:Ore:3' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * thfoLeadSize * _default_'/>
-                        <Setting name='Height' avg=':= 22' range=':= 12' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.30 * thfoLeadFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Lead -->
-                
-                <!-- End Lead Generation --> 
 
-                
-                <!-- Begin Ferrous Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Ferrous -->
-                <IfCondition condition=':= thfoFerrousDist = "layeredVeins"'>
-                
-                    <Veins name='thfoFerrousBaseVeins' block='ThermalFoundation:Ore:4'  inherits='PresetLayeredVeins' >
+            <!-- Shiny Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='thfoShinyDist'  displayState='shown' displayGroup='groupThermalFoundation'>
+                    <Description> Controls how Shiny is generated </Description>
+                    <DisplayName>Thermal Foundation Shiny</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BCBDAB</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * thfoFerrousSize * _default_' range=':= 1 * 0.85 * thfoFerrousSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * thfoFerrousSize * _default_' range=':= 1 * 0.85 * thfoFerrousSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * thfoFerrousFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Ferrous Layered Veins) Settings -->
-                    <Veins name='thfoFerrousPrefersVeins' block='ThermalFoundation:Ore:4'  inherits='thfoFerrousBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BCBDAB</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Ferrous Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Ferrous -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Ferrous -->
-                <IfCondition condition=':= thfoFerrousDist = "hugeVeins"'>
-                
-                    <Veins name='thfoFerrousBaseVeins' block='ThermalFoundation:Ore:4'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BCBDAB</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.85 * thfoFerrousSize * _default_' range=':= 1 * 0.85 * thfoFerrousSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.85 * thfoFerrousSize * _default_' range=':= 1 * 0.85 * thfoFerrousSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * thfoFerrousFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Ferrous Huge Veins) Settings -->
-                    <Veins name='thfoFerrousPrefersVeins' block='ThermalFoundation:Ore:4'  inherits='thfoFerrousBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BCBDAB</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Swamp'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Ferrous Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Ferrous -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Ferrous -->
-                <IfCondition condition=':= thfoFerrousDist = "strategicCloud"'>
-                
-                    <Cloud name='thfoFerrousBaseCloud' block='ThermalFoundation:Ore:4' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BCBDAB</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * thfoFerrousSize * _default_' range=':= 1 * 0.8 * thfoFerrousSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * thfoFerrousSize * _default_' range=':= 1 * 0.8 * thfoFerrousSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * thfoFerrousSize * _default_' range=':= 1 * 0.8 * 0.8 * thfoFerrousSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * thfoFerrousFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Ferrous Strategic Cloud Hint Veins -->
-                        <Veins name='thfoFerrousBaseHintVeins' block='ThermalFoundation:Ore:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BCBDAB</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Ferrous Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Shiny is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='thfoShinyFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                    <Description> Frequency multiplier for Thermal Foundation Shiny distributions </Description>
+                    <DisplayName>Thermal Foundation Shiny Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='thfoShinySize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupThermalFoundation'>
+                    <Description> Size multiplier for Thermal Foundation Shiny distributions </Description>
+                    <DisplayName>Thermal Foundation Shiny Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Shiny Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Ferrous -->
-                
-                
-                <!-- Begin  Vanilla distribution of Ferrous -->
-                <IfCondition condition=':= thfoFerrousDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thfoFerrousBaseStandard' block='ThermalFoundation:Ore:4' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BCBDAB</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 0.5 * thfoFerrousSize * _default_'/>
-                        <Setting name='Height' avg=':= 12' range=':= 7' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.33 * thfoFerrousFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Ferrous -->
-                
-                <!-- End Ferrous Generation --> 
-
-                
-                <!-- Begin Shiny Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Shiny -->
-                <IfCondition condition=':= thfoShinyDist = "layeredVeins"'>
-                
-                    <Veins name='thfoShinyBaseVeins' block='ThermalFoundation:Ore:5'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606FE5F3</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.80 * thfoShinySize * _default_' range=':= 1 * 0.80 * thfoShinySize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 16' range=':= 8' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.80 * thfoShinySize * _default_' range=':= 1 * 0.80 * thfoShinySize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * thfoShinyFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.8 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.7 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Shiny Layered Veins) Settings -->
-                    <Veins name='thfoShinyPrefersVeins' block='ThermalFoundation:Ore:5'  inherits='thfoShinyBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606FE5F3</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Shiny Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Shiny -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Shiny -->
-                <IfCondition condition=':= thfoShinyDist = "hugeVeins"'>
-                
-                    <Veins name='thfoShinyBaseVeins' block='ThermalFoundation:Ore:5'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606FE5F3</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.80 * thfoShinySize * _default_' range=':= 1 * 0.80 * thfoShinySize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 16' range=':= 8' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.80 * thfoShinySize * _default_' range=':= 1 * 0.80 * thfoShinySize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.8 * thfoShinyFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.8 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.7 * _default_' range=':= 1 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Shiny Huge Veins) Settings -->
-                    <Veins name='thfoShinyPrefersVeins' block='ThermalFoundation:Ore:5'  inherits='thfoShinyBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606FE5F3</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Shiny Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Shiny -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Shiny -->
-                <IfCondition condition=':= thfoShinyDist = "strategicCloud"'>
-                
-                    <Cloud name='thfoShinyBaseCloud' block='ThermalFoundation:Ore:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606FE5F3</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.6 * thfoShinySize * _default_' range=':= 1 * 0.6 * thfoShinySize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.6 * thfoShinySize * _default_' range=':= 1 * 0.6 * thfoShinySize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.6 * 0.6 * thfoShinySize * _default_' range=':= 1 * 0.6 * 0.6 * thfoShinySize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * thfoShinyFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Shiny Strategic Cloud Hint Veins -->
-                        <Veins name='thfoShinyBaseHintVeins' block='ThermalFoundation:Ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x606FE5F3</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Shiny Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Shiny -->
-                
-                
-                <!-- Begin  Vanilla distribution of Shiny -->
-                <IfCondition condition=':= thfoShinyDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thfoShinyBaseStandard' block='ThermalFoundation:Ore:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606FE5F3</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 0.5 * thfoShinySize * _default_'/>
-                        <Setting name='Height' avg=':= 12' range=':= 7' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 0.30 * thfoShinyFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Shiny -->
-                
-                <!-- End Shiny Generation --> 
-
-                
-                <!-- Begin Mana Infused Generation --> 
-                
-                <!-- Begin SparseVeins distribution of Mana Infused -->
-                <IfCondition condition=':= thfoManaInfusedDist = "sparseVeins"'>
-                
-                    <Veins name='thfoManaInfusedBaseVeins' block='ThermalFoundation:Ore:5'  inherits='PresetSparseVeins' >
-                        <Description>
-                            Large veins filled very lightly with ore.
-                            Because they contain less ore per volume,
-                            these veins are relatively wide and long.
-                            Mining the ore from them is time consuming
-                            compared to solid ore veins.  They are
-                            also more difficult to follow, since it is
-                            harder to get an idea of their direction
-                            while mining.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E2E273</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thfoManaInfusedSize * _default_' range=':= 1 * 0.75 * thfoManaInfusedSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thfoManaInfusedSize * _default_' range=':= 1 * 0.75 * thfoManaInfusedSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thfoManaInfusedFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Mana Infused Sparse Veins) Settings -->
-                    <Veins name='thfoManaInfusedPrefersVeins' block='ThermalFoundation:Ore:5'  inherits='thfoManaInfusedBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E2E273</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Mana Infused Sparse Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End SparseVeins distribution of Mana Infused -->
-                
-                
-                <!-- Begin  Small Deposits distribution of Mana Infused -->
-                <IfCondition condition=':= thfoManaInfusedDist = "smallDeposits"'>
-                
-                    <Veins name='thfoManaInfusedBaseVeins' block='ThermalFoundation:Ore:5'  inherits='PresetSmallDeposits' >
-                        <Description>
-                            Small motherlodes with no veins; similar
-                            to vanilla clusters.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E2E273</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thfoManaInfusedSize * _default_' range=':= 1 * 0.75 * thfoManaInfusedSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thfoManaInfusedSize * _default_' range=':= 1 * 0.75 * thfoManaInfusedSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thfoManaInfusedFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Mana Infused Deposit Veins) Settings -->
-                    <Veins name='thfoManaInfusedPrefersVeins' block='ThermalFoundation:Ore:5'  inherits='thfoManaInfusedBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E2E273</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Mana Infused Deposit Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Small Deposits distribution of Mana Infused -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Mana Infused -->
-                <IfCondition condition=':= thfoManaInfusedDist = "hugeVeins"'>
-                
-                    <Veins name='thfoManaInfusedBaseVeins' block='ThermalFoundation:Ore:5'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E2E273</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.75 * thfoManaInfusedSize * _default_' range=':= 1 * 0.75 * thfoManaInfusedSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='Biome' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.75 * thfoManaInfusedSize * _default_' range=':= 1 * 0.75 * thfoManaInfusedSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1.85 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * thfoManaInfusedFreq * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.75 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 12'/>
-                        <Setting name='BranchInclination' avg=':= 0' range=':= 0.35'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Mana Infused Huge Veins) Settings -->
-                    <Veins name='thfoManaInfusedPrefersVeins' block='ThermalFoundation:Ore:5'  inherits='thfoManaInfusedBaseVeins' >
-                        <Description>
-                            Spawns 4 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E2E273</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 4 * _default_'/>
-                        <BiomeType name='Magical'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Mana Infused Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Mana Infused -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Mana Infused -->
-                <IfCondition condition=':= thfoManaInfusedDist = "strategicCloud"'>
-                
-                    <Cloud name='thfoManaInfusedBaseCloud' block='ThermalFoundation:Ore:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E2E273</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * thfoManaInfusedSize * _default_' range=':= 1 * 1 * thfoManaInfusedSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * thfoManaInfusedSize * _default_' range=':= 1 * 1 * thfoManaInfusedSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 35' range=':= 20' type='normal' scaleTo='Biome'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * thfoManaInfusedSize * _default_' range=':= 1 * 1 * 1 * thfoManaInfusedSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * thfoManaInfusedFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Mana Infused Strategic Cloud Hint Veins -->
-                        <Veins name='thfoManaInfusedBaseHintVeins' block='ThermalFoundation:Ore:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E2E273</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Mana Infused Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Mana Infused -->
-                
-                
-                <!-- Begin  Vanilla distribution of Mana Infused -->
-                <IfCondition condition=':= thfoManaInfusedDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='thfoManaInfusedBaseStandard' block='ThermalFoundation:Ore:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E2E273</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1/6 * thfoManaInfusedSize * _default_'/>
-                        <Setting name='Height' avg=':= 35' range=':= 20' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/10 * thfoManaInfusedFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Mana Infused -->
-                
-                <!-- End Mana Infused Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='thfoOverworldBlockSubstitute0' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='ThermalFoundation:Ore' weight='1.0' />
+                <Replaces block='ThermalFoundation:Ore:1' weight='1.0' />
+                <Replaces block='ThermalFoundation:Ore:2' weight='1.0' />
+                <Replaces block='ThermalFoundation:Ore:3' weight='1.0' />
+                <Replaces block='ThermalFoundation:Ore:4' weight='1.0' />
+                <Replaces block='ThermalFoundation:Ore:5' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Copper Generation -->
+
+            <!-- Starting LayeredVeins Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoCopperDist = "LayeredVeins"'>
+                    <Veins name='thfoCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * thfoCopperFreq ' range=':=  _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.019 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Copper is complete. -->
+
+
+            <!-- Starting Cloud Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoCopperDist = "Cloud"'>
+                    <Cloud name='thfoCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.454 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.454 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.115  * _default_ * thfoCopperFreq ' range=':=  _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thfoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Copper is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoCopperDist = "Vanilla"'>
+                    <StandardGen name='thfoCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 10 * thfoCopperFreq ' range=':=  _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Copper is complete. -->
+
+            <!-- End Copper Generation -->
+
+
+            <!-- Begin Tin Generation -->
+
+            <!-- Starting LayeredVeins Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoTinDist = "LayeredVeins"'>
+                    <Veins name='thfoTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * thfoTinFreq ' range=':=  _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Tin is complete. -->
+
+
+            <!-- Starting Cloud Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoTinDist = "Cloud"'>
+                    <Cloud name='thfoTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.375 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.375 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * thfoTinFreq ' range=':=  _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thfoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Tin is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoTinDist = "Vanilla"'>
+                    <StandardGen name='thfoTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 8 * thfoTinFreq ' range=':=  _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Tin is complete. -->
+
+            <!-- End Tin Generation -->
+
+
+            <!-- Begin Silver Generation -->
+
+            <!-- Starting LayeredVeins Preset for Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoSilverDist = "LayeredVeins"'>
+                    <Veins name='thfoSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * thfoSilverFreq ' range=':=  _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Silver is complete. -->
+
+
+            <!-- Starting Cloud Preset for Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoSilverDist = "Cloud"'>
+                    <Cloud name='thfoSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * thfoSilverFreq ' range=':=  _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thfoSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Silver is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Silver. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoSilverDist = "Vanilla"'>
+                    <StandardGen name='thfoSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 6 * thfoSilverFreq ' range=':=  _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Silver is complete. -->
+
+            <!-- End Silver Generation -->
+
+
+            <!-- Begin Lead Generation -->
+
+            <!-- Starting LayeredVeins Preset for Lead. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoLeadDist = "LayeredVeins"'>
+                    <Veins name='thfoLeadVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * thfoLeadFreq ' range=':=  _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Lead is complete. -->
+
+
+            <!-- Starting Cloud Preset for Lead. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoLeadDist = "Cloud"'>
+                    <Cloud name='thfoLeadCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.375 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.375 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * thfoLeadFreq ' range=':=  _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thfoLeadHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Lead is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Lead. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoLeadDist = "Vanilla"'>
+                    <StandardGen name='thfoLeadStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 8 * thfoLeadFreq ' range=':=  _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Lead is complete. -->
+
+            <!-- End Lead Generation -->
+
+
+            <!-- Begin Ferrous Generation -->
+
+            <!-- Starting LayeredVeins Preset for Ferrous. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoFerrousDist = "LayeredVeins"'>
+                    <Veins name='thfoFerrousVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * thfoFerrousFreq ' range=':=  _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Ferrous is complete. -->
+
+
+            <!-- Starting Cloud Preset for Ferrous. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoFerrousDist = "Cloud"'>
+                    <Cloud name='thfoFerrousCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * thfoFerrousFreq ' range=':=  _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thfoFerrousHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Ferrous is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Ferrous. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoFerrousDist = "Vanilla"'>
+                    <StandardGen name='thfoFerrousStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 4 * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * thfoFerrousFreq ' range=':=  _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Ferrous is complete. -->
+
+            <!-- End Ferrous Generation -->
+
+
+            <!-- Begin Shiny Generation -->
+
+            <!-- Starting LayeredVeins Preset for Shiny. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoShinyDist = "LayeredVeins"'>
+                    <Veins name='thfoShinyVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.205 * _default_ * thfoShinyFreq ' range=':=  _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.590 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.590 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.590 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Shiny is complete. -->
+
+
+            <!-- Starting Cloud Preset for Shiny. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoShinyDist = "Cloud"'>
+                    <Cloud name='thfoShinyCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.640 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.640 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.410  * _default_ * thfoShinyFreq ' range=':=  _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='thfoShinyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Shiny is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Shiny. -->
+            <ConfigSection>
+                <IfCondition condition=':= thfoShinyDist = "Vanilla"'>
+                    <StandardGen name='thfoShinyStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 1 * thfoShinyFreq ' range=':=  _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Shiny is complete. -->
+
+            <!-- End Shiny Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Thermal Foundation" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -30,10 +30,15 @@
                     Distribution options for Tinkers Construct Ores.
                 </Description>
             </OptionDisplayGroup>
+            <OptionChoice name='enableTinkersConstruct' displayName='Handle Tinkers Construct Setup?' default='true' displayState='shown_dynamic' displayGroup='groupTinkersConstruct'>
+                <Description> Should Custom Ore Generation handle Tinkers Construct ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Tinkers Construct ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Tinkers Construct ores will be handled by the mod itself.'/>
+            </OptionChoice>
 
             <!-- Copper Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='ticoCopperDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                <OptionChoice name='ticoCopperDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Copper is generated </Description>
                     <DisplayName>Tinkers Construct Copper</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -53,11 +58,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='ticoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Frequency multiplier for Tinkers Construct Copper distributions </Description>
                     <DisplayName>Tinkers Construct Copper Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='ticoCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoCopperSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Size multiplier for Tinkers Construct Copper distributions </Description>
                     <DisplayName>Tinkers Construct Copper Size</DisplayName>
                 </OptionNumeric>
@@ -67,7 +72,7 @@
 
             <!-- Tin Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='ticoTinDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                <OptionChoice name='ticoTinDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Tin is generated </Description>
                     <DisplayName>Tinkers Construct Tin</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -87,11 +92,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='ticoTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoTinFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Frequency multiplier for Tinkers Construct Tin distributions </Description>
                     <DisplayName>Tinkers Construct Tin Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='ticoTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoTinSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Size multiplier for Tinkers Construct Tin distributions </Description>
                     <DisplayName>Tinkers Construct Tin Size</DisplayName>
                 </OptionNumeric>
@@ -101,7 +106,7 @@
 
             <!-- Aluminum Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='ticoAluminumDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                <OptionChoice name='ticoAluminumDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Aluminum is generated </Description>
                     <DisplayName>Tinkers Construct Aluminum</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -121,11 +126,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Aluminum is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='ticoAluminumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoAluminumFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Frequency multiplier for Tinkers Construct Aluminum distributions </Description>
                     <DisplayName>Tinkers Construct Aluminum Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='ticoAluminumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoAluminumSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Size multiplier for Tinkers Construct Aluminum distributions </Description>
                     <DisplayName>Tinkers Construct Aluminum Size</DisplayName>
                 </OptionNumeric>
@@ -135,7 +140,7 @@
 
             <!-- Iron Gravel Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='ticoIronGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                <OptionChoice name='ticoIronGravelDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Iron Gravel is generated </Description>
                     <DisplayName>Tinkers Construct Iron Gravel</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -155,11 +160,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Iron Gravel is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='ticoIronGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoIronGravelFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Frequency multiplier for Tinkers Construct Iron Gravel distributions </Description>
                     <DisplayName>Tinkers Construct Iron Gravel Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='ticoIronGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoIronGravelSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Size multiplier for Tinkers Construct Iron Gravel distributions </Description>
                     <DisplayName>Tinkers Construct Iron Gravel Size</DisplayName>
                 </OptionNumeric>
@@ -169,7 +174,7 @@
 
             <!-- Gold Gravel Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='ticoGoldGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                <OptionChoice name='ticoGoldGravelDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Gold Gravel is generated </Description>
                     <DisplayName>Tinkers Construct Gold Gravel</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -189,11 +194,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Gold Gravel is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='ticoGoldGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoGoldGravelFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Frequency multiplier for Tinkers Construct Gold Gravel distributions </Description>
                     <DisplayName>Tinkers Construct Gold Gravel Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='ticoGoldGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoGoldGravelSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Size multiplier for Tinkers Construct Gold Gravel distributions </Description>
                     <DisplayName>Tinkers Construct Gold Gravel Size</DisplayName>
                 </OptionNumeric>
@@ -203,7 +208,7 @@
 
             <!-- Copper Gravel Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='ticoCopperGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                <OptionChoice name='ticoCopperGravelDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Copper Gravel is generated </Description>
                     <DisplayName>Tinkers Construct Copper Gravel</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -223,11 +228,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Copper Gravel is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='ticoCopperGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoCopperGravelFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Frequency multiplier for Tinkers Construct Copper Gravel distributions </Description>
                     <DisplayName>Tinkers Construct Copper Gravel Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='ticoCopperGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoCopperGravelSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Size multiplier for Tinkers Construct Copper Gravel distributions </Description>
                     <DisplayName>Tinkers Construct Copper Gravel Size</DisplayName>
                 </OptionNumeric>
@@ -237,7 +242,7 @@
 
             <!-- Tin Gravel Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='ticoTinGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                <OptionChoice name='ticoTinGravelDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Tin Gravel is generated </Description>
                     <DisplayName>Tinkers Construct Tin Gravel</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -257,11 +262,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Tin Gravel is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='ticoTinGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoTinGravelFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Frequency multiplier for Tinkers Construct Tin Gravel distributions </Description>
                     <DisplayName>Tinkers Construct Tin Gravel Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='ticoTinGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoTinGravelSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Size multiplier for Tinkers Construct Tin Gravel distributions </Description>
                     <DisplayName>Tinkers Construct Tin Gravel Size</DisplayName>
                 </OptionNumeric>
@@ -271,7 +276,7 @@
 
             <!-- Aluminum Gravel Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='ticoAluminumGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                <OptionChoice name='ticoAluminumGravelDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Aluminum Gravel is generated </Description>
                     <DisplayName>Tinkers Construct Aluminum Gravel</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -291,11 +296,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Aluminum Gravel is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='ticoAluminumGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoAluminumGravelFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Frequency multiplier for Tinkers Construct Aluminum Gravel distributions </Description>
                     <DisplayName>Tinkers Construct Aluminum Gravel Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='ticoAluminumGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoAluminumGravelSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Size multiplier for Tinkers Construct Aluminum Gravel distributions </Description>
                     <DisplayName>Tinkers Construct Aluminum Gravel Size</DisplayName>
                 </OptionNumeric>
@@ -305,7 +310,7 @@
 
             <!-- Cobalt Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='ticoCobaltDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                <OptionChoice name='ticoCobaltDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Cobalt is generated </Description>
                     <DisplayName>Tinkers Construct Cobalt</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -325,11 +330,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Cobalt is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='ticoCobaltFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoCobaltFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Frequency multiplier for Tinkers Construct Cobalt distributions </Description>
                     <DisplayName>Tinkers Construct Cobalt Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='ticoCobaltSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoCobaltSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Size multiplier for Tinkers Construct Cobalt distributions </Description>
                     <DisplayName>Tinkers Construct Cobalt Size</DisplayName>
                 </OptionNumeric>
@@ -339,7 +344,7 @@
 
             <!-- Ardite Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='ticoArditeDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                <OptionChoice name='ticoArditeDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Ardite is generated </Description>
                     <DisplayName>Tinkers Construct Ardite</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -359,11 +364,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Ardite is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='ticoArditeFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoArditeFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Frequency multiplier for Tinkers Construct Ardite distributions </Description>
                     <DisplayName>Tinkers Construct Ardite Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='ticoArditeSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoArditeSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Size multiplier for Tinkers Construct Ardite distributions </Description>
                     <DisplayName>Tinkers Construct Ardite Size</DisplayName>
                 </OptionNumeric>
@@ -373,7 +378,7 @@
 
             <!-- Nether Cobalt Gravel Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='ticoNetherCobaltGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                <OptionChoice name='ticoNetherCobaltGravelDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Nether Cobalt Gravel is generated </Description>
                     <DisplayName>Tinkers Construct Nether Cobalt Gravel</DisplayName>
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -393,11 +398,11 @@
                     </Choice>
                     <Choice value='none' displayValue='None' description='Nether Cobalt Gravel is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='ticoNetherCobaltGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoNetherCobaltGravelFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Frequency multiplier for Tinkers Construct Nether Cobalt Gravel distributions </Description>
                     <DisplayName>Tinkers Construct Nether Cobalt Gravel Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='ticoNetherCobaltGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                <OptionNumeric name='ticoNetherCobaltGravelSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Size multiplier for Tinkers Construct Nether Cobalt Gravel distributions </Description>
                     <DisplayName>Tinkers Construct Nether Cobalt Gravel Size</DisplayName>
                 </OptionNumeric>
@@ -407,1385 +412,1425 @@
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
+        <IfCondition condition=':= ?enableTinkersConstruct'>
 
 
 
 
-        <!-- Overworld Setup Beginning -->
+            <!-- Overworld Setup Beginning -->
 
-        <IfCondition condition=':= ?COGActive'>
+            <IfCondition condition=':= ?COGActive'>
 
-            <!-- Starting Original "Overworld" Block Removal -->
+                <!-- Starting Original "Overworld" Block Removal -->
 
-            <Substitute name='ticoOverworldBlockSubstitute0' block='minecraft:gravel'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='TConstruct:GravelOre' weight='1.0' />
-                <Replaces block='TConstruct:GravelOre:1' weight='1.0' />
-                <Replaces block='TConstruct:GravelOre:2' weight='1.0' />
-                <Replaces block='TConstruct:GravelOre:3' weight='1.0' />
-                <Replaces block='TConstruct:GravelOre:4' weight='1.0' />
-            </Substitute>
-
-
-            <Substitute name='ticoOverworldBlockSubstitute1' block='minecraft:stone'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='TConstruct:SearedBrick:3' weight='1.0' />
-                <Replaces block='TConstruct:SearedBrick:4' weight='1.0' />
-                <Replaces block='TConstruct:SearedBrick:5' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Overworld" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Copper Generation -->
-
-            <!-- Starting LayeredVeins Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoCopperDist = "LayeredVeins"'>
-                    <Veins name='ticoCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <IfCondition condition=':= ?blockExists("minecraft:gravel")'>
+                    <Substitute name='ticoOverworldBlockSubstitute0' block='minecraft:gravel'>
                         <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoCopperFreq ' range=':=  _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <Replaces block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <Replaces block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <Replaces block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <Replaces block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <Replaces block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Copper is complete. -->
 
 
-            <!-- Starting Cloud Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoCopperDist = "Cloud"'>
-                    <Cloud name='ticoCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='ticoOverworldBlockSubstitute1' block='minecraft:stone'>
                         <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoCopperFreq ' range=':=  _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='ticoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <Replaces block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <Replaces block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <Replaces block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
+                    </Substitute>
+                </IfCondition>
+
+                <!-- Original "Overworld" Block Removal Complete -->
+
+                <!-- Adding blocks -->
+
+                <!-- Begin Copper Generation -->
+
+                <!-- Starting LayeredVeins Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoCopperDist = "LayeredVeins"'>
+                        <Veins name='ticoCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoCopperFreq ' range=':=  _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Copper is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Copper. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoCopperDist = "Vanilla"'>
-                    <StandardGen name='ticoCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * ticoCopperFreq ' range=':=  _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Copper is complete. -->
-
-            <!-- End Copper Generation -->
-
-
-            <!-- Begin Tin Generation -->
-
-            <!-- Starting LayeredVeins Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoTinDist = "LayeredVeins"'>
-                    <Veins name='ticoTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoTinFreq ' range=':=  _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Tin is complete. -->
-
-
-            <!-- Starting Cloud Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoTinDist = "Cloud"'>
-                    <Cloud name='ticoTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoTinFreq ' range=':=  _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='ticoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                <!-- Starting Cloud Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoCopperDist = "Cloud"'>
+                        <Cloud name='ticoCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Tin is complete. -->
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoCopperFreq ' range=':=  _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='ticoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Copper is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Tin. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoTinDist = "Vanilla"'>
-                    <StandardGen name='ticoTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * ticoTinFreq ' range=':=  _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Tin is complete. -->
-
-            <!-- End Tin Generation -->
-
-
-            <!-- Begin Aluminum Generation -->
-
-            <!-- Starting LayeredVeins Preset for Aluminum. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoAluminumDist = "LayeredVeins"'>
-                    <Veins name='ticoAluminumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * ticoAluminumFreq ' range=':=  _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Aluminum is complete. -->
-
-
-            <!-- Starting Cloud Preset for Aluminum. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoAluminumDist = "Cloud"'>
-                    <Cloud name='ticoAluminumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.002 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.002 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * ticoAluminumFreq ' range=':=  _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='ticoAluminumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                <!-- Starting Vanilla Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoCopperDist = "Vanilla"'>
+                        <StandardGen name='ticoCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Aluminum is complete. -->
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoCopperFreq ' range=':=  _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Copper is complete. -->
+
+                <!-- End Copper Generation -->
 
 
-            <!-- Starting Vanilla Preset for Aluminum. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoAluminumDist = "Vanilla"'>
-                    <StandardGen name='ticoAluminumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
-                        <Replaces block='minecraft:stone' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * ticoAluminumFreq ' range=':=  _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Aluminum is complete. -->
+                <!-- Begin Tin Generation -->
 
-            <!-- End Aluminum Generation -->
-
-
-            <!-- Begin Iron Gravel Generation -->
-
-            <!-- Starting LayeredVeins Preset for Iron Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoIronGravelDist = "LayeredVeins"'>
-                    <Veins name='ticoIronGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * ticoIronGravelFreq ' range=':=  1 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':=  1 * _default_ * ticoIronGravelSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':=  1 * _default_ * ticoIronGravelSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Iron Gravel is complete. -->
-
-
-            <!-- Starting Cloud Preset for Iron Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoIronGravelDist = "Cloud"'>
-                    <Cloud name='ticoIronGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.730 * _default_ * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.730 * _default_ * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * ticoIronGravelFreq ' range=':=  _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='ticoIronGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                <!-- Starting LayeredVeins Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoTinDist = "LayeredVeins"'>
+                        <Veins name='ticoTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='TConstruct:GravelOre' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoTinFreq ' range=':=  _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Iron Gravel is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Tin is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Iron Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoIronGravelDist = "Vanilla"'>
-                    <StandardGen name='ticoIronGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 20 * ticoIronGravelFreq ' range=':=  _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Iron Gravel is complete. -->
-
-            <!-- End Iron Gravel Generation -->
-
-
-            <!-- Begin Gold Gravel Generation -->
-
-            <!-- Starting LayeredVeins Preset for Gold Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoGoldGravelDist = "LayeredVeins"'>
-                    <Veins name='ticoGoldGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoGoldGravelFreq ' range=':=  1 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoGoldGravelSize ' range=':=  1 * _default_ * ticoGoldGravelSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoGoldGravelSize ' range=':=  1 * _default_ * ticoGoldGravelSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Gold Gravel is complete. -->
-
-
-            <!-- Starting Cloud Preset for Gold Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoGoldGravelDist = "Cloud"'>
-                    <Cloud name='ticoGoldGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoGoldGravelFreq ' range=':=  _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='ticoGoldGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                <!-- Starting Cloud Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoTinDist = "Cloud"'>
+                        <Cloud name='ticoTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Gold Gravel is complete. -->
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoTinFreq ' range=':=  _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='ticoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tin is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Gold Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoGoldGravelDist = "Vanilla"'>
-                    <StandardGen name='ticoGoldGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * ticoGoldGravelFreq ' range=':=  _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Gold Gravel is complete. -->
-
-            <!-- End Gold Gravel Generation -->
-
-
-            <!-- Begin Copper Gravel Generation -->
-
-            <!-- Starting LayeredVeins Preset for Copper Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoCopperGravelDist = "LayeredVeins"'>
-                    <Veins name='ticoCopperGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoCopperGravelFreq ' range=':=  _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Copper Gravel is complete. -->
-
-
-            <!-- Starting Cloud Preset for Copper Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoCopperGravelDist = "Cloud"'>
-                    <Cloud name='ticoCopperGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoCopperGravelFreq ' range=':=  _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='ticoCopperGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                <!-- Starting Vanilla Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoTinDist = "Vanilla"'>
+                        <StandardGen name='ticoTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Copper Gravel is complete. -->
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoTinFreq ' range=':=  _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tin is complete. -->
+
+                <!-- End Tin Generation -->
 
 
-            <!-- Starting Vanilla Preset for Copper Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoCopperGravelDist = "Vanilla"'>
-                    <StandardGen name='ticoCopperGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * ticoCopperGravelFreq ' range=':=  _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Copper Gravel is complete. -->
+                <!-- Begin Aluminum Generation -->
 
-            <!-- End Copper Gravel Generation -->
-
-
-            <!-- Begin Tin Gravel Generation -->
-
-            <!-- Starting LayeredVeins Preset for Tin Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoTinGravelDist = "LayeredVeins"'>
-                    <Veins name='ticoTinGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoTinGravelFreq ' range=':=  _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Tin Gravel is complete. -->
-
-
-            <!-- Starting Cloud Preset for Tin Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoTinGravelDist = "Cloud"'>
-                    <Cloud name='ticoTinGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoTinGravelFreq ' range=':=  _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='ticoTinGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                <!-- Starting LayeredVeins Preset for Aluminum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoAluminumDist = "LayeredVeins"'>
+                        <Veins name='ticoAluminumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * ticoAluminumFreq ' range=':=  _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Tin Gravel is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Aluminum is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Tin Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoTinGravelDist = "Vanilla"'>
-                    <StandardGen name='ticoTinGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 8 * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * ticoTinGravelFreq ' range=':=  _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Tin Gravel is complete. -->
-
-            <!-- End Tin Gravel Generation -->
-
-
-            <!-- Begin Aluminum Gravel Generation -->
-
-            <!-- Starting LayeredVeins Preset for Aluminum Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoAluminumGravelDist = "LayeredVeins"'>
-                    <Veins name='ticoAluminumGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * ticoAluminumGravelFreq ' range=':=  _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Aluminum Gravel is complete. -->
-
-
-            <!-- Starting Cloud Preset for Aluminum Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoAluminumGravelDist = "Cloud"'>
-                    <Cloud name='ticoAluminumGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.002 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.002 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * ticoAluminumGravelFreq ' range=':=  _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='ticoAluminumGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                <!-- Starting Cloud Preset for Aluminum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoAluminumDist = "Cloud"'>
+                        <Cloud name='ticoAluminumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
                             <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * ticoAluminumFreq ' range=':=  _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='ticoAluminumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Aluminum is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Aluminum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoAluminumDist = "Vanilla"'>
+                        <StandardGen name='ticoAluminumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * ticoAluminumFreq ' range=':=  _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Aluminum is complete. -->
+
+                <!-- End Aluminum Generation -->
+
+
+                <!-- Begin Iron Gravel Generation -->
+
+                <!-- Starting LayeredVeins Preset for Iron Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoIronGravelDist = "LayeredVeins"'>
+                        <Veins name='ticoIronGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * ticoIronGravelFreq ' range=':=  1 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':=  1 * _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':=  1 * _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                         </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Aluminum Gravel is complete. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Iron Gravel is complete. -->
 
 
-            <!-- Starting Vanilla Preset for Aluminum Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoAluminumGravelDist = "Vanilla"'>
-                    <StandardGen name='ticoAluminumGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                <!-- Starting Cloud Preset for Iron Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoIronGravelDist = "Cloud"'>
+                        <Cloud name='ticoIronGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.730 * _default_ * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.730 * _default_ * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * ticoIronGravelFreq ' range=':=  _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='ticoIronGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Iron Gravel is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Iron Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoIronGravelDist = "Vanilla"'>
+                        <StandardGen name='ticoIronGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 20 * ticoIronGravelFreq ' range=':=  _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Iron Gravel is complete. -->
+
+                <!-- End Iron Gravel Generation -->
+
+
+                <!-- Begin Gold Gravel Generation -->
+
+                <!-- Starting LayeredVeins Preset for Gold Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoGoldGravelDist = "LayeredVeins"'>
+                        <Veins name='ticoGoldGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoGoldGravelFreq ' range=':=  1 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoGoldGravelSize ' range=':=  1 * _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoGoldGravelSize ' range=':=  1 * _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Gold Gravel is complete. -->
+
+
+                <!-- Starting Cloud Preset for Gold Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoGoldGravelDist = "Cloud"'>
+                        <Cloud name='ticoGoldGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoGoldGravelFreq ' range=':=  _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='ticoGoldGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Gold Gravel is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Gold Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoGoldGravelDist = "Vanilla"'>
+                        <StandardGen name='ticoGoldGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoGoldGravelFreq ' range=':=  _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Gold Gravel is complete. -->
+
+                <!-- End Gold Gravel Generation -->
+
+
+                <!-- Begin Copper Gravel Generation -->
+
+                <!-- Starting LayeredVeins Preset for Copper Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoCopperGravelDist = "LayeredVeins"'>
+                        <Veins name='ticoCopperGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoCopperGravelFreq ' range=':=  _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Copper Gravel is
+                     complete. -->
+
+
+                <!-- Starting Cloud Preset for Copper Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoCopperGravelDist = "Cloud"'>
+                        <Cloud name='ticoCopperGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoCopperGravelFreq ' range=':=  _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='ticoCopperGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Copper Gravel is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Copper Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoCopperGravelDist = "Vanilla"'>
+                        <StandardGen name='ticoCopperGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoCopperGravelFreq ' range=':=  _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Copper Gravel is complete. -->
+
+                <!-- End Copper Gravel Generation -->
+
+
+                <!-- Begin Tin Gravel Generation -->
+
+                <!-- Starting LayeredVeins Preset for Tin Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoTinGravelDist = "LayeredVeins"'>
+                        <Veins name='ticoTinGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoTinGravelFreq ' range=':=  _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Tin Gravel is complete. -->
+
+
+                <!-- Starting Cloud Preset for Tin Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoTinGravelDist = "Cloud"'>
+                        <Cloud name='ticoTinGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoTinGravelFreq ' range=':=  _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='ticoTinGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tin Gravel is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Tin Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoTinGravelDist = "Vanilla"'>
+                        <StandardGen name='ticoTinGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoTinGravelFreq ' range=':=  _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tin Gravel is complete. -->
+
+                <!-- End Tin Gravel Generation -->
+
+
+                <!-- Begin Aluminum Gravel Generation -->
+
+                <!-- Starting LayeredVeins Preset for Aluminum Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoAluminumGravelDist = "LayeredVeins"'>
+                        <Veins name='ticoAluminumGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * ticoAluminumGravelFreq ' range=':=  _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Aluminum Gravel is
+                     complete. -->
+
+
+                <!-- Starting Cloud Preset for Aluminum Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoAluminumGravelDist = "Cloud"'>
+                        <Cloud name='ticoAluminumGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * ticoAluminumGravelFreq ' range=':=  _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='ticoAluminumGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Aluminum Gravel is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Aluminum Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoAluminumGravelDist = "Vanilla"'>
+                        <StandardGen name='ticoAluminumGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * ticoAluminumGravelFreq ' range=':=  _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Aluminum Gravel is complete. -->
+
+                <!-- End Aluminum Gravel Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
+
+
+
+            <!-- Nether Setup Beginning -->
+
+            <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
+
+                <!-- Starting Original "Nether" Block Removal -->
+
+                <IfCondition condition=':= ?blockExists("minecraft:gravel")'>
+                    <Substitute name='ticoNetherBlockSubstitute0' block='minecraft:gravel'>
                         <Description>
-                            A master preset for standardgen ore
-                            distributions.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 6 * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 3 * ticoAluminumGravelFreq ' range=':=  _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <Replaces block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Aluminum Gravel is complete. -->
 
-            <!-- End Aluminum Gravel Generation -->
 
-            <!-- Finished adding blocks -->
+                <IfCondition condition=':= ?blockExists("minecraft:netherrack")'>
+                    <Substitute name='ticoNetherBlockSubstitute1' block='minecraft:netherrack'>
+                        <Description>
+                            Replace vanilla-generated ore clusters.
+                        </Description>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <Replaces block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <Replaces block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
+                    </Substitute>
+                </IfCondition>
+
+                <!-- Original "Nether" Block Removal Complete -->
+
+                <!-- Adding blocks -->
+
+                <!-- Begin Cobalt Generation -->
+
+                <!-- Starting LayeredVeins Preset for Cobalt. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoCobaltDist = "LayeredVeins"'>
+                        <Veins name='ticoCobaltVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoCobaltFreq ' range=':=  _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Cobalt is complete. -->
+
+
+                <!-- Starting Cloud Preset for Cobalt. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoCobaltDist = "Cloud"'>
+                        <Cloud name='ticoCobaltCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoCobaltFreq ' range=':=  _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='ticoCobaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Cobalt is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Cobalt. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoCobaltDist = "Vanilla"'>
+                        <StandardGen name='ticoCobaltStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoCobaltFreq ' range=':=  _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Cobalt is complete. -->
+
+                <!-- End Cobalt Generation -->
+
+
+                <!-- Begin Ardite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Ardite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoArditeDist = "LayeredVeins"'>
+                        <Veins name='ticoArditeVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoArditeFreq ' range=':=  _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Ardite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Ardite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoArditeDist = "Cloud"'>
+                        <Cloud name='ticoArditeCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoArditeFreq ' range=':=  _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='ticoArditeHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Ardite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Ardite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoArditeDist = "Vanilla"'>
+                        <StandardGen name='ticoArditeStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoArditeFreq ' range=':=  _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Ardite is complete. -->
+
+                <!-- End Ardite Generation -->
+
+
+                <!-- Begin Nether Cobalt Gravel Generation -->
+
+                <!-- Starting LayeredVeins Preset for Nether Cobalt
+                     Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoNetherCobaltGravelDist = "LayeredVeins"'>
+                        <Veins name='ticoNetherCobaltGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoNetherCobaltGravelFreq ' range=':=  _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Nether Cobalt Gravel is
+                     complete. -->
+
+
+                <!-- Starting Cloud Preset for Nether Cobalt Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoNetherCobaltGravelDist = "Cloud"'>
+                        <Cloud name='ticoNetherCobaltGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoNetherCobaltGravelFreq ' range=':=  _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Veins name='ticoNetherCobaltGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Nether Cobalt Gravel is
+                     complete. -->
+
+
+                <!-- Starting Vanilla Preset for Nether Cobalt Gravel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= ticoNetherCobaltGravelDist = "Vanilla"'>
+                        <StandardGen name='ticoNetherCobaltGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoNetherCobaltGravelFreq ' range=':=  _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Nether Cobalt Gravel is
+                     complete. -->
+
+                <!-- End Nether Cobalt Gravel Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Nether Setup Complete -->
+
 
         </IfCondition>
-        <!-- Overworld Setup Complete -->
-
-
-
-
-
-        <!-- Nether Setup Beginning -->
-
-        <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
-
-            <!-- Starting Original "Nether" Block Removal -->
-
-            <Substitute name='ticoNetherBlockSubstitute0' block='minecraft:gravel'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='TConstruct:GravelOre:5' weight='1.0' />
-            </Substitute>
-
-
-            <Substitute name='ticoNetherBlockSubstitute1' block='minecraft:netherrack'>
-                <Description>
-                    Replace vanilla-generated ore clusters.
-                </Description>
-                <Comment>
-                    The global option deferredPopulationRange  must be
-                    large enough to catch all ore  clusters (>= 32).
-                </Comment>
-                <Replaces block='TConstruct:SearedBrick:1' weight='1.0' />
-                <Replaces block='TConstruct:SearedBrick:2' weight='1.0' />
-            </Substitute>
-
-            <!-- Original "Nether" Block Removal Complete -->
-
-            <!-- Adding blocks -->
-
-            <!-- Begin Cobalt Generation -->
-
-            <!-- Starting LayeredVeins Preset for Cobalt. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoCobaltDist = "LayeredVeins"'>
-                    <Veins name='ticoCobaltVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoCobaltFreq ' range=':=  _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Cobalt is complete. -->
-
-
-            <!-- Starting Cloud Preset for Cobalt. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoCobaltDist = "Cloud"'>
-                    <Cloud name='ticoCobaltCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoCobaltFreq ' range=':=  _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='ticoCobaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Cobalt is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Cobalt. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoCobaltDist = "Vanilla"'>
-                    <StandardGen name='ticoCobaltStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * ticoCobaltFreq ' range=':=  _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Cobalt is complete. -->
-
-            <!-- End Cobalt Generation -->
-
-
-            <!-- Begin Ardite Generation -->
-
-            <!-- Starting LayeredVeins Preset for Ardite. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoArditeDist = "LayeredVeins"'>
-                    <Veins name='ticoArditeVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoArditeFreq ' range=':=  _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Ardite is complete. -->
-
-
-            <!-- Starting Cloud Preset for Ardite. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoArditeDist = "Cloud"'>
-                    <Cloud name='ticoArditeCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoArditeFreq ' range=':=  _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='ticoArditeHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Ardite is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Ardite. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoArditeDist = "Vanilla"'>
-                    <StandardGen name='ticoArditeStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
-                        <Replaces block='minecraft:netherrack' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * ticoArditeFreq ' range=':=  _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Ardite is complete. -->
-
-            <!-- End Ardite Generation -->
-
-
-            <!-- Begin Nether Cobalt Gravel Generation -->
-
-            <!-- Starting LayeredVeins Preset for Nether Cobalt
-                 Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoNetherCobaltGravelDist = "LayeredVeins"'>
-                    <Veins name='ticoNetherCobaltGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
-                        <Description>
-                            Small, fairly rare motherlodes with  2-4
-                            horizontal veins each.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoNetherCobaltGravelFreq ' range=':=  _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                        <Setting name='MotherlodeHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentLength' avg=':= _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </Veins>
-                </IfCondition>
-            </ConfigSection>
-            <!-- LayeredVeins Preset for Nether Cobalt Gravel is
-                 complete. -->
-
-
-            <!-- Starting Cloud Preset for Nether Cobalt Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoNetherCobaltGravelDist = "Cloud"'>
-                    <Cloud name='ticoNetherCobaltGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
-                        <Description>
-                            Large irregular clouds filled lightly
-                            with ore.  These are huge, spanning
-                            several adjacent chunks, and  consequently
-                            rather rare.  They  contain a sizeable
-                            amount of ore, but  it takes some time and
-                            effort to mine  due to low density. The
-                            intent for  strategic clouds is that the
-                            player  will need to actively search for
-                            one  and then set up a semi-permanent
-                            mining base and spend some time  actually
-                            mining the ore.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                        <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' scaleTo='base' />
-                        <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoNetherCobaltGravelFreq ' range=':=  _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='CloudHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        <Veins name='ticoNetherCobaltGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
-                            <Description>
-                                Single blocks, generously  scattered
-                                through all heights  (density is about
-                                that of vanilla  iron ore). They will
-                                replace dirt  and sandstone (but not
-                                grass or  sand), so they can be found
-                                nearer to the surface than most  ores.
-                                Intened to be used as a  child
-                                distribution for large,  rare
-                                strategic deposits that  would
-                                otherwise be very difficult  to find.
-                                Note that the frequency  is multiplied
-                                by ground level to  maintain a
-                                constant density, but  not by ore
-                                frequency because it  is assumed that
-                                the frequency of  the parent
-                                distribution will  already be scaled
-                                by that.
-                            </Description>
-                            <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
-                            <Replaces block='minecraft:dirt' weight='1.0' />
-                            <Replaces block='minecraft:sandstone' weight='1.0' />
-                        </Veins>
-                    </Cloud>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Cloud Preset for Nether Cobalt Gravel is complete. -->
-
-
-            <!-- Starting Vanilla Preset for Nether Cobalt Gravel. -->
-            <ConfigSection>
-                <IfCondition condition=':= ticoNetherCobaltGravelDist = "Vanilla"'>
-                    <StandardGen name='ticoNetherCobaltGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
-                        <Description>
-                            A master preset for standardgen ore
-                            distributions.
-                        </Description>
-                        <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
-                        <Replaces block='minecraft:gravel' weight='1.0' />
-                        <Biome name='.*'  />
-                        <Setting name='Size' avg=':= 3 * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                        <Setting name='Frequency' avg=':= 2 * ticoNetherCobaltGravelFreq ' range=':=  _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
-                        <Setting name='Height' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    </StandardGen>
-                </IfCondition>
-            </ConfigSection>
-            <!-- Vanilla Preset for Nether Cobalt Gravel is complete. -->
-
-            <!-- End Nether Cobalt Gravel Generation -->
-
-            <!-- Finished adding blocks -->
-
-        </IfCondition>
-        <!-- Nether Setup Complete -->
-
-
 
     </ConfigSection>
     <!-- Configuration for Custom Ore Generation Complete! -->

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -1,2264 +1,1806 @@
- <!-- ================================================================
-      Custom Ore Generation "Tinkers Construct" Module: This
-      configuration covers copper, tin, aluminum, iron gravel, gold
-      gravel, copper gravel, tin  gravel, aluminum gravel, cobalt,
-      ardite, and nether cobalt gravel.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Tinkers Construct" Module: This
+     configuration covers copper, tin, aluminum, iron gravel, gold
+     gravel, copper gravel, tin gravel, aluminum gravel, cobalt,
+     ardite, and nether cobalt gravel.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="TConstruct">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+<!-- A mod centering around tool manufacturing, the smelting of ores
+     plays a large part.  This mod also includes ores that are
+     embedded in gravel, rather than stone. -->
+
+
+
+
+<!-- Is the "Tinkers Construct" mod on the system?  Let's find out! -->
+<IfModInstalled name="TConstruct">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupTinkersConstruct' displayName='Tinkers Construct' displayState='shown'>
+                <Description>
+                    Distribution options for Tinkers Construct Ores.
+                </Description>
+            </OptionDisplayGroup>
+
+            <!-- Copper Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupTinkersConstruct' displayName='Tinkers Construct' displayState='shown'> 
-                    <Description>
-                        Distribution options for Tinkers Construct Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Copper Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='ticoCopperDist'  displayState='shown' displayGroup='groupTinkersConstruct'> 
-                        <Description> Controls how Copper is generated </Description> 
-                        <DisplayName>Tinkers Construct Copper</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='ticoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Frequency multiplier for Tinkers Construct Copper distributions </Description>
-                        <DisplayName>Tinkers Construct Copper Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='ticoCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Size multiplier for Tinkers Construct Copper distributions </Description>
-                        <DisplayName>Tinkers Construct Copper Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Copper Configuration UI Complete -->
-                
-                
-                <!-- Tin Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='ticoTinDist'  displayState='shown' displayGroup='groupTinkersConstruct'> 
-                        <Description> Controls how Tin is generated </Description> 
-                        <DisplayName>Tinkers Construct Tin</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='ticoTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Frequency multiplier for Tinkers Construct Tin distributions </Description>
-                        <DisplayName>Tinkers Construct Tin Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='ticoTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Size multiplier for Tinkers Construct Tin distributions </Description>
-                        <DisplayName>Tinkers Construct Tin Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Tin Configuration UI Complete -->
-                
-                
-                <!-- Aluminum Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='ticoAluminumDist'  displayState='shown' displayGroup='groupTinkersConstruct'> 
-                        <Description> Controls how Aluminum is generated </Description> 
-                        <DisplayName>Tinkers Construct Aluminum</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Aluminum is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='ticoAluminumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Frequency multiplier for Tinkers Construct Aluminum distributions </Description>
-                        <DisplayName>Tinkers Construct Aluminum Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='ticoAluminumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Size multiplier for Tinkers Construct Aluminum distributions </Description>
-                        <DisplayName>Tinkers Construct Aluminum Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Aluminum Configuration UI Complete -->
-                
-                
-                <!-- Iron Gravel Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='ticoIronGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'> 
-                        <Description> Controls how Iron Gravel is generated </Description> 
-                        <DisplayName>Tinkers Construct Iron Gravel</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Iron Gravel is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='ticoIronGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Frequency multiplier for Tinkers Construct Iron Gravel distributions </Description>
-                        <DisplayName>Tinkers Construct Iron Gravel Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='ticoIronGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Size multiplier for Tinkers Construct Iron Gravel distributions </Description>
-                        <DisplayName>Tinkers Construct Iron Gravel Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Iron Gravel Configuration UI Complete -->
-                
-                
-                <!-- Gold Gravel Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='ticoGoldGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'> 
-                        <Description> Controls how Gold Gravel is generated </Description> 
-                        <DisplayName>Tinkers Construct Gold Gravel</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Gold Gravel is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='ticoGoldGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Frequency multiplier for Tinkers Construct Gold Gravel distributions </Description>
-                        <DisplayName>Tinkers Construct Gold Gravel Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='ticoGoldGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Size multiplier for Tinkers Construct Gold Gravel distributions </Description>
-                        <DisplayName>Tinkers Construct Gold Gravel Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Gold Gravel Configuration UI Complete -->
-                
-                
-                <!-- Copper Gravel Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='ticoCopperGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'> 
-                        <Description> Controls how Copper Gravel is generated </Description> 
-                        <DisplayName>Tinkers Construct Copper Gravel</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Copper Gravel is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='ticoCopperGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Frequency multiplier for Tinkers Construct Copper Gravel distributions </Description>
-                        <DisplayName>Tinkers Construct Copper Gravel Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='ticoCopperGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Size multiplier for Tinkers Construct Copper Gravel distributions </Description>
-                        <DisplayName>Tinkers Construct Copper Gravel Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Copper Gravel Configuration UI Complete -->
-                
-                
-                <!-- Tin Gravel Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='ticoTinGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'> 
-                        <Description> Controls how Tin Gravel is generated </Description> 
-                        <DisplayName>Tinkers Construct Tin Gravel</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Tin Gravel is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='ticoTinGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Frequency multiplier for Tinkers Construct Tin Gravel distributions </Description>
-                        <DisplayName>Tinkers Construct Tin Gravel Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='ticoTinGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Size multiplier for Tinkers Construct Tin Gravel distributions </Description>
-                        <DisplayName>Tinkers Construct Tin Gravel Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Tin Gravel Configuration UI Complete -->
-                
-                
-                <!-- Aluminum Gravel Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='ticoAluminumGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'> 
-                        <Description> Controls how Aluminum Gravel is generated </Description> 
-                        <DisplayName>Tinkers Construct Aluminum Gravel</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Aluminum Gravel is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='ticoAluminumGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Frequency multiplier for Tinkers Construct Aluminum Gravel distributions </Description>
-                        <DisplayName>Tinkers Construct Aluminum Gravel Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='ticoAluminumGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Size multiplier for Tinkers Construct Aluminum Gravel distributions </Description>
-                        <DisplayName>Tinkers Construct Aluminum Gravel Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Aluminum Gravel Configuration UI Complete -->
-                
-                
-                <!-- Cobalt Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='ticoCobaltDist'  displayState='shown' displayGroup='groupTinkersConstruct'> 
-                        <Description> Controls how Cobalt is generated </Description> 
-                        <DisplayName>Tinkers Construct Cobalt</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Cobalt is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='ticoCobaltFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Frequency multiplier for Tinkers Construct Cobalt distributions </Description>
-                        <DisplayName>Tinkers Construct Cobalt Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='ticoCobaltSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Size multiplier for Tinkers Construct Cobalt distributions </Description>
-                        <DisplayName>Tinkers Construct Cobalt Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Cobalt Configuration UI Complete -->
-                
-                
-                <!-- Ardite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='ticoArditeDist'  displayState='shown' displayGroup='groupTinkersConstruct'> 
-                        <Description> Controls how Ardite is generated </Description> 
-                        <DisplayName>Tinkers Construct Ardite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Ardite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='ticoArditeFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Frequency multiplier for Tinkers Construct Ardite distributions </Description>
-                        <DisplayName>Tinkers Construct Ardite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='ticoArditeSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Size multiplier for Tinkers Construct Ardite distributions </Description>
-                        <DisplayName>Tinkers Construct Ardite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Ardite Configuration UI Complete -->
-                
-                
-                <!-- Nether Cobalt Gravel Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='ticoNetherCobaltGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'> 
-                        <Description> Controls how Nether Cobalt Gravel is generated </Description> 
-                        <DisplayName>Tinkers Construct Nether Cobalt Gravel</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Nether Cobalt Gravel is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='ticoNetherCobaltGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Frequency multiplier for Tinkers Construct Nether Cobalt Gravel distributions </Description>
-                        <DisplayName>Tinkers Construct Nether Cobalt Gravel Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='ticoNetherCobaltGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
-                        <Description> Size multiplier for Tinkers Construct Nether Cobalt Gravel distributions </Description>
-                        <DisplayName>Tinkers Construct Nether Cobalt Gravel Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Nether Cobalt Gravel Configuration UI Complete -->
-                
+                <OptionChoice name='ticoCopperDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Copper is generated </Description>
+                    <DisplayName>Tinkers Construct Copper</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Copper distributions </Description>
+                    <DisplayName>Tinkers Construct Copper Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Copper distributions </Description>
+                    <DisplayName>Tinkers Construct Copper Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Copper Configuration UI Complete -->
 
 
-            <!-- Setup Overworld -->
-            <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <Substitute name='ticoOverworldOreSubstitute0' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='TConstruct:SearedBrick:3' />
-                    <Replaces block='TConstruct:SearedBrick:4' />
-                    <Replaces block='TConstruct:SearedBrick:5' />
-                </Substitute>
-                <Substitute name='ticoOverworldOreSubstitute1' block='minecraft:stone'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='TConstruct:GravelOre' />
-                    <Replaces block='TConstruct:GravelOre:1' />
-                    <Replaces block='TConstruct:GravelOre:2' />
-                    <Replaces block='TConstruct:GravelOre:3' />
-                    <Replaces block='TConstruct:GravelOre:4' />
-                </Substitute>
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Copper Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Copper -->
-                <IfCondition condition=':= ticoCopperDist = "layeredVeins"'>
-                
-                    <Veins name='ticoCopperBaseVeins' block='TConstruct:SearedBrick:3'  inherits='PresetLayeredVeins' >
+            <!-- Tin Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='ticoTinDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Tin is generated </Description>
+                    <DisplayName>Tinkers Construct Tin</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * ticoCopperSize * _default_' range=':= 1 * 0.8 * ticoCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 40' range=':= 20' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * ticoCopperSize * _default_' range=':= 1 * 0.8 * ticoCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * ticoCopperFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                    <Veins name='ticoCopperPrefersVeins' block='TConstruct:SearedBrick:3'  inherits='ticoCopperBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Jungle'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Copper -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Copper -->
-                <IfCondition condition=':= ticoCopperDist = "hugeVeins"'>
-                
-                    <Veins name='ticoCopperBaseVeins' block='TConstruct:SearedBrick:3'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * ticoCopperSize * _default_' range=':= 1 * 0.8 * ticoCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 40' range=':= 20' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * ticoCopperSize * _default_' range=':= 1 * 0.8 * ticoCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * ticoCopperFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                    <Veins name='ticoCopperPrefersVeins' block='TConstruct:SearedBrick:3'  inherits='ticoCopperBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Jungle'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Copper -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Copper -->
-                <IfCondition condition=':= ticoCopperDist = "strategicCloud"'>
-                
-                    <Cloud name='ticoCopperBaseCloud' block='TConstruct:SearedBrick:3' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * ticoCopperSize * _default_' range=':= 1 * 0.8 * ticoCopperSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * ticoCopperSize * _default_' range=':= 1 * 0.8 * ticoCopperSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * ticoCopperSize * _default_' range=':= 1 * 0.8 * 0.8 * ticoCopperSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * ticoCopperFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Copper Strategic Cloud Hint Veins -->
-                        <Veins name='ticoCopperBaseHintVeins' block='TConstruct:SearedBrick:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Copper Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Tin distributions </Description>
+                    <DisplayName>Tinkers Construct Tin Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Tin distributions </Description>
+                    <DisplayName>Tinkers Construct Tin Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Tin Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Copper -->
-                
-                
-                <!-- Begin  Vanilla distribution of Copper -->
-                <IfCondition condition=':= ticoCopperDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='ticoCopperBaseStandard' block='TConstruct:SearedBrick:3' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * ticoCopperSize * _default_'/>
-                        <Setting name='Height' avg=':= 40' range=':= 20' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/10 * ticoCopperFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Copper -->
-                
-                <!-- End Copper Generation --> 
 
-                
-                <!-- Begin Tin Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Tin -->
-                <IfCondition condition=':= ticoTinDist = "layeredVeins"'>
-                
-                    <Veins name='ticoTinBaseVeins' block='TConstruct:SearedBrick:4'  inherits='PresetLayeredVeins' >
+            <!-- Aluminum Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='ticoAluminumDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Aluminum is generated </Description>
+                    <DisplayName>Tinkers Construct Aluminum</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * ticoTinSize * _default_' range=':= 1 * 0.8 * ticoTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * ticoTinSize * _default_' range=':= 1 * 0.8 * ticoTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * ticoTinFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                    <Veins name='ticoTinPrefersVeins' block='TConstruct:SearedBrick:4'  inherits='ticoTinBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Tin -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Tin -->
-                <IfCondition condition=':= ticoTinDist = "hugeVeins"'>
-                
-                    <Veins name='ticoTinBaseVeins' block='TConstruct:SearedBrick:4'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * ticoTinSize * _default_' range=':= 1 * 0.8 * ticoTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * ticoTinSize * _default_' range=':= 1 * 0.8 * ticoTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * ticoTinFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.85 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.75 * _default_' range=':= 0.66 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                    <Veins name='ticoTinPrefersVeins' block='TConstruct:SearedBrick:4'  inherits='ticoTinBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Tin -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Tin -->
-                <IfCondition condition=':= ticoTinDist = "strategicCloud"'>
-                
-                    <Cloud name='ticoTinBaseCloud' block='TConstruct:SearedBrick:4' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * ticoTinSize * _default_' range=':= 1 * 0.8 * ticoTinSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * ticoTinSize * _default_' range=':= 1 * 0.8 * ticoTinSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.8 * ticoTinSize * _default_' range=':= 1 * 0.8 * 0.8 * ticoTinSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 4.5 * ticoTinFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Tin Strategic Cloud Hint Veins -->
-                        <Veins name='ticoTinBaseHintVeins' block='TConstruct:SearedBrick:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Tin Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Aluminum is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoAluminumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Aluminum distributions </Description>
+                    <DisplayName>Tinkers Construct Aluminum Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoAluminumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Aluminum distributions </Description>
+                    <DisplayName>Tinkers Construct Aluminum Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Aluminum Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Tin -->
-                
-                
-                <!-- Begin  Vanilla distribution of Tin -->
-                <IfCondition condition=':= ticoTinDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='ticoTinBaseStandard' block='TConstruct:SearedBrick:4' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * ticoTinSize * _default_'/>
-                        <Setting name='Height' avg=':= 20' range=':= 20' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1/10 * ticoTinFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Tin -->
-                
-                <!-- End Tin Generation --> 
 
-                
-                <!-- Begin Aluminum Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Aluminum -->
-                <IfCondition condition=':= ticoAluminumDist = "layeredVeins"'>
-                
-                    <Veins name='ticoAluminumBaseVeins' block='TConstruct:SearedBrick:5'  inherits='PresetLayeredVeins' >
+            <!-- Iron Gravel Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='ticoIronGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Iron Gravel is generated </Description>
+                    <DisplayName>Tinkers Construct Iron Gravel</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EDEDED</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.6 * ticoAluminumSize * _default_' range=':= 1 * 0.6 * ticoAluminumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.6 * ticoAluminumSize * _default_' range=':= 1 * 0.6 * ticoAluminumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * ticoAluminumFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.9 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.7 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Aluminum Layered Veins) Settings -->
-                    <Veins name='ticoAluminumPrefersVeins' block='TConstruct:SearedBrick:5'  inherits='ticoAluminumBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EDEDED</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Aluminum Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Aluminum -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Aluminum -->
-                <IfCondition condition=':= ticoAluminumDist = "hugeVeins"'>
-                
-                    <Veins name='ticoAluminumBaseVeins' block='TConstruct:SearedBrick:5'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EDEDED</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.6 * ticoAluminumSize * _default_' range=':= 1 * 0.6 * ticoAluminumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 35' range=':= 20' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.6 * ticoAluminumSize * _default_' range=':= 1 * 0.6 * ticoAluminumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 0.85 * ticoAluminumFreq * _default_'/>
-                        <Setting name='BranchFrequency' avg=':= 0.9 * _default_'/>
-                        <Setting name='BranchLength' avg=':= 0.8 * _default_' range=':= 0.7 * _default_'/>
-                        <Setting name='BranchHeightLimit' avg=':= 10.5'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Aluminum Huge Veins) Settings -->
-                    <Veins name='ticoAluminumPrefersVeins' block='TConstruct:SearedBrick:5'  inherits='ticoAluminumBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EDEDED</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Aluminum Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Aluminum -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Aluminum -->
-                <IfCondition condition=':= ticoAluminumDist = "strategicCloud"'>
-                
-                    <Cloud name='ticoAluminumBaseCloud' block='TConstruct:SearedBrick:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EDEDED</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.7 * ticoAluminumSize * _default_' range=':= 1 * 0.7 * ticoAluminumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.7 * ticoAluminumSize * _default_' range=':= 1 * 0.7 * ticoAluminumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= _default_' range=':= _default_' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * 0.7 * ticoAluminumSize * _default_' range=':= 1 * 0.8 * 0.7 * ticoAluminumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 7 * ticoAluminumFreq *_default_'/>
-                        <Replaces block='minecraft:stone'/>
-                        
-                        <!-- Begin Aluminum Strategic Cloud Hint Veins -->
-                        <Veins name='ticoAluminumBaseHintVeins' block='TConstruct:SearedBrick:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EDEDED</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:stone'/>
-                        </Veins>
-                        <!-- End Aluminum Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Iron Gravel is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoIronGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Iron Gravel distributions </Description>
+                    <DisplayName>Tinkers Construct Iron Gravel Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoIronGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Iron Gravel distributions </Description>
+                    <DisplayName>Tinkers Construct Iron Gravel Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Iron Gravel Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Aluminum -->
-                
-                
-                <!-- Begin  Vanilla distribution of Aluminum -->
-                <IfCondition condition=':= ticoAluminumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='ticoAluminumBaseStandard' block='TConstruct:SearedBrick:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EDEDED</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 3/4 * ticoAluminumSize * _default_'/>
-                        <Setting name='Height' avg=':= 35' range=':= 30' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 3/20 * ticoAluminumFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Aluminum -->
-                
-                <!-- End Aluminum Generation --> 
 
-                
-                <!-- Begin Iron Gravel Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Iron Gravel -->
-                <IfCondition condition=':= ticoIronGravelDist = "layeredVeins"'>
-                
-                    <Veins name='ticoIronGravelBaseVeins' block='TConstruct:GravelOre'  inherits='PresetLayeredVeins' >
+            <!-- Gold Gravel Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='ticoGoldGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Gold Gravel is generated </Description>
+                    <DisplayName>Tinkers Construct Gold Gravel</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoIronGravelSize * _default_' range=':= 1 * 1 * ticoIronGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoIronGravelSize * _default_' range=':= 1 * 1 * ticoIronGravelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoIronGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Iron Gravel Layered Veins) Settings -->
-                    <Veins name='ticoIronGravelPrefersVeins' block='TConstruct:GravelOre'  inherits='ticoIronGravelBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Iron Gravel Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Iron Gravel -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Iron Gravel -->
-                <IfCondition condition=':= ticoIronGravelDist = "hugeVeins"'>
-                
-                    <Veins name='ticoIronGravelBaseVeins' block='TConstruct:GravelOre'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoIronGravelSize * _default_' range=':= 1 * 1 * ticoIronGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoIronGravelSize * _default_' range=':= 1 * 1 * ticoIronGravelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoIronGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Iron Gravel Huge Veins) Settings -->
-                    <Veins name='ticoIronGravelPrefersVeins' block='TConstruct:GravelOre'  inherits='ticoIronGravelBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Cold'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Iron Gravel Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Iron Gravel -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Iron Gravel -->
-                <IfCondition condition=':= ticoIronGravelDist = "strategicCloud"'>
-                
-                    <Cloud name='ticoIronGravelBaseCloud' block='TConstruct:GravelOre' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * ticoIronGravelSize * _default_' range=':= 1 * 1 * ticoIronGravelSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * ticoIronGravelSize * _default_' range=':= 1 * 1 * ticoIronGravelSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * ticoIronGravelSize * _default_' range=':= 1 * 1 * 1 * ticoIronGravelSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 2.5 * ticoIronGravelFreq *_default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                        
-                        <!-- Begin Iron Gravel Strategic Cloud Hint Veins -->
-                        <Veins name='ticoIronGravelBaseHintVeins' block='TConstruct:GravelOre' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDC2AF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                        </Veins>
-                        <!-- End Iron Gravel Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Gold Gravel is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoGoldGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Gold Gravel distributions </Description>
+                    <DisplayName>Tinkers Construct Gold Gravel Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoGoldGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Gold Gravel distributions </Description>
+                    <DisplayName>Tinkers Construct Gold Gravel Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Gold Gravel Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Iron Gravel -->
-                
-                
-                <!-- Begin  Vanilla distribution of Iron Gravel -->
-                <IfCondition condition=':= ticoIronGravelDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='ticoIronGravelBaseStandard' block='TConstruct:GravelOre' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * ticoIronGravelSize * _default_'/>
-                        <Setting name='Height' avg=':= 64' range=':= 64' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * ticoIronGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Iron Gravel -->
-                
-                <!-- End Iron Gravel Generation --> 
 
-                
-                <!-- Begin Gold Gravel Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Gold Gravel -->
-                <IfCondition condition=':= ticoGoldGravelDist = "layeredVeins"'>
-                
-                    <Veins name='ticoGoldGravelBaseVeins' block='TConstruct:GravelOre:1'  inherits='PresetLayeredVeins' >
+            <!-- Copper Gravel Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='ticoCopperGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Copper Gravel is generated </Description>
+                    <DisplayName>Tinkers Construct Copper Gravel</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * ticoGoldGravelSize * _default_' range=':= 1 * 0.8 * ticoGoldGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * ticoGoldGravelSize * _default_' range=':= 1 * 0.8 * ticoGoldGravelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 0.85 * ticoGoldGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Gold Gravel Layered Veins) Settings -->
-                    <Veins name='ticoGoldGravelPrefersVeins' block='TConstruct:GravelOre:1'  inherits='ticoGoldGravelBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Gold Gravel Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Gold Gravel -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Gold Gravel -->
-                <IfCondition condition=':= ticoGoldGravelDist = "hugeVeins"'>
-                
-                    <Veins name='ticoGoldGravelBaseVeins' block='TConstruct:GravelOre:1'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 0.8 * ticoGoldGravelSize * _default_' range=':= 1 * 0.8 * ticoGoldGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 0.8 * ticoGoldGravelSize * _default_' range=':= 1 * 0.8 * ticoGoldGravelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 0.85 * ticoGoldGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Gold Gravel Huge Veins) Settings -->
-                    <Veins name='ticoGoldGravelPrefersVeins' block='TConstruct:GravelOre:1'  inherits='ticoGoldGravelBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Gold Gravel Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Gold Gravel -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Gold Gravel -->
-                <IfCondition condition=':= ticoGoldGravelDist = "strategicCloud"'>
-                
-                    <Cloud name='ticoGoldGravelBaseCloud' block='TConstruct:GravelOre:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 0.8 * ticoGoldGravelSize * _default_' range=':= 1 * 0.8 * ticoGoldGravelSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 0.8 * ticoGoldGravelSize * _default_' range=':= 1 * 0.8 * ticoGoldGravelSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 20' range=':= 10' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 0.3 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 0.8 * ticoGoldGravelSize * _default_' range=':= 1 * 1 * 0.8 * ticoGoldGravelSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 4.5 * ticoGoldGravelFreq *_default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                        
-                        <!-- Begin Gold Gravel Strategic Cloud Hint Veins -->
-                        <Veins name='ticoGoldGravelBaseHintVeins' block='TConstruct:GravelOre:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EAEF57</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                        </Veins>
-                        <!-- End Gold Gravel Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Copper Gravel is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoCopperGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Copper Gravel distributions </Description>
+                    <DisplayName>Tinkers Construct Copper Gravel Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoCopperGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Copper Gravel distributions </Description>
+                    <DisplayName>Tinkers Construct Copper Gravel Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Copper Gravel Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Gold Gravel -->
-                
-                
-                <!-- Begin  Vanilla distribution of Gold Gravel -->
-                <IfCondition condition=':= ticoGoldGravelDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='ticoGoldGravelBaseStandard' block='TConstruct:GravelOre:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * ticoGoldGravelSize * _default_'/>
-                        <Setting name='Height' avg=':= 20' range=':= 10' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 0.1 * ticoGoldGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Gold Gravel -->
-                
-                <!-- End Gold Gravel Generation --> 
 
-                
-                <!-- Begin Copper Gravel Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Copper Gravel -->
-                <IfCondition condition=':= ticoCopperGravelDist = "layeredVeins"'>
-                
-                    <Veins name='ticoCopperGravelBaseVeins' block='TConstruct:GravelOre:2'  inherits='PresetLayeredVeins' >
+            <!-- Tin Gravel Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='ticoTinGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Tin Gravel is generated </Description>
+                    <DisplayName>Tinkers Construct Tin Gravel</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoCopperGravelSize * _default_' range=':= 1 * 1 * ticoCopperGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoCopperGravelSize * _default_' range=':= 1 * 1 * ticoCopperGravelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoCopperGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Gravel Layered Veins) Settings -->
-                    <Veins name='ticoCopperGravelPrefersVeins' block='TConstruct:GravelOre:2'  inherits='ticoCopperGravelBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Jungle'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Gravel Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Copper Gravel -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Copper Gravel -->
-                <IfCondition condition=':= ticoCopperGravelDist = "hugeVeins"'>
-                
-                    <Veins name='ticoCopperGravelBaseVeins' block='TConstruct:GravelOre:2'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoCopperGravelSize * _default_' range=':= 1 * 1 * ticoCopperGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoCopperGravelSize * _default_' range=':= 1 * 1 * ticoCopperGravelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoCopperGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Copper Gravel Huge Veins) Settings -->
-                    <Veins name='ticoCopperGravelPrefersVeins' block='TConstruct:GravelOre:2'  inherits='ticoCopperGravelBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Jungle'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Copper Gravel Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Copper Gravel -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Copper Gravel -->
-                <IfCondition condition=':= ticoCopperGravelDist = "strategicCloud"'>
-                
-                    <Cloud name='ticoCopperGravelBaseCloud' block='TConstruct:GravelOre:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * ticoCopperGravelSize * _default_' range=':= 1 * 1 * ticoCopperGravelSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * ticoCopperGravelSize * _default_' range=':= 1 * 1 * ticoCopperGravelSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * ticoCopperGravelSize * _default_' range=':= 1 * 1 * 1 * ticoCopperGravelSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 2.5 * ticoCopperGravelFreq *_default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                        
-                        <!-- Begin Copper Gravel Strategic Cloud Hint Veins -->
-                        <Veins name='ticoCopperGravelBaseHintVeins' block='TConstruct:GravelOre:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                        </Veins>
-                        <!-- End Copper Gravel Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Tin Gravel is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoTinGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Tin Gravel distributions </Description>
+                    <DisplayName>Tinkers Construct Tin Gravel Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoTinGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Tin Gravel distributions </Description>
+                    <DisplayName>Tinkers Construct Tin Gravel Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Tin Gravel Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Copper Gravel -->
-                
-                
-                <!-- Begin  Vanilla distribution of Copper Gravel -->
-                <IfCondition condition=':= ticoCopperGravelDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='ticoCopperGravelBaseStandard' block='TConstruct:GravelOre:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * ticoCopperGravelSize * _default_'/>
-                        <Setting name='Height' avg=':= 64' range=':= 64' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * ticoCopperGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Copper Gravel -->
-                
-                <!-- End Copper Gravel Generation --> 
 
-                
-                <!-- Begin Tin Gravel Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Tin Gravel -->
-                <IfCondition condition=':= ticoTinGravelDist = "layeredVeins"'>
-                
-                    <Veins name='ticoTinGravelBaseVeins' block='TConstruct:GravelOre:3'  inherits='PresetLayeredVeins' >
+            <!-- Aluminum Gravel Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='ticoAluminumGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Aluminum Gravel is generated </Description>
+                    <DisplayName>Tinkers Construct Aluminum Gravel</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoTinGravelSize * _default_' range=':= 1 * 1 * ticoTinGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoTinGravelSize * _default_' range=':= 1 * 1 * ticoTinGravelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoTinGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Gravel Layered Veins) Settings -->
-                    <Veins name='ticoTinGravelPrefersVeins' block='TConstruct:GravelOre:3'  inherits='ticoTinGravelBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Gravel Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Tin Gravel -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Tin Gravel -->
-                <IfCondition condition=':= ticoTinGravelDist = "hugeVeins"'>
-                
-                    <Veins name='ticoTinGravelBaseVeins' block='TConstruct:GravelOre:3'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoTinGravelSize * _default_' range=':= 1 * 1 * ticoTinGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoTinGravelSize * _default_' range=':= 1 * 1 * ticoTinGravelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoTinGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Tin Gravel Huge Veins) Settings -->
-                    <Veins name='ticoTinGravelPrefersVeins' block='TConstruct:GravelOre:3'  inherits='ticoTinGravelBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Plains'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Tin Gravel Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Tin Gravel -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Tin Gravel -->
-                <IfCondition condition=':= ticoTinGravelDist = "strategicCloud"'>
-                
-                    <Cloud name='ticoTinGravelBaseCloud' block='TConstruct:GravelOre:3' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * ticoTinGravelSize * _default_' range=':= 1 * 1 * ticoTinGravelSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * ticoTinGravelSize * _default_' range=':= 1 * 1 * ticoTinGravelSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * ticoTinGravelSize * _default_' range=':= 1 * 1 * 1 * ticoTinGravelSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 2.5 * ticoTinGravelFreq *_default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                        
-                        <!-- Begin Tin Gravel Strategic Cloud Hint Veins -->
-                        <Veins name='ticoTinGravelBaseHintVeins' block='TConstruct:GravelOre:3' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                        </Veins>
-                        <!-- End Tin Gravel Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Aluminum Gravel is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoAluminumGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Aluminum Gravel distributions </Description>
+                    <DisplayName>Tinkers Construct Aluminum Gravel Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoAluminumGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Aluminum Gravel distributions </Description>
+                    <DisplayName>Tinkers Construct Aluminum Gravel Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Aluminum Gravel Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Tin Gravel -->
-                
-                
-                <!-- Begin  Vanilla distribution of Tin Gravel -->
-                <IfCondition condition=':= ticoTinGravelDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='ticoTinGravelBaseStandard' block='TConstruct:GravelOre:3' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * ticoTinGravelSize * _default_'/>
-                        <Setting name='Height' avg=':= 64' range=':= 64' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * ticoTinGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Tin Gravel -->
-                
-                <!-- End Tin Gravel Generation --> 
 
-                
-                <!-- Begin Aluminum Gravel Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Aluminum Gravel -->
-                <IfCondition condition=':= ticoAluminumGravelDist = "layeredVeins"'>
-                
-                    <Veins name='ticoAluminumGravelBaseVeins' block='TConstruct:GravelOre:4'  inherits='PresetLayeredVeins' >
+            <!-- Cobalt Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='ticoCobaltDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Cobalt is generated </Description>
+                    <DisplayName>Tinkers Construct Cobalt</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EDEDED</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoAluminumGravelSize * _default_' range=':= 1 * 1 * ticoAluminumGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoAluminumGravelSize * _default_' range=':= 1 * 1 * ticoAluminumGravelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoAluminumGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Aluminum Gravel Layered Veins) Settings -->
-                    <Veins name='ticoAluminumGravelPrefersVeins' block='TConstruct:GravelOre:4'  inherits='ticoAluminumGravelBaseVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Spawns 2 more times in preferred biomes.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EDEDED</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Aluminum Gravel Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Aluminum Gravel -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Aluminum Gravel -->
-                <IfCondition condition=':= ticoAluminumGravelDist = "hugeVeins"'>
-                
-                    <Veins name='ticoAluminumGravelBaseVeins' block='TConstruct:GravelOre:4'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EDEDED</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoAluminumGravelSize * _default_' range=':= 1 * 1 * ticoAluminumGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoAluminumGravelSize * _default_' range=':= 1 * 1 * ticoAluminumGravelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 2 * ticoAluminumGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Aluminum Gravel Huge Veins) Settings -->
-                    <Veins name='ticoAluminumGravelPrefersVeins' block='TConstruct:GravelOre:4'  inherits='ticoAluminumGravelBaseVeins' >
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EDEDED</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='Forest'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Aluminum Gravel Huge Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Aluminum Gravel -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Aluminum Gravel -->
-                <IfCondition condition=':= ticoAluminumGravelDist = "strategicCloud"'>
-                
-                    <Cloud name='ticoAluminumGravelBaseCloud' block='TConstruct:GravelOre:4' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EDEDED</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * ticoAluminumGravelSize * _default_' range=':= 1 * 1 * ticoAluminumGravelSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * ticoAluminumGravelSize * _default_' range=':= 1 * 1 * ticoAluminumGravelSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 64' range=':= 64' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * ticoAluminumGravelSize * _default_' range=':= 1 * 1 * 1 * ticoAluminumGravelSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 2.5 * ticoAluminumGravelFreq *_default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                        
-                        <!-- Begin Aluminum Gravel Strategic Cloud Hint Veins -->
-                        <Veins name='ticoAluminumGravelBaseHintVeins' block='TConstruct:GravelOre:4' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EDEDED</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                        </Veins>
-                        <!-- End Aluminum Gravel Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Cobalt is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoCobaltFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Cobalt distributions </Description>
+                    <DisplayName>Tinkers Construct Cobalt Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoCobaltSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Cobalt distributions </Description>
+                    <DisplayName>Tinkers Construct Cobalt Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Cobalt Configuration UI Complete -->
 
-                    </Cloud>
-                    
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Aluminum Gravel -->
-                
-                
-                <!-- Begin  Vanilla distribution of Aluminum Gravel -->
-                <IfCondition condition=':= ticoAluminumGravelDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='ticoAluminumGravelBaseStandard' block='TConstruct:GravelOre:4' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EDEDED</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * ticoAluminumGravelSize * _default_'/>
-                        <Setting name='Height' avg=':= 64' range=':= 64' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * ticoAluminumGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </StandardGen>
-                    
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Aluminum Gravel -->
-                
-                <!-- End Aluminum Gravel Generation --> 
 
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Overworld Setup Complete -->
+            <!-- Ardite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='ticoArditeDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Ardite is generated </Description>
+                    <DisplayName>Tinkers Construct Ardite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Ardite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoArditeFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Ardite distributions </Description>
+                    <DisplayName>Tinkers Construct Ardite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoArditeSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Ardite distributions </Description>
+                    <DisplayName>Tinkers Construct Ardite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Ardite Configuration UI Complete -->
 
-            <!-- Setup Nether -->
-            <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
-                
-                <!-- Starting Original Nether Ore Removal -->
-                <Substitute name='ticoNetherOreSubstitute0' block='minecraft:netherrack'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='TConstruct:SearedBrick:1' />
-                    <Replaces block='TConstruct:SearedBrick:2' />
-                </Substitute>
-                <Substitute name='ticoNetherOreSubstitute1' block='minecraft:netherrack'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='TConstruct:GravelOre:5' />
-                </Substitute>
-                <!-- Original Nether Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Cobalt Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Cobalt -->
-                <IfCondition condition=':= ticoCobaltDist = "layeredVeins"'>
-                
-                    <Veins name='ticoCobaltBaseVeins' block='TConstruct:SearedBrick:1'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601D62B8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoCobaltSize * _default_' range=':= 1 * 1 * ticoCobaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoCobaltSize * _default_' range=':= 1 * 1 * ticoCobaltSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 0.5 * 1 * ticoCobaltFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Cobalt -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Cobalt -->
-                <IfCondition condition=':= ticoCobaltDist = "hugeVeins"'>
-                
-                    <Veins name='ticoCobaltBaseVeins' block='TConstruct:SearedBrick:1'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601D62B8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoCobaltSize * _default_' range=':= 1 * 1 * ticoCobaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoCobaltSize * _default_' range=':= 1 * 1 * ticoCobaltSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 0.5 * 1 * ticoCobaltFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Cobalt -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Cobalt -->
-                <IfCondition condition=':= ticoCobaltDist = "strategicCloud"'>
-                
-                    <Cloud name='ticoCobaltBaseCloud' block='TConstruct:SearedBrick:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601D62B8</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * ticoCobaltSize * _default_' range=':= 1 * 1 * ticoCobaltSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * ticoCobaltSize * _default_' range=':= 1 * 1 * ticoCobaltSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * ticoCobaltSize * _default_' range=':= 1 * 1 * 1 * ticoCobaltSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 0.5 * 1 * ticoCobaltFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Cobalt Strategic Cloud Hint Veins -->
-                        <Veins name='ticoCobaltBaseHintVeins' block='TConstruct:SearedBrick:1' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x601D62B8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Cobalt Strategic Cloud Hint Veins -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Cobalt -->
-                
-                
-                <!-- Begin  Vanilla distribution of Cobalt -->
-                <IfCondition condition=':= ticoCobaltDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='ticoCobaltBaseStandard' block='TConstruct:SearedBrick:1' inherits='PresetStandardGen'>
+            <!-- Nether Cobalt Gravel Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='ticoNetherCobaltGravelDist'  displayState='shown' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Nether Cobalt Gravel is generated </Description>
+                    <DisplayName>Tinkers Construct Nether Cobalt Gravel</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            This mimics vanilla ore generation.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601D62B8</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * ticoCobaltSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 0.5 * 1 * ticoCobaltFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Cobalt -->
-                
-                <!-- End Cobalt Generation --> 
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Nether Cobalt Gravel is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoNetherCobaltGravelFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Nether Cobalt Gravel distributions </Description>
+                    <DisplayName>Tinkers Construct Nether Cobalt Gravel Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoNetherCobaltGravelSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Nether Cobalt Gravel distributions </Description>
+                    <DisplayName>Tinkers Construct Nether Cobalt Gravel Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Nether Cobalt Gravel Configuration UI Complete -->
 
-                
-                <!-- Begin Ardite Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Ardite -->
-                <IfCondition condition=':= ticoArditeDist = "layeredVeins"'>
-                
-                    <Veins name='ticoArditeBaseVeins' block='TConstruct:SearedBrick:2'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60F48A00</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoArditeSize * _default_' range=':= 1 * 1 * ticoArditeSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoArditeSize * _default_' range=':= 1 * 1 * ticoArditeSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 0.5 * 1 * ticoArditeFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Ardite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Ardite -->
-                <IfCondition condition=':= ticoArditeDist = "hugeVeins"'>
-                
-                    <Veins name='ticoArditeBaseVeins' block='TConstruct:SearedBrick:2'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60F48A00</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoArditeSize * _default_' range=':= 1 * 1 * ticoArditeSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoArditeSize * _default_' range=':= 1 * 1 * ticoArditeSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 0.5 * 1 * ticoArditeFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Ardite -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Ardite -->
-                <IfCondition condition=':= ticoArditeDist = "strategicCloud"'>
-                
-                    <Cloud name='ticoArditeBaseCloud' block='TConstruct:SearedBrick:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60F48A00</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * ticoArditeSize * _default_' range=':= 1 * 1 * ticoArditeSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * ticoArditeSize * _default_' range=':= 1 * 1 * ticoArditeSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * ticoArditeSize * _default_' range=':= 1 * 1 * 1 * ticoArditeSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 0.5 * 1 * ticoArditeFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ardite Strategic Cloud Hint Veins -->
-                        <Veins name='ticoArditeBaseHintVeins' block='TConstruct:SearedBrick:2' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60F48A00</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ardite Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Ardite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Ardite -->
-                <IfCondition condition=':= ticoArditeDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='ticoArditeBaseStandard' block='TConstruct:SearedBrick:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60F48A00</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * ticoArditeSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 0.5 * 1 * ticoArditeFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Ardite -->
-                
-                <!-- End Ardite Generation --> 
-
-                
-                <!-- Begin Nether Cobalt Gravel Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Nether Cobalt Gravel -->
-                <IfCondition condition=':= ticoNetherCobaltGravelDist = "layeredVeins"'>
-                
-                    <Veins name='ticoNetherCobaltGravelBaseVeins' block='TConstruct:GravelOre:5'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601D62B8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_' range=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_' range=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * ticoNetherCobaltGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Nether Cobalt Gravel -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Nether Cobalt Gravel -->
-                <IfCondition condition=':= ticoNetherCobaltGravelDist = "hugeVeins"'>
-                
-                    <Veins name='ticoNetherCobaltGravelBaseVeins' block='TConstruct:GravelOre:5'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601D62B8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_' range=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_' range=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * ticoNetherCobaltGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Nether Cobalt Gravel -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Nether Cobalt Gravel -->
-                <IfCondition condition=':= ticoNetherCobaltGravelDist = "strategicCloud"'>
-                
-                    <Cloud name='ticoNetherCobaltGravelBaseCloud' block='TConstruct:GravelOre:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601D62B8</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_' range=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_' range=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * ticoNetherCobaltGravelSize * _default_' range=':= 1 * 1 * 1 * ticoNetherCobaltGravelSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * ticoNetherCobaltGravelFreq *_default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                        
-                        <!-- Begin Nether Cobalt Gravel Strategic Cloud Hint Veins -->
-                        <Veins name='ticoNetherCobaltGravelBaseHintVeins' block='TConstruct:GravelOre:5' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x601D62B8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:gravel'/>
-                        </Veins>
-                        <!-- End Nether Cobalt Gravel Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Nether Cobalt Gravel -->
-                
-                
-                <!-- Begin  Vanilla distribution of Nether Cobalt Gravel -->
-                <IfCondition condition=':= ticoNetherCobaltGravelDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='ticoNetherCobaltGravelBaseStandard' block='TConstruct:GravelOre:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601D62B8</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * ticoNetherCobaltGravelSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * ticoNetherCobaltGravelFreq * _default_'/>
-                        <Replaces block='minecraft:gravel'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Nether Cobalt Gravel -->
-                
-                <!-- End Nether Cobalt Gravel Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Nether Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+        <!-- Overworld Setup Beginning -->
+
+        <IfCondition condition=':= ?COGActive'>
+
+            <!-- Starting Original "Overworld" Block Removal -->
+
+            <Substitute name='ticoOverworldBlockSubstitute0' block='minecraft:gravel'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='TConstruct:GravelOre' weight='1.0' />
+                <Replaces block='TConstruct:GravelOre:1' weight='1.0' />
+                <Replaces block='TConstruct:GravelOre:2' weight='1.0' />
+                <Replaces block='TConstruct:GravelOre:3' weight='1.0' />
+                <Replaces block='TConstruct:GravelOre:4' weight='1.0' />
+            </Substitute>
+
+
+            <Substitute name='ticoOverworldBlockSubstitute1' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='TConstruct:SearedBrick:3' weight='1.0' />
+                <Replaces block='TConstruct:SearedBrick:4' weight='1.0' />
+                <Replaces block='TConstruct:SearedBrick:5' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Overworld" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Copper Generation -->
+
+            <!-- Starting LayeredVeins Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoCopperDist = "LayeredVeins"'>
+                    <Veins name='ticoCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoCopperFreq ' range=':=  _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Copper is complete. -->
+
+
+            <!-- Starting Cloud Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoCopperDist = "Cloud"'>
+                    <Cloud name='ticoCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoCopperFreq ' range=':=  _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='ticoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Copper is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Copper. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoCopperDist = "Vanilla"'>
+                    <StandardGen name='ticoCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * ticoCopperFreq ' range=':=  _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Copper is complete. -->
+
+            <!-- End Copper Generation -->
+
+
+            <!-- Begin Tin Generation -->
+
+            <!-- Starting LayeredVeins Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoTinDist = "LayeredVeins"'>
+                    <Veins name='ticoTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoTinFreq ' range=':=  _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Tin is complete. -->
+
+
+            <!-- Starting Cloud Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoTinDist = "Cloud"'>
+                    <Cloud name='ticoTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoTinFreq ' range=':=  _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='ticoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Tin is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Tin. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoTinDist = "Vanilla"'>
+                    <StandardGen name='ticoTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * ticoTinFreq ' range=':=  _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Tin is complete. -->
+
+            <!-- End Tin Generation -->
+
+
+            <!-- Begin Aluminum Generation -->
+
+            <!-- Starting LayeredVeins Preset for Aluminum. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoAluminumDist = "LayeredVeins"'>
+                    <Veins name='ticoAluminumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * ticoAluminumFreq ' range=':=  _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Aluminum is complete. -->
+
+
+            <!-- Starting Cloud Preset for Aluminum. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoAluminumDist = "Cloud"'>
+                    <Cloud name='ticoAluminumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.002 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.002 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * ticoAluminumFreq ' range=':=  _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='ticoAluminumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Aluminum is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Aluminum. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoAluminumDist = "Vanilla"'>
+                    <StandardGen name='ticoAluminumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
+                        <Replaces block='minecraft:stone' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * ticoAluminumFreq ' range=':=  _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Aluminum is complete. -->
+
+            <!-- End Aluminum Generation -->
+
+
+            <!-- Begin Iron Gravel Generation -->
+
+            <!-- Starting LayeredVeins Preset for Iron Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoIronGravelDist = "LayeredVeins"'>
+                    <Veins name='ticoIronGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * ticoIronGravelFreq ' range=':=  1 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':=  1 * _default_ * ticoIronGravelSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':=  1 * _default_ * ticoIronGravelSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Iron Gravel is complete. -->
+
+
+            <!-- Starting Cloud Preset for Iron Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoIronGravelDist = "Cloud"'>
+                    <Cloud name='ticoIronGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.730 * _default_ * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.730 * _default_ * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * ticoIronGravelFreq ' range=':=  _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='ticoIronGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='TConstruct:GravelOre' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Iron Gravel is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Iron Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoIronGravelDist = "Vanilla"'>
+                    <StandardGen name='ticoIronGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 20 * ticoIronGravelFreq ' range=':=  _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Iron Gravel is complete. -->
+
+            <!-- End Iron Gravel Generation -->
+
+
+            <!-- Begin Gold Gravel Generation -->
+
+            <!-- Starting LayeredVeins Preset for Gold Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoGoldGravelDist = "LayeredVeins"'>
+                    <Veins name='ticoGoldGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoGoldGravelFreq ' range=':=  1 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoGoldGravelSize ' range=':=  1 * _default_ * ticoGoldGravelSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoGoldGravelSize ' range=':=  1 * _default_ * ticoGoldGravelSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Gold Gravel is complete. -->
+
+
+            <!-- Starting Cloud Preset for Gold Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoGoldGravelDist = "Cloud"'>
+                    <Cloud name='ticoGoldGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoGoldGravelFreq ' range=':=  _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='ticoGoldGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Gold Gravel is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Gold Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoGoldGravelDist = "Vanilla"'>
+                    <StandardGen name='ticoGoldGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * ticoGoldGravelFreq ' range=':=  _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Gold Gravel is complete. -->
+
+            <!-- End Gold Gravel Generation -->
+
+
+            <!-- Begin Copper Gravel Generation -->
+
+            <!-- Starting LayeredVeins Preset for Copper Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoCopperGravelDist = "LayeredVeins"'>
+                    <Veins name='ticoCopperGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoCopperGravelFreq ' range=':=  _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Copper Gravel is complete. -->
+
+
+            <!-- Starting Cloud Preset for Copper Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoCopperGravelDist = "Cloud"'>
+                    <Cloud name='ticoCopperGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoCopperGravelFreq ' range=':=  _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='ticoCopperGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Copper Gravel is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Copper Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoCopperGravelDist = "Vanilla"'>
+                    <StandardGen name='ticoCopperGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * ticoCopperGravelFreq ' range=':=  _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Copper Gravel is complete. -->
+
+            <!-- End Copper Gravel Generation -->
+
+
+            <!-- Begin Tin Gravel Generation -->
+
+            <!-- Starting LayeredVeins Preset for Tin Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoTinGravelDist = "LayeredVeins"'>
+                    <Veins name='ticoTinGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoTinGravelFreq ' range=':=  _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Tin Gravel is complete. -->
+
+
+            <!-- Starting Cloud Preset for Tin Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoTinGravelDist = "Cloud"'>
+                    <Cloud name='ticoTinGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoTinGravelFreq ' range=':=  _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='ticoTinGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Tin Gravel is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Tin Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoTinGravelDist = "Vanilla"'>
+                    <StandardGen name='ticoTinGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 8 * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * ticoTinGravelFreq ' range=':=  _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Tin Gravel is complete. -->
+
+            <!-- End Tin Gravel Generation -->
+
+
+            <!-- Begin Aluminum Gravel Generation -->
+
+            <!-- Starting LayeredVeins Preset for Aluminum Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoAluminumGravelDist = "LayeredVeins"'>
+                    <Veins name='ticoAluminumGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * ticoAluminumGravelFreq ' range=':=  _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Aluminum Gravel is complete. -->
+
+
+            <!-- Starting Cloud Preset for Aluminum Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoAluminumGravelDist = "Cloud"'>
+                    <Cloud name='ticoAluminumGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.002 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.002 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * ticoAluminumGravelFreq ' range=':=  _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='ticoAluminumGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Aluminum Gravel is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Aluminum Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoAluminumGravelDist = "Vanilla"'>
+                    <StandardGen name='ticoAluminumGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 6 * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 3 * ticoAluminumGravelFreq ' range=':=  _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Aluminum Gravel is complete. -->
+
+            <!-- End Aluminum Gravel Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Overworld Setup Complete -->
+
+
+
+
+
+        <!-- Nether Setup Beginning -->
+
+        <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
+
+            <!-- Starting Original "Nether" Block Removal -->
+
+            <Substitute name='ticoNetherBlockSubstitute0' block='minecraft:gravel'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='TConstruct:GravelOre:5' weight='1.0' />
+            </Substitute>
+
+
+            <Substitute name='ticoNetherBlockSubstitute1' block='minecraft:netherrack'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <Replaces block='TConstruct:SearedBrick:1' weight='1.0' />
+                <Replaces block='TConstruct:SearedBrick:2' weight='1.0' />
+            </Substitute>
+
+            <!-- Original "Nether" Block Removal Complete -->
+
+            <!-- Adding blocks -->
+
+            <!-- Begin Cobalt Generation -->
+
+            <!-- Starting LayeredVeins Preset for Cobalt. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoCobaltDist = "LayeredVeins"'>
+                    <Veins name='ticoCobaltVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoCobaltFreq ' range=':=  _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Cobalt is complete. -->
+
+
+            <!-- Starting Cloud Preset for Cobalt. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoCobaltDist = "Cloud"'>
+                    <Cloud name='ticoCobaltCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoCobaltFreq ' range=':=  _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='ticoCobaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Cobalt is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Cobalt. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoCobaltDist = "Vanilla"'>
+                    <StandardGen name='ticoCobaltStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * ticoCobaltFreq ' range=':=  _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Cobalt is complete. -->
+
+            <!-- End Cobalt Generation -->
+
+
+            <!-- Begin Ardite Generation -->
+
+            <!-- Starting LayeredVeins Preset for Ardite. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoArditeDist = "LayeredVeins"'>
+                    <Veins name='ticoArditeVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoArditeFreq ' range=':=  _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Ardite is complete. -->
+
+
+            <!-- Starting Cloud Preset for Ardite. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoArditeDist = "Cloud"'>
+                    <Cloud name='ticoArditeCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoArditeFreq ' range=':=  _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='ticoArditeHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Ardite is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Ardite. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoArditeDist = "Vanilla"'>
+                    <StandardGen name='ticoArditeStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
+                        <Replaces block='minecraft:netherrack' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * ticoArditeFreq ' range=':=  _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Ardite is complete. -->
+
+            <!-- End Ardite Generation -->
+
+
+            <!-- Begin Nether Cobalt Gravel Generation -->
+
+            <!-- Starting LayeredVeins Preset for Nether Cobalt
+                 Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoNetherCobaltGravelDist = "LayeredVeins"'>
+                    <Veins name='ticoNetherCobaltGravelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                        <Description>
+                            Small, fairly rare motherlodes with  2-4
+                            horizontal veins each.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoNetherCobaltGravelFreq ' range=':=  _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                        <Setting name='MotherlodeHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                        <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentLength' avg=':= _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                        <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </Veins>
+                </IfCondition>
+            </ConfigSection>
+            <!-- LayeredVeins Preset for Nether Cobalt Gravel is
+                 complete. -->
+
+
+            <!-- Starting Cloud Preset for Nether Cobalt Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoNetherCobaltGravelDist = "Cloud"'>
+                    <Cloud name='ticoNetherCobaltGravelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                        <Description>
+                            Large irregular clouds filled lightly
+                            with ore.  These are huge, spanning
+                            several adjacent chunks, and  consequently
+                            rather rare.  They  contain a sizeable
+                            amount of ore, but  it takes some time and
+                            effort to mine  due to low density. The
+                            intent for  strategic clouds is that the
+                            player  will need to actively search for
+                            one  and then set up a semi-permanent
+                            mining base and spend some time  actually
+                            mining the ore.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                        <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' scaleTo='base' />
+                        <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoNetherCobaltGravelFreq ' range=':=  _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='CloudHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
+                        <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                        <Veins name='ticoNetherCobaltGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                            <Description>
+                                Single blocks, generously  scattered
+                                through all heights  (density is about
+                                that of vanilla  iron ore). They will
+                                replace dirt  and sandstone (but not
+                                grass or  sand), so they can be found
+                                nearer to the surface than most  ores.
+                                Intened to be used as a  child
+                                distribution for large,  rare
+                                strategic deposits that  would
+                                otherwise be very difficult  to find.
+                                Note that the frequency  is multiplied
+                                by ground level to  maintain a
+                                constant density, but  not by ore
+                                frequency because it  is assumed that
+                                the frequency of  the parent
+                                distribution will  already be scaled
+                                by that.
+                            </Description>
+                            <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
+                            <Replaces block='minecraft:dirt' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
+                        </Veins>
+                    </Cloud>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Cloud Preset for Nether Cobalt Gravel is complete. -->
+
+
+            <!-- Starting Vanilla Preset for Nether Cobalt Gravel. -->
+            <ConfigSection>
+                <IfCondition condition=':= ticoNetherCobaltGravelDist = "Vanilla"'>
+                    <StandardGen name='ticoNetherCobaltGravelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                        <Description>
+                            A master preset for standardgen ore
+                            distributions.
+                        </Description>
+                        <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
+                        <Biome name='.*'  />
+                        <Setting name='Size' avg=':= 3 * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                        <Setting name='Frequency' avg=':= 2 * ticoNetherCobaltGravelFreq ' range=':=  _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                        <Setting name='Height' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
+                        <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    </StandardGen>
+                </IfCondition>
+            </ConfigSection>
+            <!-- Vanilla Preset for Nether Cobalt Gravel is complete. -->
+
+            <!-- End Nether Cobalt Gravel Generation -->
+
+            <!-- Finished adding blocks -->
+
+        </IfCondition>
+        <!-- Nether Setup Complete -->
+
+
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Tinkers Construct" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -390,7 +390,7 @@
                     <Biome name='Ocean'  weight='-1' />
                     <Biome name='Desert'  weight='-1' />
                     <Biome name='Mountain'  weight='-1' />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.50 * _default_ * vnlaClayFreq ' range=':=  0.50 * _default_ * vnlaClayFreq ' type='uniform' scaleTo='base' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.5 * _default_ * vnlaClayFreq ' range=':=  0.5 * _default_ * vnlaClayFreq ' type='uniform' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 2 * _default_ * vnlaClaySize ' range=':=  2 * _default_ * vnlaClaySize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 60 ' range=':=  4 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -423,7 +423,7 @@
                     <Biome name='Ocean'  weight='-1' />
                     <Biome name='Desert'  weight='-1' />
                     <Biome name='Mountain'  weight='-1' />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.50 * _default_ * vnlaClayFreq ' range=':=  0.50 * _default_ * vnlaClayFreq ' type='uniform' scaleTo='base' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.5 * _default_ * vnlaClayFreq ' range=':=  0.5 * _default_ * vnlaClayFreq ' type='uniform' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 2 * _default_ * vnlaClaySize ' range=':=  2 * _default_ * vnlaClaySize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 60 ' range=':=  4 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -467,19 +467,19 @@
                     <OreBlock block='minecraft:coal_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 4.610 * _default_ * vnlaCoalFreq ' range=':=  1 * _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.664 * _default_ * vnlaCoalSize ' range=':=  1 * _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 6.262 * _default_ * vnlaCoalFreq ' range=':=  1 * _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 1.843 * _default_ * vnlaCoalSize ' range=':=  1 * _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.664 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.843 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.664 * _default_ * vnlaCoalSize ' range=':=  1 * _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.843 * _default_ * vnlaCoalSize ' range=':=  1 * _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </Veins>
@@ -507,9 +507,9 @@
                     <OreBlock block='minecraft:coal_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 1.045 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 1.045 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 1.091  * _default_ * vnlaCoalFreq ' range=':=  _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudRadius' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * vnlaCoalFreq ' range=':=  _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
                     <Setting name='CloudHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -556,8 +556,8 @@
                     <OreBlock block='minecraft:coal_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 10 * vnlaCoalSize ' range=':=  3 * vnlaCoalSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 17 * vnlaCoalFreq ' range=':=  1 * vnlaCoalFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 16 * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 20 * vnlaCoalFreq ' range=':=  _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </StandardGen>
@@ -585,9 +585,9 @@
                     <OreBlock block='minecraft:coal_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 1.045 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 1.045 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 1.091  * _default_ * vnlaCoalFreq ' range=':=  _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudRadius' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * vnlaCoalFreq ' range=':=  _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
                     <Setting name='CloudHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -638,19 +638,19 @@
                     <OreBlock block='minecraft:iron_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 1.137 * _default_ * vnlaIronFreq ' range=':=  1 * _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.044 * _default_ * vnlaIronSize ' range=':=  1 * _default_ * vnlaIronSize ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * vnlaIronFreq ' range=':=  1 * _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * vnlaIronSize ' range=':=  1 * _default_ * vnlaIronSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.044 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.044 * _default_ * vnlaIronSize ' range=':=  1 * _default_ * vnlaIronSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * vnlaIronSize ' range=':=  1 * _default_ * vnlaIronSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </Veins>
@@ -670,8 +670,8 @@
                     <OreBlock block='minecraft:iron_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 8 * vnlaIronSize ' range=':=  2 * vnlaIronSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 11 * vnlaIronFreq ' range=':=  1 * vnlaIronFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 8 * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 20 * vnlaIronFreq ' range=':=  _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </StandardGen>
@@ -699,9 +699,9 @@
                     <OreBlock block='minecraft:iron_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 0.519 * _default_ * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.519 * _default_ * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.269  * _default_ * vnlaIronFreq ' range=':=  _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudRadius' avg=':= 1.730 * _default_ * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 1.730 * _default_ * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * vnlaIronFreq ' range=':=  _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
                     <Setting name='CloudHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -752,19 +752,19 @@
                     <OreBlock block='minecraft:gold_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.349 * _default_ * vnlaGoldFreq ' range=':=  1 * _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.704 * _default_ * vnlaGoldSize ' range=':=  1 * _default_ * vnlaGoldSize ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * vnlaGoldFreq ' range=':=  1 * _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * vnlaGoldSize ' range=':=  1 * _default_ * vnlaGoldSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.704 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.704 * _default_ * vnlaGoldSize ' range=':=  1 * _default_ * vnlaGoldSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * vnlaGoldSize ' range=':=  1 * _default_ * vnlaGoldSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </Veins>
@@ -784,8 +784,8 @@
                     <OreBlock block='minecraft:gold_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 5 * vnlaGoldSize ' range=':=  1 * vnlaGoldSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 2 * vnlaGoldFreq ' range=':=  0 * vnlaGoldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 8 * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 2 * vnlaGoldFreq ' range=':=  _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </StandardGen>
@@ -813,9 +813,9 @@
                     <OreBlock block='minecraft:gold_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 0.287 * _default_ * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.287 * _default_ * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.083  * _default_ * vnlaGoldFreq ' range=':=  _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudRadius' avg=':= 0.973 * _default_ * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 0.973 * _default_ * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * vnlaGoldFreq ' range=':=  _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
                     <Setting name='CloudHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -866,19 +866,19 @@
                     <OreBlock block='minecraft:redstone_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 1.114 * _default_ * vnlaRedstoneFreq ' range=':=  1 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.037 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * vnlaRedstoneFreq ' range=':=  1 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.037 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.037 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </Veins>
@@ -892,19 +892,19 @@
                     <OreBlock block='minecraft:redstone_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <BiomeType name='Desert'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 1.114 * _default_ * vnlaRedstoneFreq ' range=':=  1 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.037 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * vnlaRedstoneFreq ' range=':=  1 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.037 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.037 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </Veins>
@@ -926,8 +926,8 @@
                     <OreBlock block='minecraft:redstone_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 5 * vnlaRedstoneSize ' range=':=  1 * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 5 * vnlaRedstoneFreq ' range=':=  1 * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 7 * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 8 * vnlaRedstoneFreq ' range=':=  _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </StandardGen>
@@ -955,9 +955,9 @@
                     <OreBlock block='minecraft:redstone_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 0.514 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.514 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.264  * _default_ * vnlaRedstoneFreq ' range=':=  _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudRadius' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * vnlaRedstoneFreq ' range=':=  _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
                     <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -998,9 +998,9 @@
                     <OreBlock block='minecraft:redstone_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <BiomeType name='Desert'  />
-                    <Setting name='CloudRadius' avg=':= 0.514 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.514 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.264  * _default_ * vnlaRedstoneFreq ' range=':=  _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudRadius' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * vnlaRedstoneFreq ' range=':=  _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
                     <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1040,19 +1040,19 @@
                     <OreBlock block='minecraft:diamond_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.247 * _default_ * vnlaDiamondFreq ' range=':=  1 * _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.627 * _default_ * vnlaDiamondSize ' range=':=  1 * _default_ * vnlaDiamondSize ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.365 * _default_ * vnlaDiamondFreq ' range=':=  1 * _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * vnlaDiamondSize ' range=':=  1 * _default_ * vnlaDiamondSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.627 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.715 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.627 * _default_ * vnlaDiamondSize ' range=':=  1 * _default_ * vnlaDiamondSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * vnlaDiamondSize ' range=':=  1 * _default_ * vnlaDiamondSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </Veins>
@@ -1062,8 +1062,8 @@
                     <OreBlock block='minecraft:lava' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Replaces block='minecraft:diamond_ore' weight='1.0' />
-                    <Setting name='MotherlodeSize' avg=':= 0.627 * _default_ * vnlaDiamondSize  * 0.5 ' range=':=  1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.627 * _default_ * vnlaDiamondSize  * 0.5 ' range=':=  1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * vnlaDiamondSize  * 0.5 ' range=':=  1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * vnlaDiamondSize  * 0.5 ' range=':=  1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
                     <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                 </Veins>
             </IfCondition>
@@ -1082,8 +1082,8 @@
                     <OreBlock block='minecraft:diamond_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 3 * vnlaDiamondSize ' range=':=  1 * vnlaDiamondSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 1 * vnlaDiamondFreq ' range=':=  0 * vnlaDiamondFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 7 * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 1 * vnlaDiamondFreq ' range=':=  _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </StandardGen>
@@ -1111,9 +1111,9 @@
                     <OreBlock block='minecraft:diamond_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 0.242 * _default_ * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.242 * _default_ * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.058  * _default_ * vnlaDiamondFreq ' range=':=  _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudRadius' avg=':= 0.791 * _default_ * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 0.791 * _default_ * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 0.626  * _default_ * vnlaDiamondFreq ' range=':=  _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
                     <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1164,19 +1164,19 @@
                     <OreBlock block='minecraft:lapis_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.416 * _default_ * vnlaLapisLazuliFreq ' range=':=  1 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.747 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * vnlaLapisLazuliFreq ' range=':=  1 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.747 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.747 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </Veins>
@@ -1190,19 +1190,19 @@
                     <OreBlock block='minecraft:lapis_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <BiomeType name='Ocean'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.416 * _default_ * vnlaLapisLazuliFreq ' range=':=  1 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.747 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * vnlaLapisLazuliFreq ' range=':=  1 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.747 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.747 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </Veins>
@@ -1224,8 +1224,8 @@
                     <OreBlock block='minecraft:lapis_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 4 * vnlaLapisLazuliSize ' range=':=  1 * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 1 * vnlaLapisLazuliFreq ' range=':=  0 * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 6 * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 1 * vnlaLapisLazuliFreq ' range=':=  _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </StandardGen>
@@ -1253,9 +1253,9 @@
                     <OreBlock block='minecraft:lapis_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 0.314 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.314 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.099  * _default_ * vnlaLapisLazuliFreq ' range=':=  _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudRadius' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * vnlaLapisLazuliFreq ' range=':=  _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
                     <Setting name='CloudHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1296,9 +1296,9 @@
                     <OreBlock block='minecraft:lapis_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <BiomeType name='Ocean'  />
-                    <Setting name='CloudRadius' avg=':= 0.314 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.314 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.099  * _default_ * vnlaLapisLazuliFreq ' range=':=  _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudRadius' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * vnlaLapisLazuliFreq ' range=':=  _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
                     <Setting name='CloudHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1330,7 +1330,7 @@
         <!-- Starting PipeVeins Preset for Emerald. -->
         <ConfigSection>
             <IfCondition condition=':= vnlaEmeraldDist = "PipeVeins"'>
-                <Veins name='vnlaEmeraldVeins'  inherits='PresetPipeVeins' seed='0x2AB0' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                <Veins name='vnlaEmeraldVeins'  inherits='PresetPipeVeins' seed='0x54B3' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                     <Description>
                         Short sparsely filled veins sloping up  from
                         near the bottom of the map.
@@ -1338,30 +1338,30 @@
                     <OreBlock block='minecraft:emerald_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <BiomeType name='Mountain'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.079 * _default_ * vnlaEmeraldFreq ' range=':=  1 * _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.428 * _default_ * vnlaEmeraldSize ' range=':=  1 * _default_ * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * vnlaEmeraldFreq ' range=':=  1 * _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * vnlaEmeraldSize ' range=':=  1 * _default_ * vnlaEmeraldSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.428 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.428 * _default_ * vnlaEmeraldSize ' range=':=  1 * _default_ * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * vnlaEmeraldSize ' range=':=  1 * _default_ * vnlaEmeraldSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </Veins>
 
                 <!-- Configuring contained material. -->
-                <Veins name='vnlaEmeraldVeinsPipe'  inherits='vnlaEmeraldVeins' seed='0x2AB0' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                <Veins name='vnlaEmeraldVeinsPipe'  inherits='vnlaEmeraldVeins' seed='0x54B3' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                     <OreBlock block='minecraft:monster_egg' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <Replaces block='minecraft:emerald_ore' weight='1.0' />
-                    <Setting name='MotherlodeSize' avg=':= 0.428 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':=  1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.428 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':=  1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':=  1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':=  1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
                     <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                 </Veins>
             </IfCondition>
@@ -1380,8 +1380,8 @@
                     <OreBlock block='minecraft:emerald_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <BiomeType name='Mountain'  />
-                    <Setting name='Size' avg=':= 1 * vnlaEmeraldSize ' range=':=  0 * vnlaEmeraldSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 1 * vnlaEmeraldFreq ' range=':=  0 * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 1 * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 1 * vnlaEmeraldFreq ' range=':=  _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </StandardGen>
@@ -1409,9 +1409,9 @@
                     <OreBlock block='minecraft:emerald_ore' weight='1.0' />
                     <Replaces block='minecraft:stone' weight='1.0' />
                     <BiomeType name='Mountain'  />
-                    <Setting name='CloudRadius' avg=':= 0.136 * _default_ * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.136 * _default_ * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.019  * _default_ * vnlaEmeraldFreq ' range=':=  _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudRadius' avg=':= 0.486 * _default_ * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 0.486 * _default_ * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * vnlaEmeraldFreq ' range=':=  _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
                     <Setting name='CloudHeight' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
@@ -1491,19 +1491,19 @@
                     <OreBlock block='minecraft:quartz_ore' weight='1.0' />
                     <Replaces block='minecraft:netherrack' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 4.375 * _default_ * vnlaNetherQuartzFreq ' range=':=  1 * _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.636 * _default_ * vnlaNetherQuartzSize ' range=':=  1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 5.049 * _default_ * vnlaNetherQuartzFreq ' range=':=  1 * _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 1.716 * _default_ * vnlaNetherQuartzSize ' range=':=  1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.636 * _default_ ' range=':=  1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.716 * _default_ ' range=':=  1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.636 * _default_ * vnlaNetherQuartzSize ' range=':=  1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.716 * _default_ * vnlaNetherQuartzSize ' range=':=  1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </Veins>
@@ -1523,8 +1523,8 @@
                     <OreBlock block='minecraft:quartz_ore' weight='1.0' />
                     <Replaces block='minecraft:netherrack' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 10 * vnlaNetherQuartzSize ' range=':=  3 * vnlaNetherQuartzSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 15 * vnlaNetherQuartzFreq ' range=':=  5 * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 13 * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 16 * vnlaNetherQuartzFreq ' range=':=  _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                 </StandardGen>
@@ -1552,9 +1552,9 @@
                     <OreBlock block='minecraft:quartz_ore' weight='1.0' />
                     <Replaces block='minecraft:netherrack' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 1.018 * _default_ * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 1.018 * _default_ * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 1.036  * _default_ * vnlaNetherQuartzFreq ' range=':=  _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudRadius' avg=':= 1.847 * _default_ * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 1.847 * _default_ * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 3.411  * _default_ * vnlaNetherQuartzFreq ' range=':=  _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
                     <Setting name='CloudHeight' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -27,7 +27,7 @@
 
         <!-- Clay Configuration UI Starting -->
         <ConfigSection>
-            <OptionChoice name='vnlaClayDist'  displayState='shown' displayGroup='groupVanillaMinecraft'>
+            <OptionChoice name='vnlaClayDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
                 <Description> Controls how Clay is generated </Description>
                 <DisplayName>Vanilla Minecraft Clay</DisplayName>
                 <Choice value='SmallDeposits' displayValue='Small Deposits'>
@@ -37,11 +37,11 @@
                 </Choice>
                 <Choice value='none' displayValue='None' description='Clay is not generated in the world.'/>
             </OptionChoice>
-            <OptionNumeric name='vnlaClayFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaClayFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Frequency multiplier for Vanilla Minecraft Clay distributions </Description>
                 <DisplayName>Vanilla Minecraft Clay Freq.</DisplayName>
             </OptionNumeric>
-            <OptionNumeric name='vnlaClaySize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaClaySize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Size multiplier for Vanilla Minecraft Clay distributions </Description>
                 <DisplayName>Vanilla Minecraft Clay Size</DisplayName>
             </OptionNumeric>
@@ -51,7 +51,7 @@
 
         <!-- Coal Configuration UI Starting -->
         <ConfigSection>
-            <OptionChoice name='vnlaCoalDist'  displayState='shown' displayGroup='groupVanillaMinecraft'>
+            <OptionChoice name='vnlaCoalDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
                 <Description> Controls how Coal is generated </Description>
                 <DisplayName>Vanilla Minecraft Coal</DisplayName>
                 <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -76,11 +76,11 @@
                 </Choice>
                 <Choice value='none' displayValue='None' description='Coal is not generated in the world.'/>
             </OptionChoice>
-            <OptionNumeric name='vnlaCoalFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaCoalFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Frequency multiplier for Vanilla Minecraft Coal distributions </Description>
                 <DisplayName>Vanilla Minecraft Coal Freq.</DisplayName>
             </OptionNumeric>
-            <OptionNumeric name='vnlaCoalSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaCoalSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Size multiplier for Vanilla Minecraft Coal distributions </Description>
                 <DisplayName>Vanilla Minecraft Coal Size</DisplayName>
             </OptionNumeric>
@@ -90,7 +90,7 @@
 
         <!-- Iron Configuration UI Starting -->
         <ConfigSection>
-            <OptionChoice name='vnlaIronDist'  displayState='shown' displayGroup='groupVanillaMinecraft'>
+            <OptionChoice name='vnlaIronDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
                 <Description> Controls how Iron is generated </Description>
                 <DisplayName>Vanilla Minecraft Iron</DisplayName>
                 <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -110,11 +110,11 @@
                 </Choice>
                 <Choice value='none' displayValue='None' description='Iron is not generated in the world.'/>
             </OptionChoice>
-            <OptionNumeric name='vnlaIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Frequency multiplier for Vanilla Minecraft Iron distributions </Description>
                 <DisplayName>Vanilla Minecraft Iron Freq.</DisplayName>
             </OptionNumeric>
-            <OptionNumeric name='vnlaIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Size multiplier for Vanilla Minecraft Iron distributions </Description>
                 <DisplayName>Vanilla Minecraft Iron Size</DisplayName>
             </OptionNumeric>
@@ -124,7 +124,7 @@
 
         <!-- Gold Configuration UI Starting -->
         <ConfigSection>
-            <OptionChoice name='vnlaGoldDist'  displayState='shown' displayGroup='groupVanillaMinecraft'>
+            <OptionChoice name='vnlaGoldDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
                 <Description> Controls how Gold is generated </Description>
                 <DisplayName>Vanilla Minecraft Gold</DisplayName>
                 <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -144,11 +144,11 @@
                 </Choice>
                 <Choice value='none' displayValue='None' description='Gold is not generated in the world.'/>
             </OptionChoice>
-            <OptionNumeric name='vnlaGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Frequency multiplier for Vanilla Minecraft Gold distributions </Description>
                 <DisplayName>Vanilla Minecraft Gold Freq.</DisplayName>
             </OptionNumeric>
-            <OptionNumeric name='vnlaGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Size multiplier for Vanilla Minecraft Gold distributions </Description>
                 <DisplayName>Vanilla Minecraft Gold Size</DisplayName>
             </OptionNumeric>
@@ -158,7 +158,7 @@
 
         <!-- Redstone Configuration UI Starting -->
         <ConfigSection>
-            <OptionChoice name='vnlaRedstoneDist'  displayState='shown' displayGroup='groupVanillaMinecraft'>
+            <OptionChoice name='vnlaRedstoneDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
                 <Description> Controls how Redstone is generated </Description>
                 <DisplayName>Vanilla Minecraft Redstone</DisplayName>
                 <Choice value='VerticalVeins' displayValue='Vertical Veins'>
@@ -178,11 +178,11 @@
                 </Choice>
                 <Choice value='none' displayValue='None' description='Redstone is not generated in the world.'/>
             </OptionChoice>
-            <OptionNumeric name='vnlaRedstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaRedstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Frequency multiplier for Vanilla Minecraft Redstone distributions </Description>
                 <DisplayName>Vanilla Minecraft Redstone Freq.</DisplayName>
             </OptionNumeric>
-            <OptionNumeric name='vnlaRedstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaRedstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Size multiplier for Vanilla Minecraft Redstone distributions </Description>
                 <DisplayName>Vanilla Minecraft Redstone Size</DisplayName>
             </OptionNumeric>
@@ -192,7 +192,7 @@
 
         <!-- Diamond Configuration UI Starting -->
         <ConfigSection>
-            <OptionChoice name='vnlaDiamondDist'  displayState='shown' displayGroup='groupVanillaMinecraft'>
+            <OptionChoice name='vnlaDiamondDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
                 <Description> Controls how Diamond is generated </Description>
                 <DisplayName>Vanilla Minecraft Diamond</DisplayName>
                 <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -212,11 +212,11 @@
                 </Choice>
                 <Choice value='none' displayValue='None' description='Diamond is not generated in the world.'/>
             </OptionChoice>
-            <OptionNumeric name='vnlaDiamondFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaDiamondFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Frequency multiplier for Vanilla Minecraft Diamond distributions </Description>
                 <DisplayName>Vanilla Minecraft Diamond Freq.</DisplayName>
             </OptionNumeric>
-            <OptionNumeric name='vnlaDiamondSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaDiamondSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Size multiplier for Vanilla Minecraft Diamond distributions </Description>
                 <DisplayName>Vanilla Minecraft Diamond Size</DisplayName>
             </OptionNumeric>
@@ -226,7 +226,7 @@
 
         <!-- Lapis Lazuli Configuration UI Starting -->
         <ConfigSection>
-            <OptionChoice name='vnlaLapisLazuliDist'  displayState='shown' displayGroup='groupVanillaMinecraft'>
+            <OptionChoice name='vnlaLapisLazuliDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
                 <Description> Controls how Lapis Lazuli is generated </Description>
                 <DisplayName>Vanilla Minecraft Lapis Lazuli</DisplayName>
                 <Choice value='VerticalVeins' displayValue='Vertical Veins'>
@@ -246,11 +246,11 @@
                 </Choice>
                 <Choice value='none' displayValue='None' description='Lapis Lazuli is not generated in the world.'/>
             </OptionChoice>
-            <OptionNumeric name='vnlaLapisLazuliFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaLapisLazuliFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Frequency multiplier for Vanilla Minecraft Lapis Lazuli distributions </Description>
                 <DisplayName>Vanilla Minecraft Lapis Lazuli Freq.</DisplayName>
             </OptionNumeric>
-            <OptionNumeric name='vnlaLapisLazuliSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaLapisLazuliSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Size multiplier for Vanilla Minecraft Lapis Lazuli distributions </Description>
                 <DisplayName>Vanilla Minecraft Lapis Lazuli Size</DisplayName>
             </OptionNumeric>
@@ -260,7 +260,7 @@
 
         <!-- Emerald Configuration UI Starting -->
         <ConfigSection>
-            <OptionChoice name='vnlaEmeraldDist'  displayState='shown' displayGroup='groupVanillaMinecraft'>
+            <OptionChoice name='vnlaEmeraldDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
                 <Description> Controls how Emerald is generated </Description>
                 <DisplayName>Vanilla Minecraft Emerald</DisplayName>
                 <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -280,11 +280,11 @@
                 </Choice>
                 <Choice value='none' displayValue='None' description='Emerald is not generated in the world.'/>
             </OptionChoice>
-            <OptionNumeric name='vnlaEmeraldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaEmeraldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Frequency multiplier for Vanilla Minecraft Emerald distributions </Description>
                 <DisplayName>Vanilla Minecraft Emerald Freq.</DisplayName>
             </OptionNumeric>
-            <OptionNumeric name='vnlaEmeraldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaEmeraldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Size multiplier for Vanilla Minecraft Emerald distributions </Description>
                 <DisplayName>Vanilla Minecraft Emerald Size</DisplayName>
             </OptionNumeric>
@@ -294,7 +294,7 @@
 
         <!-- Nether Quartz Configuration UI Starting -->
         <ConfigSection>
-            <OptionChoice name='vnlaNetherQuartzDist'  displayState='shown' displayGroup='groupVanillaMinecraft'>
+            <OptionChoice name='vnlaNetherQuartzDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
                 <Description> Controls how Nether Quartz is generated </Description>
                 <DisplayName>Vanilla Minecraft Nether Quartz</DisplayName>
                 <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -314,11 +314,11 @@
                 </Choice>
                 <Choice value='none' displayValue='None' description='Nether Quartz is not generated in the world.'/>
             </OptionChoice>
-            <OptionNumeric name='vnlaNetherQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaNetherQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Frequency multiplier for Vanilla Minecraft Nether Quartz distributions </Description>
                 <DisplayName>Vanilla Minecraft Nether Quartz Freq.</DisplayName>
             </OptionNumeric>
-            <OptionNumeric name='vnlaNetherQuartzSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupVanillaMinecraft'>
+            <OptionNumeric name='vnlaNetherQuartzSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
                 <Description> Size multiplier for Vanilla Minecraft Nether Quartz distributions </Description>
                 <DisplayName>Vanilla Minecraft Nether Quartz Size</DisplayName>
             </OptionNumeric>
@@ -338,34 +338,38 @@
 
         <!-- Starting Original "Overworld" Block Removal -->
 
-        <Substitute name='vnlaOverworldBlockSubstitute2' block='minecraft:sand'>
-            <Description>
-                Replace vanilla-generated ore clusters.
-            </Description>
-            <Comment>
-                The global option deferredPopulationRange must be
-                large enough to catch all ore clusters (>= 32).
-            </Comment>
-            <Replaces block='minecraft:clay' weight='1.0' />
-        </Substitute>
+        <IfCondition condition=':= ?blockExists("minecraft:sand")'>
+            <Substitute name='vnlaOverworldBlockSubstitute2' block='minecraft:sand'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <IfCondition condition=':= ?blockExists("minecraft:clay")'> <Replaces block='minecraft:clay' weight='1.0' /> </IfCondition>
+            </Substitute>
+        </IfCondition>
 
 
-        <Substitute name='vnlaOverworldBlockSubstitute3' block='minecraft:stone'>
-            <Description>
-                Replace vanilla-generated ore clusters.
-            </Description>
-            <Comment>
-                The global option deferredPopulationRange must be
-                large enough to catch all ore clusters (>= 32).
-            </Comment>
-            <Replaces block='minecraft:coal_ore' weight='1.0' />
-            <Replaces block='minecraft:diamond_ore' weight='1.0' />
-            <Replaces block='minecraft:emerald_ore' weight='1.0' />
-            <Replaces block='minecraft:gold_ore' weight='1.0' />
-            <Replaces block='minecraft:iron_ore' weight='1.0' />
-            <Replaces block='minecraft:lapis_ore' weight='1.0' />
-            <Replaces block='minecraft:redstone_ore' weight='1.0' />
-        </Substitute>
+        <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+            <Substitute name='vnlaOverworldBlockSubstitute3' block='minecraft:stone'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <Replaces block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
+                <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
+                <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
+                <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <Replaces block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
+                <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <Replaces block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
+                <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <Replaces block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <Replaces block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+            </Substitute>
+        </IfCondition>
 
         <!-- Original "Overworld" Block Removal Complete -->
 
@@ -382,10 +386,10 @@
                         Similar to the deposits produced by
                         StandardGen distributions.
                     </Description>
-                    <OreBlock block='minecraft:clay' weight='1.0' />
-                    <Replaces block='minecraft:sand' weight='1.0' />
-                    <Replaces block='minecraft:gravel' weight='1.0' />
-                    <Replaces block='minecraft:dirt' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:clay")'> <OreBlock block='minecraft:clay' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Biome name='Ocean'  weight='-1' />
                     <Biome name='Desert'  weight='-1' />
@@ -413,10 +417,10 @@
                         Ore generation is doubled in preferred
                         biomes.
                     </Description>
-                    <OreBlock block='minecraft:clay' weight='1.0' />
-                    <Replaces block='minecraft:sand' weight='1.0' />
-                    <Replaces block='minecraft:gravel' weight='1.0' />
-                    <Replaces block='minecraft:dirt' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:clay")'> <OreBlock block='minecraft:clay' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
                     <BiomeType name='Swamp'  />
                     <BiomeType name='Beach'  />
                     <BiomeType name='River'  />
@@ -464,8 +468,8 @@
                         to get an idea of  their direction while
                         mining.
                     </Description>
-                    <OreBlock block='minecraft:coal_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 6.262 * _default_ * vnlaCoalFreq ' range=':=  1 * _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 1.843 * _default_ * vnlaCoalSize ' range=':=  1 * _default_ * vnlaCoalSize ' type='normal' />
@@ -504,8 +508,8 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <OreBlock block='minecraft:coal_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
@@ -535,9 +539,9 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <OreBlock block='minecraft:coal_ore' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:sandstone' weight='1.0' />
+                        <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -553,8 +557,8 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <OreBlock block='minecraft:coal_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 16 * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 20 * vnlaCoalFreq ' range=':=  _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
@@ -582,8 +586,8 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <OreBlock block='minecraft:coal_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
@@ -613,9 +617,9 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <OreBlock block='minecraft:coal_ore' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:sandstone' weight='1.0' />
+                        <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -635,8 +639,8 @@
                         Small, fairly rare motherlodes with 2-4
                         horizontal veins each.
                     </Description>
-                    <OreBlock block='minecraft:iron_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * vnlaIronFreq ' range=':=  1 * _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * vnlaIronSize ' range=':=  1 * _default_ * vnlaIronSize ' type='normal' />
@@ -667,8 +671,8 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <OreBlock block='minecraft:iron_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 8 * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 20 * vnlaIronFreq ' range=':=  _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
@@ -696,8 +700,8 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <OreBlock block='minecraft:iron_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 1.730 * _default_ * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.730 * _default_ * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' scaleTo='base' />
@@ -727,9 +731,9 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <OreBlock block='minecraft:iron_ore' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:sandstone' weight='1.0' />
+                        <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -749,8 +753,8 @@
                         Small, fairly rare motherlodes with 2-4
                         horizontal veins each.
                     </Description>
-                    <OreBlock block='minecraft:gold_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * vnlaGoldFreq ' range=':=  1 * _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * vnlaGoldSize ' range=':=  1 * _default_ * vnlaGoldSize ' type='normal' />
@@ -781,8 +785,8 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <OreBlock block='minecraft:gold_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 8 * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 2 * vnlaGoldFreq ' range=':=  _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
@@ -810,8 +814,8 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <OreBlock block='minecraft:gold_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 0.973 * _default_ * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.973 * _default_ * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' scaleTo='base' />
@@ -841,9 +845,9 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <OreBlock block='minecraft:gold_ore' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:sandstone' weight='1.0' />
+                        <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -863,8 +867,8 @@
                         Single vertical veins that occur with no
                         motherlodes.
                     </Description>
-                    <OreBlock block='minecraft:redstone_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * vnlaRedstoneFreq ' range=':=  1 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
@@ -889,8 +893,8 @@
                         Ore generation is doubled in preferred
                         biomes.
                     </Description>
-                    <OreBlock block='minecraft:redstone_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Desert'  />
                     <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * vnlaRedstoneFreq ' range=':=  1 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
@@ -923,8 +927,8 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <OreBlock block='minecraft:redstone_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 7 * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 8 * vnlaRedstoneFreq ' range=':=  _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
@@ -952,8 +956,8 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <OreBlock block='minecraft:redstone_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
@@ -983,9 +987,9 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <OreBlock block='minecraft:redstone_ore' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:sandstone' weight='1.0' />
+                        <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                     </Veins>
                 </Cloud>
 
@@ -995,8 +999,8 @@
                         Ore generation is doubled in preferred
                         biomes.
                     </Description>
-                    <OreBlock block='minecraft:redstone_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Desert'  />
                     <Setting name='CloudRadius' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
@@ -1013,9 +1017,9 @@
                             Ore generation is doubled in  preferred
                             biomes.
                         </Description>
-                        <OreBlock block='minecraft:redstone_ore' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:sandstone' weight='1.0' />
+                        <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                     </Veins>
                 </Cloud>
                 <!-- "Preferred" configuration complete. -->
@@ -1037,8 +1041,8 @@
                         Short sparsely filled veins sloping up  from
                         near the bottom of the map.
                     </Description>
-                    <OreBlock block='minecraft:diamond_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.365 * _default_ * vnlaDiamondFreq ' range=':=  1 * _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * vnlaDiamondSize ' range=':=  1 * _default_ * vnlaDiamondSize ' type='normal' />
@@ -1059,9 +1063,9 @@
 
                 <!-- Configuring contained material. -->
                 <Veins name='vnlaDiamondVeinsPipe'  inherits='vnlaDiamondVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
-                    <OreBlock block='minecraft:lava' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
-                    <Replaces block='minecraft:diamond_ore' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
                     <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * vnlaDiamondSize  * 0.5 ' range=':=  1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
                     <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * vnlaDiamondSize  * 0.5 ' range=':=  1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
                     <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -1079,8 +1083,8 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <OreBlock block='minecraft:diamond_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 7 * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 1 * vnlaDiamondFreq ' range=':=  _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
@@ -1108,8 +1112,8 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <OreBlock block='minecraft:diamond_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 0.791 * _default_ * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.791 * _default_ * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' scaleTo='base' />
@@ -1139,9 +1143,9 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <OreBlock block='minecraft:diamond_ore' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:sandstone' weight='1.0' />
+                        <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -1161,8 +1165,8 @@
                         Single vertical veins that occur with no
                         motherlodes.
                     </Description>
-                    <OreBlock block='minecraft:lapis_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * vnlaLapisLazuliFreq ' range=':=  1 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
@@ -1187,8 +1191,8 @@
                         Ore generation is doubled in preferred
                         biomes.
                     </Description>
-                    <OreBlock block='minecraft:lapis_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Ocean'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * vnlaLapisLazuliFreq ' range=':=  1 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
@@ -1221,8 +1225,8 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <OreBlock block='minecraft:lapis_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 6 * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 1 * vnlaLapisLazuliFreq ' range=':=  _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
@@ -1250,8 +1254,8 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <OreBlock block='minecraft:lapis_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
@@ -1281,9 +1285,9 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <OreBlock block='minecraft:lapis_ore' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:sandstone' weight='1.0' />
+                        <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                     </Veins>
                 </Cloud>
 
@@ -1293,8 +1297,8 @@
                         Ore generation is doubled in preferred
                         biomes.
                     </Description>
-                    <OreBlock block='minecraft:lapis_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Ocean'  />
                     <Setting name='CloudRadius' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
@@ -1311,9 +1315,9 @@
                             Ore generation is doubled in  preferred
                             biomes.
                         </Description>
-                        <OreBlock block='minecraft:lapis_ore' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:sandstone' weight='1.0' />
+                        <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                     </Veins>
                 </Cloud>
                 <!-- "Preferred" configuration complete. -->
@@ -1335,8 +1339,8 @@
                         Short sparsely filled veins sloping up  from
                         near the bottom of the map.
                     </Description>
-                    <OreBlock block='minecraft:emerald_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Mountain'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * vnlaEmeraldFreq ' range=':=  1 * _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * vnlaEmeraldSize ' range=':=  1 * _default_ * vnlaEmeraldSize ' type='normal' />
@@ -1357,9 +1361,9 @@
 
                 <!-- Configuring contained material. -->
                 <Veins name='vnlaEmeraldVeinsPipe'  inherits='vnlaEmeraldVeins' seed='0x54B3' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
-                    <OreBlock block='minecraft:monster_egg' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
-                    <Replaces block='minecraft:emerald_ore' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:monster_egg")'> <OreBlock block='minecraft:monster_egg' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
                     <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':=  1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
                     <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':=  1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
                     <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -1377,8 +1381,8 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <OreBlock block='minecraft:emerald_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Mountain'  />
                     <Setting name='Size' avg=':= 1 * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 1 * vnlaEmeraldFreq ' range=':=  _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
@@ -1406,8 +1410,8 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <OreBlock block='minecraft:emerald_ore' weight='1.0' />
-                    <Replaces block='minecraft:stone' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Mountain'  />
                     <Setting name='CloudRadius' avg=':= 0.486 * _default_ * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.486 * _default_ * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' scaleTo='base' />
@@ -1437,9 +1441,9 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <OreBlock block='minecraft:emerald_ore' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:sandstone' weight='1.0' />
+                        <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -1463,16 +1467,18 @@
 
         <!-- Starting Original "Nether" Block Removal -->
 
-        <Substitute name='vnlaNetherBlockSubstitute0' block='minecraft:netherrack'>
-            <Description>
-                Replace vanilla-generated ore clusters.
-            </Description>
-            <Comment>
-                The global option deferredPopulationRange must be
-                large enough to catch all ore clusters (>= 32).
-            </Comment>
-            <Replaces block='minecraft:quartz_ore' weight='1.0' />
-        </Substitute>
+        <IfCondition condition=':= ?blockExists("minecraft:netherrack")'>
+            <Substitute name='vnlaNetherBlockSubstitute0' block='minecraft:netherrack'>
+                <Description>
+                    Replace vanilla-generated ore clusters.
+                </Description>
+                <Comment>
+                    The global option deferredPopulationRange  must be
+                    large enough to catch all ore  clusters (>= 32).
+                </Comment>
+                <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <Replaces block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
+            </Substitute>
+        </IfCondition>
 
         <!-- Original "Nether" Block Removal Complete -->
 
@@ -1488,8 +1494,8 @@
                         Small, fairly rare motherlodes with 2-4
                         horizontal veins each.
                     </Description>
-                    <OreBlock block='minecraft:quartz_ore' weight='1.0' />
-                    <Replaces block='minecraft:netherrack' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 5.049 * _default_ * vnlaNetherQuartzFreq ' range=':=  1 * _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 1.716 * _default_ * vnlaNetherQuartzSize ' range=':=  1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
@@ -1520,8 +1526,8 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <OreBlock block='minecraft:quartz_ore' weight='1.0' />
-                    <Replaces block='minecraft:netherrack' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 13 * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 16 * vnlaNetherQuartzFreq ' range=':=  _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
@@ -1549,8 +1555,8 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <OreBlock block='minecraft:quartz_ore' weight='1.0' />
-                    <Replaces block='minecraft:netherrack' weight='1.0' />
+                    <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 1.847 * _default_ * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.847 * _default_ * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' scaleTo='base' />
@@ -1580,9 +1586,9 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <OreBlock block='minecraft:quartz_ore' weight='1.0' />
-                        <Replaces block='minecraft:dirt' weight='1.0' />
-                        <Replaces block='minecraft:sandstone' weight='1.0' />
+                        <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                     </Veins>
                 </Cloud>
             </IfCondition>


### PR DESCRIPTION
After researching intended ore amounts by reading the original mods' source code on github, The vein sizes, chunk chances, and y levels have been recorded, and converted into COG ore configuration values.  The final tally was reduced by 1/12 to account for the vanilla overabundance due to ores being spread out.

End results:
* Ores are as rare in vein and cloud form as they were in vanilla form... at least when compared to each other (the comparative rarity of iron, redstone, and certus quartz, for example, are consistent between vanilla, vein, and cloud).
* Heights have all be restored to their mod-specified levels.
* Dense Ores and Applied Energistics makes use of "weighted and mixed ores," in which a single vein can contain more than one ore type.
* In Railcraft, sulfur, saltpeter, and firestone have been disabled, due to the distributions breaking their original design in the Railcraft mod (they are designed to regenerate, and so need to be where RC expects them).